### PR TITLE
Release 0.8.9 to fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
+            use-cross: true
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             use-cross: true
           - os: macos-15-intel
             target: x86_64-apple-darwin
@@ -143,6 +144,17 @@ jobs:
           else
             cargo build --release -p lemma-cli --target ${{ matrix.target }}
           fi
+
+      - name: Verify static Linux binary
+        if: contains(matrix.target, 'linux-musl')
+        shell: bash
+        run: |
+          B="target/${{ matrix.target }}/release/lemma"
+          file "$B"
+          file "$B" | grep -Eiq 'statically linked|static-pie' || {
+            echo "error: expected static musl binary (scratch Docker)"
+            exit 1
+          }
 
       - name: Package binary
         shell: bash
@@ -178,7 +190,6 @@ jobs:
           - { target: x86_64-apple-darwin,       os: macos-15-intel }
           - { target: aarch64-unknown-linux-gnu,  os: ubuntu-latest, use-cross: true }
           - { target: x86_64-unknown-linux-gnu,   os: ubuntu-latest }
-          - { target: x86_64-unknown-linux-musl,  os: ubuntu-latest, use-cross: true }
           - { target: x86_64-pc-windows-msvc,     os: windows-latest }
     steps:
       - uses: actions/checkout@v4
@@ -407,7 +418,7 @@ jobs:
 
   publish-docker:
     name: Publish Docker Image
-    needs: [detect-version-changes, create-release, build-cli-binaries]
+    needs: [detect-version-changes, create-release]
     if: |
       !cancelled() &&
       needs.create-release.result == 'success' &&
@@ -418,16 +429,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download Linux binaries from release
-        run: |
-          VERSION="${{ needs.detect-version-changes.outputs.version }}"
-          gh release download "cli-v${VERSION}" --pattern 'lemma-*-linux-gnu.tar.gz'
-          mkdir -p binaries/amd64 binaries/arm64
-          tar -xzf lemma-x86_64-unknown-linux-gnu.tar.gz -C binaries/amd64
-          tar -xzf lemma-aarch64-unknown-linux-gnu.tar.gz -C binaries/arm64
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The release version is `[workspace.package] version` in the root `Cargo.toml`. G
 
 Draft notes for the next version quickly: from the repo root run `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`).
 
+## [0.8.9] - 2026-03-30
+
+### Changed
+
+- Precompiled Hex NIFs: drop **`x86_64-unknown-linux-musl`** from the release **build-nif-binaries** matrix and **RustlerPrecompiled** `targets` (that triple cannot build this `cdylib`); Linux x86_64 uses **`x86_64-unknown-linux-gnu`** only.
+- Hex **README**: precompiled Linux wording matches (gnu x86_64 + arm64).
+- Workspace / crates / VS Code extension / lockfiles bumped to **0.8.9** (routine version alignment).
+- Linux `lemma` CLI release assets are **musl static** only (`lemma-*-linux-musl.tar.gz`); **publish-docker** copies them into `FROM scratch`. GNU Linux CLI tarballs removed. Hex NIF prebuilds stay **linux-gnu** (`cdylib`).
+
 ## [0.8.8] - 2026-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-cli"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "async-trait",
  "boolean_expression",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "lemma-engine",
  "rust_decimal",
@@ -1764,7 +1764,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.8"
+version = "0.8.9"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,8 +12,8 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.8", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.8", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.9", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.9", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.8"
+lemma-engine = "0.8.9"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.8", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.9", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/packages/hex/README.md
+++ b/engine/packages/hex/README.md
@@ -6,7 +6,7 @@ Elixir client for the [Lemma](https://github.com/benrogmans/lemma) rules engine,
 
 - Elixir >= 1.14
 
-Precompiled NIF binaries are downloaded automatically for macOS (arm64/x86_64), Linux (gnu/musl x86_64, gnu arm64), and Windows (x86_64).
+Precompiled NIF binaries are downloaded automatically for macOS (arm64/x86_64), Linux (gnu x86_64 and arm64), and Windows (x86_64).
 
 ## Development
 

--- a/engine/packages/hex/lib/lemma/native.ex
+++ b/engine/packages/hex/lib/lemma/native.ex
@@ -13,7 +13,6 @@ defmodule Lemma.Native do
       x86_64-apple-darwin
       aarch64-unknown-linux-gnu
       x86_64-unknown-linux-gnu
-      x86_64-unknown-linux-musl
       x86_64-pc-windows-msvc
     )
 

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.8"
+  @version "0.8.9"
   @source_url "https://github.com/benrogmans/lemma"
 
   def project do

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.8", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.9", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
Drop the musl NIF target. Use musl wherever possible elsewhere.