### PR TITLE
Release 0.8.8: precompiled Hex NIFs, release CI, changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,76 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-nif-binaries:
+    name: Build NIF (${{ matrix.job.target }})
+    needs: [detect-version-changes, create-release]
+    if: needs.detect-version-changes.outputs.changed == 'true'
+    runs-on: ${{ matrix.job.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        nif: ["2.15"]
+        job:
+          - { target: aarch64-apple-darwin,      os: macos-latest }
+          - { target: x86_64-apple-darwin,       os: macos-15-intel }
+          - { target: aarch64-unknown-linux-gnu,  os: ubuntu-latest, use-cross: true }
+          - { target: x86_64-unknown-linux-gnu,   os: ubuntu-latest }
+          - { target: x86_64-unknown-linux-musl,  os: ubuntu-latest, use-cross: true }
+          - { target: x86_64-pc-windows-msvc,     os: windows-latest }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+          targets: ${{ matrix.job.target }}
+
+      - name: Install cross
+        if: matrix.job.use-cross
+        uses: taiki-e/install-action@cross
+
+      - name: Build NIF
+        shell: bash
+        run: |
+          if [ "${{ matrix.job.use-cross }}" == "true" ]; then
+            cross build --release -p lemma_hex --target ${{ matrix.job.target }}
+          else
+            cargo build --release -p lemma_hex --target ${{ matrix.job.target }}
+          fi
+
+      - name: Package NIF library
+        shell: bash
+        run: |
+          VERSION="${{ needs.detect-version-changes.outputs.version }}"
+          NIF_VERSION="${{ matrix.nif }}"
+          TARGET="${{ matrix.job.target }}"
+          RELEASE_DIR="target/${TARGET}/release"
+
+          case "${{ runner.os }}" in
+            Windows)
+              LIB_NAME="lemma_hex-v${VERSION}-nif-${NIF_VERSION}-${TARGET}.dll"
+              cp "${RELEASE_DIR}/lemma_hex.dll" "${LIB_NAME}" ;;
+            macOS)
+              LIB_NAME="liblemma_hex-v${VERSION}-nif-${NIF_VERSION}-${TARGET}.so"
+              cp "${RELEASE_DIR}/liblemma_hex.dylib" "${LIB_NAME}" ;;
+            *)
+              LIB_NAME="liblemma_hex-v${VERSION}-nif-${NIF_VERSION}-${TARGET}.so"
+              cp "${RELEASE_DIR}/liblemma_hex.so" "${LIB_NAME}" ;;
+          esac
+
+          tar czf "${LIB_NAME}.tar.gz" "${LIB_NAME}"
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: cli-v${{ needs.detect-version-changes.outputs.version }}
+          files: "*lemma_hex-*.tar.gz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Publish jobs run in parallel (no dependencies between them). If one fails
   # (e.g. auth/expired token), update the secret and use "Re-run failed jobs".
   publish-crates:
@@ -282,11 +352,12 @@ jobs:
 
   publish-hex:
     name: Publish to Hex.pm
-    needs: [detect-version-changes, create-release, publish-crates]
+    needs: [detect-version-changes, create-release, publish-crates, build-nif-binaries]
     if: |
       !cancelled() &&
       needs.create-release.result == 'success' &&
       needs.publish-crates.result == 'success' &&
+      needs.build-nif-binaries.result == 'success' &&
       needs.detect-version-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -321,6 +392,12 @@ jobs:
       - name: Install mix deps
         working-directory: engine/packages/hex
         run: mix deps.get
+
+      - name: Generate NIF checksums
+        working-directory: engine/packages/hex
+        run: mix rustler_precompiled.download Lemma.Native --all --print
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to Hex
         working-directory: engine/packages/hex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The release version is `[workspace.package] version` in the root `Cargo.toml`. G
 
 Draft notes for the next version quickly: from the repo root run `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`).
 
