### PR TITLE
Release/0.8.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             Or use the Elixir package:
 
             ```elixir
-            {:lemma, "~> ${{ needs.detect-version-changes.outputs.version }}"}
+            {:lemma_engine, "~> ${{ needs.detect-version-changes.outputs.version }}"}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The release version is `[workspace.package] version` in the root `Cargo.toml`. G
 
 Draft notes for the next version quickly: from the repo root run `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`).
 
+## [0.8.6] - 2025-03-27
+
+### Changed
+
+- Hex publishes the Elixir package as `lemma_engine` instead of `lemma`. Replace `{:lemma, ...}` with `{:lemma_engine, ...}` in `mix.exs`, README, and the GitHub release workflow Elixir snippet; `mix.exs` sets `package` `name: "lemma_engine"`.
+- Workspace and artifacts are bumped to **0.8.6** (root `Cargo.toml` / lockfile, `lemma-cli`, `lemma-engine`, `lemma-openapi`, `lsp`, VS Code `package.json` / lockfile, Hex `@version`).
+- Root **README** rewrites the “Why Lemma?” and “What about AI?” sections: clearer story on rules vs systems, single source of truth, determinism and auditability, and how Lemma differs from approximate AI for compliance-style logic.
+
 ## [0.8.5] - 2025-03-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-cli"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "boolean_expression",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "lemma-engine",
  "rust_decimal",
@@ -1761,7 +1761,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 # Exact version: avoid cargo install resolving a newer lemma-engine patch that may be API-incompatible.
-lemma = { package = "lemma-engine", version = "=0.8.5", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.5", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.6", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.6", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.5"
+lemma-engine = "0.8.6"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 
 [dependencies]
 # Exact version: avoid resolving a newer lemma-engine patch that may be API-incompatible.
-lemma = { package = "lemma-engine", version = "=0.8.5", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.6", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/packages/hex/README.md
+++ b/engine/packages/hex/README.md
@@ -26,7 +26,7 @@ Add to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:lemma, "~> 0.8"}
+    {:lemma_engine, "~> 0.8"}
   ]
 end
 ```
@@ -34,7 +34,7 @@ end
 Or from git:
 
 ```elixir
-{:lemma, git: "https://github.com/benrogmans/lemma", sparse: "engine/packages/hex"}
+{:lemma_engine, git: "https://github.com/benrogmans/lemma", sparse: "engine/packages/hex"}
 ```
 
 ## Usage

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.5"
+  @version "0.8.6"
   @source_url "https://github.com/benrogmans/lemma"
 
   def project do

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -39,6 +39,7 @@ defmodule Lemma.MixProject do
 
   defp package do
     [
+      name: "lemma_engine",
       files: ["lib", "native", "mix.exs", "README.md"],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @source_url}

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -9,7 +9,7 @@ description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
 # Exact version: avoid resolving a newer lemma-engine patch that may be API-incompatible.
-lemma = { package = "lemma-engine", version = "=0.8.5", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.6", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
### Changed

- Hex publishes the Elixir package as `lemma_engine` instead of `lemma`. Replace `{:lemma, ...}` with `{:lemma_engine, ...}` in `mix.exs`, README, and the GitHub release workflow Elixir snippet; `mix.exs` sets `package` `name: "lemma_engine"`.
- Workspace and artifacts are bumped to **0.8.6** (root `Cargo.toml` / lockfile, `lemma-cli`, `lemma-engine`, `lemma-openapi`, `lsp`, VS Code `package.json` / lockfile, Hex `@version`).
- Root **README** rewrites the “Why Lemma?” and “What about AI?” sections: clearer story on rules vs systems, single source of truth, determinism and auditability, and how Lemma differs from approximate AI for compliance-style logic.