+## [0.8.8] - 2026-03-29
+
+### Added
+
+- Release workflow **build-nif-binaries** job: cross-build `lemma_hex` for macOS (arm64/x86_64), Linux (gnu arm64/x86_64, musl x86_64), Windows x86_64; package `.so`/`.dll` as versioned tarballs and upload to the `cli-v*` GitHub release.
+- Hex package uses **rustler_precompiled**: consumers download matching NIFs from release assets; contributors can still compile from source with `LEMMA_BUILD_NIF=1` and Rust on `PATH`.
+- **publish-hex** runs `mix rustler_precompiled.download Lemma.Native --all --print` (with `GITHUB_TOKEN`) so checksum files are generated before publish; job depends on **build-nif-binaries** completing.
+
+### Changed
+
+- Hex **mix.exs** OTP application `:lemma` → `:lemma_engine`; **package** `files` list includes checksum scripts and trimmed native sources for precompiled workflow.
+- Hex **README**: documents precompiled targets and dev workflow (`LEMMA_BUILD_NIF=1` for `mix compile` / `mix precommit`).
+- Workspace / crates / VS Code extension / lockfiles bumped to **0.8.8** (routine version alignment).
+
+### Removed
+
+- **engine/packages/hex/.mise.toml** (Erlang/Elixir pin no longer shipped in the package tree).
+
 ## [0.8.7] - 2026-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f40e41efb5f592d3a0764f818e2f08e5e21c4f368126f74f37c81bd4af7a0c6"
+checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
 dependencies = [
  "console",
  "once_cell",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
 dependencies = [
  "rustversion",
 ]
@@ -1491,9 +1491,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1630,7 +1630,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-cli"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "async-trait",
  "boolean_expression",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "lemma-engine",
  "rust_decimal",
@@ -1764,7 +1764,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -4069,18 +4069,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,8 +12,8 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.7", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.7", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.8", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.8", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.7"
+lemma-engine = "0.8.8"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.7", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.8", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/packages/hex/.mise.toml
+++ b/engine/packages/hex/.mise.toml
@@ -1,3 +1,0 @@
-[tools]
-erlang = "28.4"
-elixir = "1.19.5-otp-28"

--- a/engine/packages/hex/README.md
+++ b/engine/packages/hex/README.md
@@ -1,23 +1,26 @@
 # Lemma
 
-Elixir client for the [Lemma](https://github.com/benrogmans/lemma) rules engine, via Rustler NIFs.
+Elixir client for the [Lemma](https://github.com/benrogmans/lemma) rules engine, via precompiled NIFs.
 
 ## Requirements
 
 - Elixir >= 1.14
-- Rust toolchain (stable) — Rustler compiles the NIF from source
 
-With [mise](https://mise.jdx.dev/), from this directory: `mise install` (uses `.mise.toml`: Erlang/OTP 28.4 + Elixir 1.19.5).
+Precompiled NIF binaries are downloaded automatically for macOS (arm64/x86_64), Linux (gnu/musl x86_64, gnu arm64), and Windows (x86_64).
 
 ## Development
 
-From this directory (Rust on `PATH` for Rustler):
+To compile the NIF from source (contributors), set `LEMMA_BUILD_NIF=1` and have Rust stable on `PATH`:
 
 ```bash
-mix precommit
+LEMMA_BUILD_NIF=1 mix compile
 ```
 
-Runs format check, `mix deps.get --check-locked`, and `mix compile` (builds the NIF).
+Pre-commit check:
+
+```bash
+LEMMA_BUILD_NIF=1 mix precommit
+```
 
 ## Installation
 

--- a/engine/packages/hex/lib/lemma/native.ex
+++ b/engine/packages/hex/lib/lemma/native.ex
@@ -1,6 +1,21 @@
 defmodule Lemma.Native do
   @moduledoc false
-  use Rustler, otp_app: :lemma, crate: :lemma_hex
+  version = Mix.Project.config()[:version]
+
+  use RustlerPrecompiled,
+    otp_app: :lemma_engine,
+    crate: "lemma_hex",
+    base_url: "https://github.com/benrogmans/lemma/releases/download/cli-v#{version}",
+    force_build: not File.exists?("checksum-Elixir.Lemma.Native.exs"),
+    version: version,
+    targets: ~w(
+      aarch64-apple-darwin
+      x86_64-apple-darwin
+      aarch64-unknown-linux-gnu
+      x86_64-unknown-linux-gnu
+      x86_64-unknown-linux-musl
+      x86_64-pc-windows-msvc
+    )
 
   def lemma_new(_limits), do: :erlang.nif_error(:nif_not_loaded)
   def lemma_load(_resource, _code, _source_label), do: :erlang.nif_error(:nif_not_loaded)

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,12 +1,12 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.7"
+  @version "0.8.8"
   @source_url "https://github.com/benrogmans/lemma"
 
   def project do
     [
-      app: :lemma,
+      app: :lemma_engine,
       version: @version,
       elixir: "~> 1.14",
       compilers: Mix.compilers(),
@@ -32,7 +32,8 @@ defmodule Lemma.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
-      {:rustler, "~> 0.37", runtime: false},
+      {:rustler_precompiled, "~> 0.9"},
+      {:rustler, ">= 0.9.0", optional: true},
       {:ex_doc, "~> 0.40.1", only: :dev, runtime: false}
     ]
   end
@@ -40,7 +41,14 @@ defmodule Lemma.MixProject do
   defp package do
     [
       name: "lemma_engine",
-      files: ["lib", "native", "mix.exs", "README.md"],
+      files: [
+        "lib",
+        "native/lemma_hex/src",
+        "native/lemma_hex/Cargo*",
+        "checksum-*.exs",
+        "mix.exs",
+        "README.md"
+      ],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @source_url}
     ]

--- a/engine/packages/hex/mix.lock
+++ b/engine/packages/hex/mix.lock
@@ -7,4 +7,5 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "rustler": {:hex, :rustler, "0.37.3", "5f4e6634d43b26f0a69834dd1d3ed4e1710b022a053bf4a670220c9540c92602", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "a6872c6f53dcf00486d1e7f9e046e20e01bf1654bdacc4193016c2e8002b32a2"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.9.0", "3a052eda09f3d2436364645cc1f13279cf95db310eb0c17b0d8f25484b233aa0", [:mix], [{:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: true]}], "hexpm", "471d97315bd3bf7b64623418b3693eedd8e47de3d1cb79a0ac8f9da7d770d94c"},
 }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.7", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.8", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
### Added

- Release workflow **build-nif-binaries** job: cross-build `lemma_hex` for macOS (arm64/x86_64), Linux (gnu arm64/x86_64, musl x86_64), Windows x86_64; package `.so`/`.dll` as versioned tarballs and upload to the `cli-v*` GitHub release.
- Hex package uses **rustler_precompiled**: consumers download matching NIFs from release assets; contributors can still compile from source with `LEMMA_BUILD_NIF=1` and Rust on `PATH`.
- **publish-hex** runs `mix rustler_precompiled.download Lemma.Native --all --print` (with `GITHUB_TOKEN`) so checksum files are generated before publish; job depends on **build-nif-binaries** completing.

### Changed

- Hex **mix.exs** OTP application `:lemma` → `:lemma_engine`; **package** `files` list includes checksum scripts and trimmed native sources for precompiled workflow.
- Hex **README**: documents precompiled targets and dev workflow (`LEMMA_BUILD_NIF=1` for `mix compile` / `mix precommit`).
- Workspace / crates / VS Code extension / lockfiles bumped to **0.8.8** (routine version alignment).

### Removed

- **engine/packages/hex/.mise.toml** (Erlang/Elixir pin no longer shipped in the package tree).
