### PR TITLE
Release 0.8.10: Nix dev shell, SpecRef hash validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,10 +418,11 @@ jobs:
 
   publish-docker:
     name: Publish Docker Image
-    needs: [detect-version-changes, create-release]
+    needs: [detect-version-changes, create-release, build-cli-binaries]
     if: |
       !cancelled() &&
       needs.create-release.result == 'success' &&
+      needs.build-cli-binaries.result == 'success' &&
       needs.detect-version-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -429,6 +430,18 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download Linux binaries from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.detect-version-changes.outputs.version }}"
+          TAG="cli-v${VERSION}"
+          mkdir -p binaries/amd64 binaries/arm64
+          gh release download "$TAG" -p "lemma-x86_64-unknown-linux-musl.tar.gz" -D /tmp
+          gh release download "$TAG" -p "lemma-aarch64-unknown-linux-musl.tar.gz" -D /tmp
+          tar xzf /tmp/lemma-x86_64-unknown-linux-musl.tar.gz -C binaries/amd64
+          tar xzf /tmp/lemma-aarch64-unknown-linux-musl.tar.gz -C binaries/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+result
+result-*
 
 # npm build output
 engine/packages/npm/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Co
 
 ### Changed
 
+- CLI: workspace or `.lemma` file is a positional argument (`run`/`schema`/`get [source] [spec]…`, `list`/`server`/`mcp [source]`); `-d`/`--dir` removed. Spec auto-selected when the source defines exactly one spec; multiple specs without a name yield an error listing names (or use `-i`). Lemma source from filesystem only; positional `-` is rejected (not a valid path).
 - Planning: `FactData::SpecRef.resolved_plan_hash` is a required `String`; fingerprints always build `SpecId` from it (no optional fallback to bare spec name).
 - Graph / types: missing plan hash on type-import or spec-reference binding yields validation errors instead of `unreachable!` when a dependency spec failed validation or is absent from the hash registry.
 - `build_graph` test helper pre-plans dependency specs so `PlanHashRegistry` matches topological `plan()` behavior.
@@ -21,7 +22,7 @@ Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Co
 - Fix for docker image building in CI.
 - Formatter cleanup: deterministic output improvements.
 - Deterministic fingerprinting on semantics.
-- Type resolver: rename `register_dependency_types` to `register_dependency_specs` to clarify scope.
+- Type resolver: rename contributing-spec registration to `register_dependency_specs` to clarify scope.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `cli-v{version}` (for example `cli-v0.8.5`). Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
-## [0.8.10] - 2026-03-30
+## [0.8.10] - 2026-03-31
 
 ### Added
 
 - Nix flake dev shell (Rust from `rust-toolchain.toml`, cargo-nextest, cargo-deny, wasm-pack, Node 24, Elixir, nixpkgs-fmt formatter) plus `flake.lock`.
 - `rust-toolchain.toml`: `wasm32-unknown-unknown` target.
-- Test cases for temporal type imports
+- Test cases for temporal type imports.
+- `ExecutionPlan.sources`: keyed `SpecSources` map (`IndexMap<(name, effective_from), source>`) with AST-reconstructed canonical source for every spec in the plan. Custom serde serializes as `[{name, effective_from, source}]` for downstream consumers.
 
 ### Changed
 
@@ -16,8 +17,16 @@ Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Co
 - Graph / types: missing plan hash on type-import or spec-reference binding yields validation errors instead of `unreachable!` when a dependency spec failed validation or is absent from the hash registry.
 - `build_graph` test helper pre-plans dependency specs so `PlanHashRegistry` matches topological `plan()` behavior.
 - `.gitignore`: `result` / `result-*` (Nix build outputs).
-- Fixes for temporal type imports, to properly pin and resolve them
-- Fix for docker image building in CI
+- Fixes for temporal type imports, to properly pin and resolve them.
+- Fix for docker image building in CI.
+- Formatter cleanup: deterministic output improvements.
+- Deterministic fingerprinting on semantics.
+- Type resolver: rename `register_dependency_types` to `register_dependency_specs` to clarify scope.
+
+### Removed
+
+- `==` / `!=` syntax (use `=` and `!=` was already removed).
+- Raw source text from operation records and expression evaluation (replaced by plan-level `sources`).
 
 ## [0.8.9] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,56 @@
 # Changelog
 
-Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere.
+Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `cli-v{version}` (for example `cli-v0.8.5`). Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
-The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `cli-v{version}` (for example `cli-v0.8.5`).
+## [0.8.10] - 2026-03-30
 
-Draft notes for the next version quickly: from the repo root run `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`).
+### Added
+
+- Nix flake dev shell (Rust from `rust-toolchain.toml`, cargo-nextest, cargo-deny, wasm-pack, Node 24, Elixir, nixpkgs-fmt formatter) plus `flake.lock`.
+- `rust-toolchain.toml`: `wasm32-unknown-unknown` target.
+- Test cases for temporal type imports
+
+### Changed
+
+- Planning: `FactData::SpecRef.resolved_plan_hash` is a required `String`; fingerprints always build `SpecId` from it (no optional fallback to bare spec name).
+- Graph / types: missing plan hash on type-import or spec-reference binding yields validation errors instead of `unreachable!` when a dependency spec failed validation or is absent from the hash registry.
+- `build_graph` test helper pre-plans dependency specs so `PlanHashRegistry` matches topological `plan()` behavior.
+- `.gitignore`: `result` / `result-*` (Nix build outputs).
+- Fixes for temporal type imports, to properly pin and resolve them
+- Fix for docker image building in CI
 
 ## [0.8.9] - 2026-03-30
 
 ### Changed
 
-- Precompiled Hex NIFs: drop **`x86_64-unknown-linux-musl`** from the release **build-nif-binaries** matrix and **RustlerPrecompiled** `targets` (that triple cannot build this `cdylib`); Linux x86_64 uses **`x86_64-unknown-linux-gnu`** only.
-- Hex **README**: precompiled Linux wording matches (gnu x86_64 + arm64).
-- Workspace / crates / VS Code extension / lockfiles bumped to **0.8.9** (routine version alignment).
-- Linux `lemma` CLI release assets are **musl static** only (`lemma-*-linux-musl.tar.gz`); **publish-docker** copies them into `FROM scratch`. GNU Linux CLI tarballs removed. Hex NIF prebuilds stay **linux-gnu** (`cdylib`).
+- Precompiled Hex NIFs: drop `x86_64-unknown-linux-musl` from the release build-nif-binaries matrix and RustlerPrecompiled `targets` (that triple cannot build this `cdylib`); Linux x86_64 uses `x86_64-unknown-linux-gnu` only.
+- Hex README: precompiled Linux wording matches (gnu x86_64 + arm64).
+- Workspace / crates / VS Code extension / lockfiles bumped to 0.8.9 (routine version alignment).
+- Linux `lemma` CLI release assets are musl static only (`lemma-*-linux-musl.tar.gz`); publish-docker copies them into `FROM scratch`. GNU Linux CLI tarballs removed. Hex NIF prebuilds stay linux-gnu (`cdylib`).
 
 ## [0.8.8] - 2026-03-29
 
 ### Added
 
-- Release workflow **build-nif-binaries** job: cross-build `lemma_hex` for macOS (arm64/x86_64), Linux (gnu arm64/x86_64, musl x86_64), Windows x86_64; package `.so`/`.dll` as versioned tarballs and upload to the `cli-v*` GitHub release.
-- Hex package uses **rustler_precompiled**: consumers download matching NIFs from release assets; contributors can still compile from source with `LEMMA_BUILD_NIF=1` and Rust on `PATH`.
-- **publish-hex** runs `mix rustler_precompiled.download Lemma.Native --all --print` (with `GITHUB_TOKEN`) so checksum files are generated before publish; job depends on **build-nif-binaries** completing.
+- Release workflow build-nif-binaries job: cross-build `lemma_hex` for macOS (arm64/x86_64), Linux (gnu arm64/x86_64, musl x86_64), Windows x86_64; package `.so`/`.dll` as versioned tarballs and upload to the `cli-v*` GitHub release.
+- Hex package uses rustler_precompiled: consumers download matching NIFs from release assets; contributors can still compile from source with `LEMMA_BUILD_NIF=1` and Rust on `PATH`.
+- publish-hex runs `mix rustler_precompiled.download Lemma.Native --all --print` (with `GITHUB_TOKEN`) so checksum files are generated before publish; job depends on build-nif-binaries completing.
 
 ### Changed
 
-- Hex **mix.exs** OTP application `:lemma` → `:lemma_engine`; **package** `files` list includes checksum scripts and trimmed native sources for precompiled workflow.
-- Hex **README**: documents precompiled targets and dev workflow (`LEMMA_BUILD_NIF=1` for `mix compile` / `mix precommit`).
-- Workspace / crates / VS Code extension / lockfiles bumped to **0.8.8** (routine version alignment).
+- Hex `mix.exs` OTP application `:lemma` → `:lemma_engine`; package `files` list includes checksum scripts and trimmed native sources for precompiled workflow.
+- Hex README: documents precompiled targets and dev workflow (`LEMMA_BUILD_NIF=1` for `mix compile` / `mix precommit`).
+- Workspace / crates / VS Code extension / lockfiles bumped to 0.8.8 (routine version alignment).
 
 ### Removed
 
-- **engine/packages/hex/.mise.toml** (Erlang/Elixir pin no longer shipped in the package tree).
+- `engine/packages/hex/.mise.toml` (Erlang/Elixir pin no longer shipped in the package tree).
 
 ## [0.8.7] - 2026-03-28
 
 ### Added
 
-- **SpecId** type (`name` + `plan_hash`) with `Display` impl (`name~hash`); replaces ad-hoc `Arc<ExecutionPlan>` set and `format!` string concatenation in fingerprints.
+- `SpecId` type (`name` + `plan_hash`) with `Display` impl (`name~hash`); replaces ad-hoc `Arc<ExecutionPlan>` set and `format!` string concatenation in fingerprints.
 - Execution plans now carry `dependencies: IndexSet<SpecId>` populated from dependency rules in topological order.
 - Six dependency-tracking unit tests: basic cross-spec, standalone, multiple deps, hash correctness, unused spec ref, and implicit dep via rules.
 
@@ -55,24 +68,24 @@ Draft notes for the next version quickly: from the repo root run `cargo changelo
 ### Changed
 
 - Hex publishes the Elixir package as `lemma_engine` instead of `lemma`. Replace `{:lemma, ...}` with `{:lemma_engine, ...}` in `mix.exs`, README, and the GitHub release workflow Elixir snippet; `mix.exs` sets `package` `name: "lemma_engine"`.
-- Workspace and artifacts are bumped to **0.8.6** (root `Cargo.toml` / lockfile, `lemma-cli`, `lemma-engine`, `lemma-openapi`, `lsp`, VS Code `package.json` / lockfile, Hex `@version`).
-- Root **README** rewrites the “Why Lemma?” and “What about AI?” sections: clearer story on rules vs systems, single source of truth, determinism and auditability, and how Lemma differs from approximate AI for compliance-style logic.
+- Workspace and artifacts are bumped to 0.8.6 (root `Cargo.toml` / lockfile, `lemma-cli`, `lemma-engine`, `lemma-openapi`, `lsp`, VS Code `package.json` / lockfile, Hex `@version`).
+- Root README rewrites the “Why Lemma?” and “What about AI?” sections: clearer story on rules vs systems, single source of truth, determinism and auditability, and how Lemma differs from approximate AI for compliance-style logic.
 
 ## [0.8.5] - 2025-03-27
 
 ### Added
 
-- Cargo aliases `cargo bump`, `cargo verify`, and `cargo changelog` wired to xtask: centralized **versions-bump** (workspace semver + mirrored pins in CLI/OpenAPI/LSP manifests, Hex `mix.exs`, `engine/README.md`, VS Code `package.json`), **versions-verify**, and **versions-diff** (tag-to-tree or tag-range changelog helper).
-- **versions-verify** step in the quality workflow lint job so CI matches local precommit.
-- **xtask/README.md** and a maintainer **Release version** section in **documentation/contributing.md**; **README.md** documents running **versions-verify** in precommit and using bump/verify when changing the release.
+- Cargo aliases `cargo bump`, `cargo verify`, and `cargo changelog` wired to xtask: centralized versions-bump (workspace semver + mirrored pins in CLI/OpenAPI/LSP manifests, Hex `mix.exs`, `engine/README.md`, VS Code `package.json`), versions-verify, and versions-diff (tag-to-tree or tag-range changelog helper).
+- versions-verify step in the quality workflow lint job so CI matches local precommit.
+- `xtask/README.md` and a maintainer Release version section in `documentation/contributing.md`; `README.md` documents running versions-verify in precommit and using bump/verify when changing the release.
 
 ### Changed
 
-- Workspace release **0.8.5** across crates, **Cargo.lock**, exact path-dep pins, Hex `@version`, engine README quick-start line, and VS Code extension **version** (aligned with the workspace release; release workflow no longer rewrites extension version in a separate Node step).
-- **cargo precommit** runs **versions-verify** before fmt, Clippy, nextest, and cargo-deny. Also triggers SDK precommits (npm precommit, mix precommit).
-- Release workflow: Intel macOS build uses **macos-15-intel** instead of **macos-13**.
-- Hex **mix.exs**: **ex_doc** added as a dev-only dependency; dependency ordering/lockfile updated.
+- Workspace release 0.8.5 across crates, `Cargo.lock`, exact path-dep pins, Hex `@version`, engine README quick-start line, and VS Code extension version (aligned with the workspace release; release workflow no longer rewrites extension version in a separate Node step).
+- `cargo precommit` runs versions-verify before fmt, Clippy, nextest, and cargo-deny. Also triggers SDK precommits (npm precommit, mix precommit).
+- Release workflow: Intel macOS build uses macos-15-intel instead of macos-13.
+- Hex `mix.exs`: ex_doc added as a dev-only dependency; dependency ordering/lockfile updated.
 
 ### Removed
 
-- Jekyll/GitHub Pages scaffolding: **documentation/Gemfile** and **documentation/_config.yml**.
+- Jekyll/GitHub Pages scaffolding: `documentation/Gemfile` and `documentation/_config.yml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-cli"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "async-trait",
  "boolean_expression",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "lemma-engine",
  "rust_decimal",
@@ -1764,7 +1764,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -3920,9 +3920,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.9"
+version = "0.8.10"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,8 +12,8 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.9", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.9", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.10", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.10", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -544,7 +544,7 @@ async fn get_single_spec(
     }
 
     let bundle = registry
-        .get_specs(spec_id)
+        .get(spec_id)
         .await
         .map_err(|e| anyhow::anyhow!("Registry error for {}: {}", spec_id, e.message))?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,38 +39,22 @@ enum OutputFormat {
 enum Commands {
     /// Evaluate rules and display results
     ///
-    /// Loads all .lemma files from the workspace, evaluates the specified spec with optional fact values,
-    /// and displays the computed results. Use this for command-line evaluation and testing.
+    /// Load a .lemma file or workspace, evaluate the specified spec, and display results.
     ///
-    /// Syntax: spec [--rules=rule1,rule2] [spec~hash for hash pin]
+    /// Examples:
+    ///   lemma run tax.lemma income=85000
+    ///   lemma run tax.lemma calculator income=85000
+    ///   lemma run calculator income=85000
+    ///   lemma run ./project calculator income=85000
     Run {
-        /// Spec to evaluate (optionally suffixed with ~hash to pin to a plan hash)
-        ///
-        /// Examples:
-        ///   pricing                    - evaluate all rules in pricing spec
-        ///   nl/tax/net_salary~a1b2c3d4 - pin to specific plan hash
-        #[arg(value_name = "SPEC")]
-        spec_id: Option<String>,
+        /// [source] [spec] [name=value ...] — source is a .lemma file or directory
+        args: Vec<String>,
         /// Rules to evaluate (comma-separated); omit to evaluate all rules
         #[arg(long, value_name = "RULES")]
         rules: Option<String>,
-        /// Fact values to provide (format: name=value or ref_spec.fact=value)
-        ///
-        /// Examples: price=100, quantity=5, config.tax_rate=0.21
-        facts: Vec<String>,
         /// Invert a rule to find inputs that produce desired output
-        ///
-        /// Format: rule[=target] where target can be =value, >value, <value, >=value, <=value, or =veto
-        ///
-        /// Examples:
-        ///   --target total=100
-        ///   --target total>50
-        ///   --target can_drive=veto
         #[arg(short = 't', long)]
         target: Option<String>,
-        /// Workspace root directory containing .lemma files
-        #[arg(short = 'd', long = "dir", default_value = ".")]
-        workdir: PathBuf,
         /// Output format: table (human-readable) or json (machine-readable)
         #[arg(
             short = 'o',
@@ -91,36 +75,30 @@ enum Commands {
     },
     /// Spec schema (facts and rules)
     ///
-    /// Displays spec structure and dependencies.
+    /// Examples:
+    ///   lemma schema tax.lemma
+    ///   lemma schema calculator
+    ///   lemma schema calculator --hash
     Schema {
-        /// Name of the spec
-        spec_name: String,
-        /// Workspace root directory containing .lemma files
-        #[arg(short = 'd', long = "dir", default_value = ".")]
-        workdir: PathBuf,
+        /// [source] [spec] — source is a .lemma file or directory
+        args: Vec<String>,
         /// Effective datetime (e.g. 2026, 2026-03-04)
         #[arg(long)]
         effective: Option<String>,
-        /// Output only the plan hash (for piping, e.g. lemma run spec~$(lemma schema spec --hash))
+        /// Output only the plan hash
         #[arg(long)]
         hash: bool,
     },
     /// List all specs with facts and rules counts
-    ///
-    /// Scans the workspace for .lemma files and displays all available specs
-    /// with their facts and rules counts. Use this to explore a Lemma project.
     List {
-        /// Workspace root directory containing .lemma files
+        /// Workspace directory or .lemma file
         #[arg(default_value = ".")]
-        root: PathBuf,
-        /// List at effective datetime (e.g. 2026, 2026-03-04)
+        source: PathBuf,
+        /// Effective datetime (e.g. 2026, 2026-03-04)
         #[arg(long)]
         effective: Option<String>,
     },
     /// Start HTTP REST API server with auto-generated typed endpoints (default: localhost:8012)
-    ///
-    /// Loads all .lemma files from the workspace and generates typed REST API endpoints
-    /// for each spec. Interactive OpenAPI documentation is available at /docs.
     ///
     /// Routes:
     ///   GET  /{spec}              — evaluate all rules (facts as query params)
@@ -132,9 +110,9 @@ enum Commands {
     ///   GET  /openapi.json       — OpenAPI 3.1 specification
     ///   GET  /health             — health check
     Server {
-        /// Workspace root directory containing .lemma files
-        #[arg(short = 'd', long = "dir", default_value = ".")]
-        workdir: PathBuf,
+        /// Workspace directory or .lemma file
+        #[arg(default_value = ".")]
+        source: PathBuf,
         /// Host address to bind to
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
@@ -144,48 +122,31 @@ enum Commands {
         /// Watch workspace for .lemma file changes and reload automatically
         #[arg(short, long)]
         watch: bool,
-        /// Enable explanation generation; clients send header x-explanations to receive explanation objects in responses
+        /// Enable explanation generation
         #[arg(long)]
         explanations: bool,
     },
     /// Start MCP server for AI assistant integration (stdio)
-    ///
-    /// Runs an MCP server over stdio for AI assistant integration.
-    /// The server provides tools for adding specs, evaluating rules, and inspecting specs.
-    /// Designed for use with AI coding assistants and agents.
     Mcp {
-        /// Workspace root directory containing .lemma files
-        #[arg(short = 'd', long = "dir", default_value = ".")]
-        workdir: PathBuf,
+        /// Workspace directory or .lemma file
+        #[arg(default_value = ".")]
+        source: PathBuf,
         /// Enable admin tools: add_spec, get_spec_source (read-only by default)
         #[arg(long)]
         admin: bool,
     },
     /// Get dependencies from the registry
     ///
-    /// Without arguments: parses all local .lemma files, collects @... references,
-    /// and downloads dependencies from the registry into the global deps cache.
-    ///
-    /// With a spec argument (e.g. `lemma get @user/repo/spec`): fetches all
-    /// temporal versions of that specific spec from the registry.
-    ///
-    /// Old dependency versions are kept (not pruned) so that spec~hash pinning
-    /// continues to work.
+    /// Without arguments: resolves all @... references in the workspace.
+    /// With a spec: fetches that specific spec from the registry.
     Get {
-        /// Specific spec to fetch (e.g. @user/repo/spec). If omitted, resolves all @... references.
-        #[arg(value_name = "SPEC")]
-        spec_id: Option<String>,
-        /// Workspace root directory containing .lemma files
-        #[arg(short = 'd', long = "dir", default_value = ".")]
-        workdir: PathBuf,
+        /// [source] [spec] — spec to fetch (e.g. @user/repo/spec)
+        args: Vec<String>,
         /// Overwrite existing registry specs when content has changed
         #[arg(short = 'f', long)]
         force: bool,
     },
     /// Format .lemma files to canonical style
-    ///
-    /// Parses and re-emits .lemma files with consistent formatting.
-    /// Without flags, formats files in place. Use --check for CI.
     Format {
         /// Files or directories to format (default: current directory)
         #[arg(default_value = ".")]
@@ -197,6 +158,76 @@ enum Commands {
         #[arg(long)]
         stdout: bool,
     },
+}
+
+struct ParsedTarget {
+    source: PathBuf,
+    spec: Option<String>,
+    facts: Vec<String>,
+}
+
+fn parse_target(args: &[String]) -> Result<ParsedTarget> {
+    let mut facts = Vec::new();
+    let mut positionals = Vec::new();
+    for arg in args {
+        if arg.contains('=') {
+            facts.push(arg.clone());
+        } else {
+            if arg == "-" {
+                anyhow::bail!(
+                    "`-` is not a valid source path (stdin is not supported); pass a .lemma file or directory"
+                );
+            }
+            positionals.push(arg.as_str());
+        }
+    }
+    let (source, spec) = match positionals.as_slice() {
+        [] => (PathBuf::from("."), None),
+        [first] => {
+            if Path::new(first).exists() {
+                (PathBuf::from(first), None)
+            } else {
+                (PathBuf::from("."), Some(first.to_string()))
+            }
+        }
+        [first, second, ..] => {
+            if Path::new(first).exists() {
+                (PathBuf::from(first), Some(second.to_string()))
+            } else {
+                (PathBuf::from("."), Some(first.to_string()))
+            }
+        }
+    };
+    Ok(ParsedTarget {
+        source,
+        spec,
+        facts,
+    })
+}
+
+/// Resolve spec name: use explicit name, auto-select for single-spec sources,
+/// or error/interactive for multi-spec sources.
+fn resolve_spec(engine: &Engine, spec: Option<&String>, interactive: bool) -> Result<String> {
+    resolve_spec_str(engine, spec.map(|s| s.as_str()), interactive)
+}
+
+fn resolve_spec_str(engine: &Engine, spec: Option<&str>, interactive: bool) -> Result<String> {
+    if let Some(name) = spec {
+        return Ok(name.to_string());
+    }
+    let specs = engine.list_specs();
+    match specs.len() {
+        0 => anyhow::bail!("No specs found in source"),
+        1 => Ok(specs[0].name.clone()),
+        _ if interactive => Ok(String::new()),
+        _ => {
+            let names: Vec<&str> = specs.iter().map(|s| s.name.as_str()).collect();
+            anyhow::bail!(
+                "Source contains multiple specs: {}\n\nUsage: lemma run <source> <spec> [facts...]",
+                names.join(", ")
+            );
+        }
+    }
 }
 
 fn resolve_effective(raw: Option<&String>) -> Result<DateTimeValue> {
@@ -212,54 +243,61 @@ fn resolve_effective(raw: Option<&String>) -> Result<DateTimeValue> {
 fn main() {
     let cli = Cli::parse();
 
-    let result = match &cli.command {
+    let result: Result<()> = (|| match &cli.command {
         Commands::Run {
-            workdir,
-            spec_id,
+            args,
             rules,
-            facts,
             target,
             output,
             explain,
             interactive,
             effective,
-        } => run_command(RunOptions {
-            workdir,
-            spec_id: spec_id.as_ref(),
-            rules: rules.as_ref(),
-            facts,
-            target: target.as_ref(),
-            output: *output,
-            explain: *explain,
-            interactive: *interactive,
-            effective_raw: effective.as_ref(),
-        }),
+        } => {
+            let parsed = parse_target(args)?;
+            run_command(RunOptions {
+                source: &parsed.source,
+                spec_id: parsed.spec.as_ref(),
+                rules: rules.as_ref(),
+                facts: &parsed.facts,
+                target: target.as_ref(),
+                output: *output,
+                explain: *explain,
+                interactive: *interactive,
+                effective_raw: effective.as_ref(),
+            })
+        }
         Commands::Schema {
-            workdir,
-            spec_name,
+            args,
             effective,
             hash,
-        } => schema_command(workdir, spec_name, effective.as_ref(), *hash),
-        Commands::List { root, effective } => list_command(root, effective.as_ref()),
+        } => {
+            let parsed = parse_target(args)?;
+            schema_command(
+                &parsed.source,
+                parsed.spec.as_deref(),
+                effective.as_ref(),
+                *hash,
+            )
+        }
+        Commands::List { source, effective } => list_command(source, effective.as_ref()),
         Commands::Server {
-            workdir,
+            source,
             host,
             port,
             watch,
             explanations,
-        } => server_command(workdir, host, *port, *watch, *explanations),
-        Commands::Mcp { workdir, admin } => mcp_command(workdir, *admin),
-        Commands::Get {
-            spec_id,
-            workdir,
-            force,
-        } => get_command(workdir, spec_id.as_ref(), *force),
+        } => server_command(source, host, *port, *watch, *explanations),
+        Commands::Mcp { source, admin } => mcp_command(source, *admin),
+        Commands::Get { args, force } => {
+            let parsed = parse_target(args)?;
+            get_command(&parsed.source, parsed.spec.as_deref(), *force)
+        }
         Commands::Format {
             paths,
             check,
             stdout,
         } => format_command(paths, *check, *stdout),
-    };
+    })();
 
     if let Err(e) = result {
         eprintln!("{}", e);
@@ -268,7 +306,7 @@ fn main() {
 }
 
 struct RunOptions<'a> {
-    workdir: &'a Path,
+    source: &'a Path,
     spec_id: Option<&'a String>,
     rules: Option<&'a String>,
     facts: &'a [String],
@@ -282,39 +320,17 @@ struct RunOptions<'a> {
 fn run_command(opts: RunOptions<'_>) -> Result<()> {
     let now = resolve_effective(opts.effective_raw)?;
     let mut engine = Engine::new();
-    load_workspace(&mut engine, opts.workdir)?;
+    load_workspace(&mut engine, opts.source)?;
 
-    let (spec_id, rules, final_facts, target) = if opts.interactive || opts.spec_id.is_none() {
-        if opts.spec_id.is_none() && !opts.interactive {
-            eprintln!("Error: No spec specified\n");
-            eprintln!("Usage: lemma run [SPEC] [--rules=rule1,rule2] [FACTS...] [OPTIONS]\n");
-            eprintln!("Examples:");
-            eprintln!(
-                "  lemma run pricing                    - Evaluate all rules in 'pricing' spec"
-            );
-            eprintln!("  lemma run pricing --rules=total        - Evaluate only 'total' rule");
-            eprintln!(
-                "  lemma run pricing --rules=total,tax     - Evaluate 'total' and 'tax' rules"
-            );
-            eprintln!("  lemma run pricing price=100 qty=5      - Evaluate with fact values");
-            eprintln!("  lemma run spec~a1b2c3d4                - Pin to plan hash (use lemma schema for hash)");
-            eprintln!(
-                "  lemma run --interactive                - Interactive mode for selection\n"
-            );
-            eprintln!("To see available specs:");
-            eprintln!("  lemma list\n");
-            eprintln!("For more information:");
-            eprintln!("  lemma run --help");
-            std::process::exit(1);
-        }
+    let resolved_spec = resolve_spec(&engine, opts.spec_id, opts.interactive)?;
 
-        let (parsed_spec, parsed_rules) = match opts.spec_id {
-            Some(spec_id) => {
-                let (name, _) =
-                    lemma::parse_spec_id(spec_id).map_err(|e| anyhow::anyhow!("{}", e))?;
-                (Some(name), opts.rules.map(|r| parse_rule_names(r.as_str())))
-            }
-            None => (None, None),
+    let (spec_id, rules, final_facts, target) = if opts.interactive {
+        let (parsed_spec, parsed_rules) = if resolved_spec.is_empty() {
+            (None, None)
+        } else {
+            let (name, _) =
+                lemma::parse_spec_id(&resolved_spec).map_err(|e| anyhow::anyhow!("{}", e))?;
+            (Some(name), opts.rules.map(|r| parse_rule_names(r.as_str())))
         };
 
         let cli_facts: std::collections::HashMap<String, String> = parse_fact_strings(opts.facts);
@@ -328,24 +344,19 @@ fn run_command(opts: RunOptions<'_>) -> Result<()> {
             &now,
         )?;
 
-        // Add a blank line after the final interactive prompt so the
-        // formatted output sections ("Facts", "Rules", etc.) don't run
-        // directly against the last user-entered line.
         println!();
 
         let mut all_facts = cli_facts;
         all_facts.extend(interactive_facts);
         (s, r.unwrap_or_default(), all_facts, interactive_target)
-    } else if let Some(spec_id) = opts.spec_id {
-        lemma::parse_spec_id(spec_id).map_err(|e| anyhow::anyhow!("{}", e))?;
+    } else {
+        lemma::parse_spec_id(&resolved_spec).map_err(|e| anyhow::anyhow!("{}", e))?;
         let rules = opts
             .rules
             .map(|r| parse_rule_names(r.as_str()))
             .unwrap_or_default();
         let fact_values = parse_fact_strings(opts.facts);
-        (spec_id.to_owned(), rules, fact_values, None)
-    } else {
-        unreachable!()
+        (resolved_spec, rules, fact_values, None)
     };
 
     if target.is_some() {
@@ -421,17 +432,18 @@ fn parse_fact_strings(facts: &[String]) -> HashMap<String, String> {
 }
 
 fn schema_command(
-    workdir: &Path,
-    spec_id: &str,
+    source: &Path,
+    spec: Option<&str>,
     effective_raw: Option<&String>,
     hash_only: bool,
 ) -> Result<()> {
     let now = resolve_effective(effective_raw)?;
     let mut engine = Engine::new();
-    load_workspace(&mut engine, workdir)?;
+    load_workspace(&mut engine, source)?;
 
+    let spec_id = resolve_spec_str(&engine, spec, false)?;
     let plan = engine
-        .get_plan(spec_id, Some(&now))
+        .get_plan(&spec_id, Some(&now))
         .map_err(|e| anyhow::anyhow!("{}", error_formatter::format_error(&e, engine.sources())))?;
     let hash = plan.plan_hash();
     if hash_only {
@@ -443,17 +455,21 @@ fn schema_command(
     Ok(())
 }
 
-fn list_command(root: &PathBuf, effective_raw: Option<&String>) -> Result<()> {
+fn list_command(source: &Path, effective_raw: Option<&String>) -> Result<()> {
     let now = resolve_effective(effective_raw)?;
     let mut engine = Engine::new();
 
-    let file_count = WalkDir::new(root)
-        .into_iter()
-        .flatten()
-        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("lemma"))
-        .count();
+    let file_count = if source.is_file() {
+        1
+    } else {
+        WalkDir::new(source)
+            .into_iter()
+            .flatten()
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("lemma"))
+            .count()
+    };
 
-    load_workspace(&mut engine, root)?;
+    load_workspace(&mut engine, source)?;
 
     let specs = engine.list_specs();
     let schemas: Vec<lemma::SpecSchema> = specs
@@ -477,7 +493,7 @@ fn list_command(root: &PathBuf, effective_raw: Option<&String>) -> Result<()> {
 }
 
 fn server_command(
-    workdir: &Path,
+    source: &Path,
     host: &str,
     port: u16,
     watch: bool,
@@ -487,7 +503,7 @@ fn server_command(
     let rt = Runtime::new()?;
     rt.block_on(async {
         let mut engine = Engine::new();
-        load_workspace(&mut engine, workdir)?;
+        load_workspace(&mut engine, source)?;
 
         let spec_names = engine.list_specs();
         let spec_count = spec_names.len();
@@ -498,16 +514,16 @@ fn server_command(
             port,
             watch,
             explanations,
-            workdir.to_path_buf(),
+            source.to_path_buf(),
         )
         .await
     })?;
     Ok(())
 }
 
-fn mcp_command(workdir: &Path, admin: bool) -> Result<()> {
+fn mcp_command(source: &Path, admin: bool) -> Result<()> {
     let mut engine = Engine::new();
-    load_workspace(&mut engine, workdir)?;
+    load_workspace(&mut engine, source)?;
 
     let config = mcp::McpConfig { admin };
 
@@ -519,17 +535,17 @@ fn mcp_command(workdir: &Path, admin: bool) -> Result<()> {
     Ok(())
 }
 
-fn get_command(workdir: &Path, spec_id: Option<&String>, force: bool) -> Result<()> {
+fn get_command(source: &Path, spec_id: Option<&str>, force: bool) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(get_command_async(workdir, spec_id, force))
+    rt.block_on(get_command_async(source, spec_id, force))
 }
 
-async fn get_command_async(workdir: &Path, spec_id: Option<&String>, force: bool) -> Result<()> {
+async fn get_command_async(source: &Path, spec_id: Option<&str>, force: bool) -> Result<()> {
     let registry = make_fetch_registry();
 
     match spec_id {
-        Some(spec_id) => get_single_spec(workdir, spec_id, &*registry, force).await,
-        None => get_all_workspace_deps(workdir, &*registry, force).await,
+        Some(spec_id) => get_single_spec(source, spec_id, &*registry, force).await,
+        None => get_all_workspace_deps(source, &*registry, force).await,
     }
 }
 
@@ -866,16 +882,18 @@ fn make_fetch_registry() -> Box<dyn lemma::Registry> {
     std::process::exit(1);
 }
 
-/// Load all .lemma files from the workspace directory.
-///
-/// Walks the workspace recursively for user-authored specs and cached registry
-/// dependencies (stored in `.deps/` inside the workspace by `lemma get`).
+/// Load specs from a workspace directory (recursive walk) or a single .lemma file.
+/// When given a directory, also picks up cached registry deps in `.deps/`.
 fn load_workspace(engine: &mut Engine, workdir: &std::path::Path) -> Result<()> {
     let mut paths: Vec<std::path::PathBuf> = Vec::new();
-    for entry in WalkDir::new(workdir) {
-        let entry = entry?;
-        if entry.path().extension().and_then(|s| s.to_str()) == Some("lemma") {
-            paths.push(entry.path().to_path_buf());
+    if workdir.is_file() {
+        paths.push(workdir.to_path_buf());
+    } else {
+        for entry in WalkDir::new(workdir) {
+            let entry = entry?;
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("lemma") {
+                paths.push(entry.path().to_path_buf());
+            }
         }
     }
     if let Err(load_err) = engine.load_from_paths(&paths, false) {

--- a/cli/tests/integrations/examples.rs
+++ b/cli/tests/integrations/examples.rs
@@ -1,7 +1,7 @@
 //! Tests for all CLI integration example files
 //!
 //! Ensures all example files in cli/tests/integrations/examples/ are valid and can be evaluated
-//! This validates that the examples work correctly through the CLI command interface.
+//! through the CLI command interface.
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
@@ -24,10 +24,7 @@ fn test_example_01_simple_facts() {
     fs::copy(&example_file, temp_dir.path().join("01_simple_facts.lemma")).unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("simple_facts")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("simple_facts");
 
     cmd.assert().success();
 }
@@ -39,10 +36,7 @@ fn test_schema_includes_hash() {
     fs::copy(&example_file, temp_dir.path().join("01_simple_facts.lemma")).unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("schema")
-        .arg("simple_facts")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("schema").arg(temp_dir.path()).arg("simple_facts");
 
     cmd.assert()
         .success()
@@ -58,10 +52,9 @@ fn test_schema_hash_only_outputs_hash() {
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("schema")
+        .arg(temp_dir.path())
         .arg("simple_facts")
-        .arg("--hash")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("--hash");
 
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -88,10 +81,9 @@ fn test_example_02_rules_and_unless() {
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("rules_and_unless")
-        .arg("base_price=100.00")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("base_price=100.00");
 
     cmd.assert()
         .success()
@@ -109,32 +101,20 @@ fn test_example_03_spec_references() {
     )
     .unwrap();
 
-    // Test base_employee spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("base_employee")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("base_employee");
 
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("annual_salary").or(predicate::str::is_empty()));
 
-    // Test specific_employee spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("specific_employee")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("specific_employee");
 
     cmd.assert().success();
 
-    // Test contractor spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("contractor")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("contractor");
 
     cmd.assert().success();
 }
@@ -151,10 +131,7 @@ fn test_example_04_unit_conversions() {
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("unit_conversions")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("unit_conversions");
 
     cmd.assert()
         .success()
@@ -174,10 +151,9 @@ fn test_example_05_date_handling() {
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("date_handling")
-        .arg("current_date=2024-06-15")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("current_date=2024-06-15");
 
     cmd.assert()
         .success()
@@ -196,10 +172,7 @@ fn test_example_06_tax_calculation() {
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("tax_calculation")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("tax_calculation");
 
     cmd.assert()
         .success()
@@ -219,6 +192,7 @@ fn test_example_07_shipping_policy() {
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("shipping_policy")
         .arg("order_total=75.00")
         .arg("item_weight=8")
@@ -226,9 +200,7 @@ fn test_example_07_shipping_policy() {
         .arg("destination_region=North Holland")
         .arg("is_po_box=false")
         .arg("is_expedited=false")
-        .arg("is_hazardous=false")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("is_hazardous=false");
 
     cmd.assert()
         .success()
@@ -249,23 +221,15 @@ fn test_example_08_rule_references() {
     )
     .unwrap();
 
-    // Test rule_references spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("rule_references")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("rule_references");
 
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("can_drive_legally").or(predicate::str::is_empty()));
 
-    // Test eligibility_check spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("eligibility_check")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("eligibility_check");
 
     cmd.assert().success().stdout(
         predicate::str::contains("can_travel_internationally").or(predicate::str::is_empty()),
@@ -281,6 +245,7 @@ fn test_example_09_stress_test() {
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("stress_test")
         .arg("base_price=100.00")
         .arg("quantity=50")
@@ -290,24 +255,20 @@ fn test_example_09_stress_test() {
         .arg("delivery_distance=300")
         .arg("is_express=false")
         .arg("is_fragile=false")
-        .arg("payment_method=credit")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("payment_method=credit");
 
     cmd.assert().success();
 
-    // Test stress_test_config spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("stress_test_config")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("stress_test_config");
 
     cmd.assert().success();
 
-    // Test stress_test_extended spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("stress_test_extended")
         .arg("order.base_price=100.00")
         .arg("order.quantity=100")
@@ -317,9 +278,7 @@ fn test_example_09_stress_test() {
         .arg("order.delivery_distance=250")
         .arg("order.is_express=true")
         .arg("order.is_fragile=true")
-        .arg("order.payment_method=debit")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("order.payment_method=debit");
 
     cmd.assert().success();
 }
@@ -338,9 +297,8 @@ fn test_example_10_compensation_policy() {
     // Test base_policy spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("compensation/base_policy")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("compensation/base_policy");
 
     cmd.assert()
         .success()
@@ -349,9 +307,8 @@ fn test_example_10_compensation_policy() {
     // Test engineering_dept spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("compensation/engineering_dept")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("compensation/engineering_dept");
 
     cmd.assert()
         .success()
@@ -360,18 +317,16 @@ fn test_example_10_compensation_policy() {
     // Test senior_engineer spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("compensation/senior_engineer")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("compensation/senior_engineer");
 
     cmd.assert().success();
 
     // Test principal_engineer spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("compensation/principal_engineer")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("compensation/principal_engineer");
 
     cmd.assert().success();
 }
@@ -390,9 +345,8 @@ fn test_example_11_spec_composition() {
     // Test base_config spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("pricing/base_config")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("pricing/base_config");
 
     cmd.assert()
         .success()
@@ -400,10 +354,7 @@ fn test_example_11_spec_composition() {
 
     // Test wholesale spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("pricing/wholesale")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("pricing/wholesale");
 
     cmd.assert()
         .success()
@@ -412,27 +363,22 @@ fn test_example_11_spec_composition() {
     // Test wholesale_order spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("order/wholesale_order")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("order/wholesale_order");
 
     cmd.assert().success();
 
     // Test comparison spec
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("order/comparison")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("order/comparison");
 
     cmd.assert().success();
 
     // Test custom_wholesale spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("order/custom_wholesale")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("order/custom_wholesale");
 
     cmd.assert()
         .success()
@@ -441,9 +387,8 @@ fn test_example_11_spec_composition() {
     // Test multi_reference spec
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
-        .arg("complex/multi_reference")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg(temp_dir.path())
+        .arg("complex/multi_reference");
 
     cmd.assert().success();
 }
@@ -466,9 +411,8 @@ fn test_example_13_temporal_versioning() {
     let output_2024 = std::process::Command::new(env!("CARGO_BIN_EXE_lemma"))
         .args([
             "run",
-            "ind/kennismigrant/aanvraag",
-            "--dir",
             dir,
+            "ind/kennismigrant/aanvraag",
             "--effective",
             "2024-06",
             "applicant_age=28",
@@ -494,9 +438,8 @@ fn test_example_13_temporal_versioning() {
     let output_2025 = std::process::Command::new(env!("CARGO_BIN_EXE_lemma"))
         .args([
             "run",
-            "ind/kennismigrant/aanvraag",
-            "--dir",
             dir,
+            "ind/kennismigrant/aanvraag",
             "--effective",
             "2025-06",
             "applicant_age=31",

--- a/cli/tests/integrations/examples/06_tax_calculation.lemma
+++ b/cli/tests/integrations/examples/06_tax_calculation.lemma
@@ -67,7 +67,7 @@ rule total_income_tax:
 
 rule country_tax_rate:
   21%
-  unless country != "NL" then 0%
+  unless country is not "NL" then 0%
 
 rule vat_tax:
   taxable_income * country_tax_rate
@@ -77,7 +77,7 @@ rule total_tax:
 
 rule effective_tax_rate:
   total_tax / income in percent
-  unless income == 0 then 0%
+  unless income is 0 then 0%
 
 rule after_tax_income:
   income - total_tax

--- a/cli/tests/integrations/examples/07_shipping_policy.lemma
+++ b/cli/tests/integrations/examples/07_shipping_policy.lemma
@@ -55,7 +55,7 @@ rule expedited_fee:
 rule hazardous_fee:
   0
   unless is_hazardous then 50
-  unless is_hazardous and destination_country != "NL"
+  unless is_hazardous and destination_country is not "NL"
     then veto "Cannot ship hazardous materials internationally"
 
 rule customer_discount:
@@ -91,7 +91,7 @@ rule ships_to_location:
   true
   unless is_po_box and is_hazardous
     then veto "Cannot ship hazardous materials to PO boxes"
-  unless destination_region == "Svalbard"
+  unless destination_region is "Svalbard"
     then veto "Shipping not available to Svalbard"
 
 rule total_with_shipping:

--- a/cli/tests/integrations/mcp.rs
+++ b/cli/tests/integrations/mcp.rs
@@ -30,7 +30,7 @@ fn mcp_session(
 ) -> Vec<serde_json::Value> {
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut cmd = Command::new(bin);
-    cmd.arg("mcp").arg("--dir").arg(workdir);
+    cmd.arg("mcp").arg(workdir);
     if admin {
         cmd.arg("--admin");
     }
@@ -853,7 +853,7 @@ fn test_mcp_malformed_json() {
 
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut cmd = Command::new(bin);
-    cmd.arg("mcp").arg("--dir").arg(temp_dir.path());
+    cmd.arg("mcp").arg(temp_dir.path());
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());

--- a/cli/tests/integrations/run.rs
+++ b/cli/tests/integrations/run.rs
@@ -7,10 +7,8 @@ use tempfile::TempDir;
 #[test]
 fn test_cli_run_simple_spec() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec simple_test
 fact x: 10
@@ -22,10 +20,7 @@ rule product: x * y
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("simple_test")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("simple_test");
 
     cmd.assert()
         .success()
@@ -38,10 +33,8 @@ rule product: x * y
 #[test]
 fn test_cli_run_with_fact_values() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec override_test
 fact base: [number]
@@ -52,10 +45,9 @@ rule doubled: base * 2
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("override_test")
-        .arg("base=7")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("base=7");
 
     cmd.assert()
         .success()
@@ -67,10 +59,7 @@ fn test_cli_run_nonexistent_spec() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("nonexistent")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("nonexistent");
 
     cmd.assert()
         .failure()
@@ -78,12 +67,20 @@ fn test_cli_run_nonexistent_spec() {
 }
 
 #[test]
+fn test_cli_run_rejects_dash_source() {
+    let mut cmd = cargo_bin_cmd!("lemma");
+    cmd.arg("run").arg("-").arg("any_spec");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("stdin is not supported"));
+}
+
+#[test]
 fn test_cli_run_with_unless_clause() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec discount_test
 fact quantity: 15
@@ -95,10 +92,7 @@ rule discount: 0
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("discount_test")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("discount_test");
 
     cmd.assert()
         .success()
@@ -108,10 +102,8 @@ rule discount: 0
 #[test]
 fn test_cli_schema_spec() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec inspect_test
 fact name: "Test"
@@ -122,10 +114,7 @@ rule doubled: value * 2
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("schema")
-        .arg("inspect_test")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("schema").arg(temp_dir.path()).arg("inspect_test");
 
     cmd.assert()
         .success()
@@ -168,10 +157,8 @@ fact y: 2
 #[test]
 fn test_cli_run_with_arithmetic() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec arithmetic_test
 fact price: 100
@@ -181,10 +168,7 @@ rule with_tax: price * 1.21
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("arithmetic_test")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("arithmetic_test");
 
     cmd.assert()
         .success()
@@ -194,10 +178,8 @@ rule with_tax: price * 1.21
 #[test]
 fn test_cli_parse_error_handling() {
     let temp_dir = TempDir::new().unwrap();
-    let lemma_file = temp_dir.path().join("test.lemma");
-
     fs::write(
-        &lemma_file,
+        temp_dir.path().join("test.lemma"),
         r#"
 spec invalid
 this is not valid lemma syntax
@@ -206,10 +188,7 @@ this is not valid lemma syntax
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("invalid")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("invalid");
 
     cmd.assert()
         .failure()
@@ -220,7 +199,6 @@ this is not valid lemma syntax
 fn test_cli_reports_errors_from_all_files() {
     let temp_dir = TempDir::new().unwrap();
 
-    // File 1: valid
     fs::write(
         temp_dir.path().join("valid.lemma"),
         r#"
@@ -231,7 +209,6 @@ rule doubled: price * 2
     )
     .unwrap();
 
-    // File 2: broken (parse error)
     fs::write(
         temp_dir.path().join("broken_a.lemma"),
         r#"
@@ -241,7 +218,6 @@ this is not valid lemma
     )
     .unwrap();
 
-    // File 3: broken (different parse error)
     fs::write(
         temp_dir.path().join("broken_b.lemma"),
         r#"
@@ -252,12 +228,8 @@ also invalid lemma syntax
     .unwrap();
 
     let mut cmd = cargo_bin_cmd!("lemma");
-    cmd.arg("run")
-        .arg("valid_spec")
-        .arg("--dir")
-        .arg(temp_dir.path());
+    cmd.arg("run").arg(temp_dir.path()).arg("valid_spec");
 
-    // Should fail, and the error output should mention BOTH broken files
     let output = cmd.output().unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
 
@@ -292,11 +264,10 @@ rule total: a + b + c
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("nested_explanation")
         .arg("--rules=total")
-        .arg("--explain")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("--explain");
 
     let output = cmd.output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -346,10 +317,9 @@ rule out: true
 
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.arg("run")
+        .arg(temp_dir.path())
         .arg("explain_test")
-        .arg("--explain")
-        .arg("--dir")
-        .arg(temp_dir.path());
+        .arg("--explain");
 
     let output = cmd.output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/cli/tests/integrations/server.rs
+++ b/cli/tests/integrations/server.rs
@@ -31,7 +31,6 @@ rule result: x
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut child = std::process::Command::new(bin)
         .arg("server")
-        .arg("--dir")
         .arg(temp_dir.path())
         .arg("--port")
         .arg(SERVER_TEST_PORT.to_string())
@@ -75,7 +74,9 @@ fn test_server_help_shows_new_routes() {
 
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("Workspace root directory"))
+        .stdout(predicates::str::contains(
+            "Workspace directory or .lemma file",
+        ))
         .stdout(predicates::str::contains("--watch"))
         .stdout(predicates::str::contains("/docs"))
         .stdout(predicates::str::contains("/openapi.json"));
@@ -100,7 +101,7 @@ fn test_server_help_shows_explanations_flag() {
     cmd.assert()
         .success()
         .stdout(predicates::str::contains("--explanations"))
-        .stdout(predicates::str::contains("x-explanations"));
+        .stdout(predicates::str::contains("Enable explanation generation"));
 }
 
 #[test]
@@ -120,7 +121,6 @@ rule result: x
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut child = std::process::Command::new(bin)
         .arg("server")
-        .arg("--dir")
         .arg(temp_dir.path())
         .arg("--port")
         .arg(port.to_string())

--- a/documentation/examples/05_weather_clothing.lemma
+++ b/documentation/examples/05_weather_clothing.lemma
@@ -57,9 +57,9 @@ rule comfort_level:
 
 rule recommendation:
   "Enjoy your day!"
-  unless comfort_level == "cold"
+  unless comfort_level is "cold"
     then "Dress warmly and stay indoors if possible"
-  unless comfort_level == "hot"
+  unless comfort_level is "hot"
     then "Stay hydrated and seek shade"
-  unless comfort_level == "uncomfortable"
+  unless comfort_level is "uncomfortable"
     then "Consider postponing outdoor activities"

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -161,7 +161,7 @@ Reference other rules by name (the engine resolves whether a name is a fact or a
 ```lemma
 rule is_adult: age >= 18
 
-rule has_license: license_status == "valid"
+rule has_license: license_status is "valid"
 
 rule can_drive: is_adult and has_license
   unless license_suspended then veto "License suspended"
@@ -207,7 +207,7 @@ rule not_cancelled: status is not "cancelled"
 rule is_eligible: age >= 18 and income > 30000
 ```
 
-Operators: `>`, `<`, `>=`, `<=`, `==`, `!=`, `is`, `is not`
+Operators: `>`, `<`, `>=`, `<=`, `is`, `is not`
 
 ### Logical
 

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -26,10 +26,8 @@ Quick reference for all operators and types in Lemma.
 | `<` | Less than | `price < 100` |
 | `>=` | Greater or equal | `score >= 70` |
 | `<=` | Less or equal | `weight <= 50` |
-| `==` | Equal | `status == "active"` |
-| `!=` | Not equal | `type != "admin"` |
-| `is` | Equal (text-friendly) | `status is "approved"` |
-| `is not` | Not equal (text-friendly) | `status is not "cancelled"` |
+| `is` | Equal | `status is "approved"` |
+| `is not` | Not equal | `status is not "cancelled"` |
 
 ### Logical
 | Operator | Description | Example |

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -213,6 +213,17 @@ type currency from base_types
 type discount_rate from pricing -> maximum 0.5
 ```
 
+Type imports support explicit effective datetimes and hash pins, identical to fact spec refs:
+
+```lemma
+type money from finance 2026-01-15
+type money from finance~a1b2c3d4
+type money from finance~a1b2c3d4 2026-01-15T00:00:03
+```
+
+Unpinned type imports (without `~hash`) participate in temporal slicing: the engine
+creates slice boundaries when the imported spec has multiple temporal versions.
+
 ### Inline Type Definitions
 
 Define types inline in fact declarations:

--- a/documentation/registry.md
+++ b/documentation/registry.md
@@ -26,8 +26,7 @@ Implement `lemma::Registry`. All methods receive the identifier **without** the 
 
 | Method | Purpose |
 |--------|---------|
-| `get_specs(&self, name) -> Result<RegistryBundle, RegistryError>` | Download all temporal versions for a `spec @...` reference. |
-| `get_types(&self, name) -> Result<RegistryBundle, RegistryError>` | Download all temporal versions for a `type ... from @...` reference. |
+| `get(&self, name) -> Result<RegistryBundle, RegistryError>` | Download all temporal versions for an `@...` identifier (both spec refs and type imports). |
 | `url_for_id(&self, name, effective) -> Option<String>` | Optional: return a URL for editor navigation. |
 
 The trait is **async** and requires `Send + Sync`. On WASM the future is `?Send`.

--- a/documentation/whitepaper.md
+++ b/documentation/whitepaper.md
@@ -99,7 +99,7 @@ Lemma encodes this exactly as stated:
 
 ```lemma
 rule shipping: 12.99
-  unless destination == "CA" then 25.00
+  unless destination is "CA" then 25.00
   unless order_total >= 100 then 0
 ```
 
@@ -195,7 +195,7 @@ Rules can reference other rules by name (the engine resolves whether a name is a
 
 ```lemma
 rule is_adult: age >= 18
-rule has_license: license_status == "valid"
+rule has_license: license_status is "valid"
 rule can_drive: is_adult and has_license
 ```
 
@@ -234,7 +234,7 @@ Lemma provides comprehensive operators for arithmetic, comparison, logical opera
 rule compound: principal * (1 + rate) ^ years
 ```
 
-**Comparison**: `>`, `<`, `>=`, `<=`, `==`, `!=`, `is`, `is not`
+**Comparison**: `>`, `<`, `>=`, `<=`, `is`, `is not`
 
 ```lemma
 rule is_eligible: age >= 18 and income > 30000
@@ -588,7 +588,7 @@ fact filing_status: "single"
 rule taxable_income: income - standard_deduction
 
 rule standard_deduction: 13850
-  unless filing_status == "married" then 27700
+  unless filing_status is "married" then 27700
 
 rule tax_owed: 0
   unless taxable_income > 11000
@@ -616,9 +616,9 @@ rule volume_discount: 0%
   unless quantity >= 100 then 15%
 
 rule tier_discount: 0%
-  unless customer_tier == "silver" then 5%
-  unless customer_tier == "gold" then 10%
-  unless customer_tier == "platinum" then 15%
+  unless customer_tier is "silver" then 5%
+  unless customer_tier is "gold" then 10%
+  unless customer_tier is "platinum" then 15%
 
 rule best_discount: volume_discount
   unless tier_discount > volume_discount then tier_discount
@@ -643,13 +643,13 @@ rule eligible_age: age >= 18 and age <= 65
 rule eligible_health: not pre_existing_conditions
 
 rule eligible_employment: false
-  unless employment_status == "full_time" then true
-  unless employment_status == "part_time" then true
+  unless employment_status is "full_time" then true
+  unless employment_status is "part_time" then true
 
 rule is_eligible: eligible_age and eligible_health and eligible_employment
-  unless eligible_age == false then veto "Age not within eligible range"
-  unless eligible_health == false then veto "Pre-existing conditions"
-  unless eligible_employment == false then veto "Employment status ineligible"
+  unless eligible_age is false then veto "Age not within eligible range"
+  unless eligible_health is false then veto "Pre-existing conditions"
+  unless eligible_employment is false then veto "Employment status ineligible"
 ```
 
 ### 7.4 Shipping policy
@@ -667,8 +667,8 @@ fact destination: [text]
 fact is_expedited: false
 
 rule base_rate: 12.99
-  unless destination == "CA" then 25.00
-  unless destination == "MX" then 22.00
+  unless destination is "CA" then 25.00
+  unless destination is "MX" then 22.00
 
 rule weight_surcharge: 0
   unless weight > 5 kilograms then 7.50
@@ -677,7 +677,7 @@ rule weight_surcharge: 0
 rule expedited_fee: 0
   unless is_expedited then 25.00
 
-rule free_shipping: order_total >= 100 and destination == "US"
+rule free_shipping: order_total >= 100 and destination is "US"
 
 rule final_shipping: base_rate + weight_surcharge + expedited_fee
   unless free_shipping then 0
@@ -706,8 +706,8 @@ rule performance_bonus: base_salary * 0%
   unless performance_rating >= 4.5 then base_salary * 15%
 
 rule department_bonus: 0
-  unless department == "sales" then base_salary * 10%
-  unless department == "engineering" then base_salary * 5%
+  unless department is "sales" then base_salary * 10%
+  unless department is "engineering" then base_salary * 5%
 
 rule total_compensation: base_salary + tenure_bonus
                           + performance_bonus + department_bonus
@@ -991,9 +991,9 @@ fact location: [text]
 fact is_manager: false
 
 rule cost_of_living_adjustment: 0%
-  unless location == "San Francisco" then 25%
-  unless location == "New York" then 20%
-  unless location == "Seattle" then 15%
+  unless location is "San Francisco" then 25%
+  unless location is "New York" then 20%
+  unless location is "Seattle" then 15%
 
 rule adjusted_salary: base_salary * (1 + cost_of_living_adjustment)
 
@@ -1011,7 +1011,7 @@ rule performance_multiplier: 1.0
 
 rule target_bonus_rate: 10%
   unless is_manager then 20%
-  unless department == "sales" then 30%
+  unless department is "sales" then 30%
 
 rule performance_bonus: adjusted_salary * target_bonus_rate * performance_multiplier
 
@@ -1066,7 +1066,7 @@ Rule Definition:
 
 Expressions:
   <arithmetic>        // +, -, *, /, %, ^
-  <comparison>        // >, <, >=, <=, ==, !=, is, is not
+  <comparison>        // >, <, >=, <=, is, is not
   <logical>          // and, not
   <mathematical>     // sqrt, sin, cos, tan, log, exp, abs, floor, ceil, round
   <unit-conversion>  // <value> in <unit>

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.9"
+lemma-engine = "0.8.10"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.9", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.10", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/lsp/src/registry.rs
+++ b/engine/lsp/src/registry.rs
@@ -1,7 +1,7 @@
 //! Registry for the Language Server.
 //!
 //! Uses the engine's LemmaBase on both native and WASM: registry/spec links (`url_for_id`)
-//! and resolution (`get_specs`, `get_types`) work in the browser via fetch.
+//! and resolution (`get`) work in the browser via fetch.
 
 pub use lemma::registry::Registry;
 pub use lemma::LemmaBase;

--- a/engine/lsp/src/semantic_tokens.rs
+++ b/engine/lsp/src/semantic_tokens.rs
@@ -104,8 +104,6 @@ fn token_type_index(kind: &TokenKind) -> Option<u32> {
         | TokenKind::Lt
         | TokenKind::Gte
         | TokenKind::Lte
-        | TokenKind::EqEq
-        | TokenKind::BangEq
         | TokenKind::Arrow
         | TokenKind::Is => Some(7),
 

--- a/engine/lsp/src/spec_links.rs
+++ b/engine/lsp/src/spec_links.rs
@@ -107,16 +107,9 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Registry for TestLinkRegistry {
-        async fn get_specs(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
+        async fn get(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
             Err(RegistryError {
-                message: format!("TestLinkRegistry does not resolve specs: '{}'", name),
-                kind: RegistryErrorKind::Other,
-            })
-        }
-
-        async fn get_types(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
-            Err(RegistryError {
-                message: format!("TestLinkRegistry does not resolve type imports: '{}'", name),
+                message: format!("TestLinkRegistry does not resolve: '{}'", name),
                 kind: RegistryErrorKind::Other,
             })
         }

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.9"
+  @version "0.8.10"
   @source_url "https://github.com/benrogmans/lemma"
 
   def project do

--- a/engine/src/computation/comparison.rs
+++ b/engine/src/computation/comparison.rs
@@ -18,10 +18,10 @@ pub fn comparison_operation(
         }
 
         (ValueKind::Boolean(l), ValueKind::Boolean(r)) => match op {
-            ComparisonComputation::Equal | ComparisonComputation::Is => {
+            ComparisonComputation::Is => {
                 OperationResult::Value(Box::new(LiteralValue::from_bool(l == r)))
             }
-            ComparisonComputation::NotEqual | ComparisonComputation::IsNot => {
+            ComparisonComputation::IsNot => {
                 OperationResult::Value(Box::new(LiteralValue {
                     value: ValueKind::Boolean(l != r),
                     lemma_type: primitive_boolean().clone(),
@@ -34,10 +34,10 @@ pub fn comparison_operation(
         },
 
         (ValueKind::Text(l), ValueKind::Text(r)) => match op {
-            ComparisonComputation::Equal | ComparisonComputation::Is => {
+            ComparisonComputation::Is => {
                 OperationResult::Value(Box::new(LiteralValue::from_bool(l == r)))
             }
-            ComparisonComputation::NotEqual | ComparisonComputation::IsNot => {
+            ComparisonComputation::IsNot => {
                 OperationResult::Value(Box::new(LiteralValue {
                     value: ValueKind::Boolean(l != r),
                     lemma_type: primitive_boolean().clone(),
@@ -117,8 +117,8 @@ fn compare_decimals(left: Decimal, op: &ComparisonComputation, right: &Decimal) 
         ComparisonComputation::LessThan => left < *right,
         ComparisonComputation::GreaterThanOrEqual => left >= *right,
         ComparisonComputation::LessThanOrEqual => left <= *right,
-        ComparisonComputation::Equal | ComparisonComputation::Is => left == *right,
-        ComparisonComputation::NotEqual | ComparisonComputation::IsNot => left != *right,
+        ComparisonComputation::Is => left == *right,
+        ComparisonComputation::IsNot => left != *right,
     }
 }
 

--- a/engine/src/computation/datetime.rs
+++ b/engine/src/computation/datetime.rs
@@ -365,8 +365,8 @@ pub fn datetime_comparison(
                 ComparisonComputation::LessThan => l_utc < r_utc,
                 ComparisonComputation::GreaterThanOrEqual => l_utc >= r_utc,
                 ComparisonComputation::LessThanOrEqual => l_utc <= r_utc,
-                ComparisonComputation::Equal | ComparisonComputation::Is => l_utc == r_utc,
-                ComparisonComputation::NotEqual | ComparisonComputation::IsNot => l_utc != r_utc,
+                ComparisonComputation::Is => l_utc == r_utc,
+                ComparisonComputation::IsNot => l_utc != r_utc,
             };
 
             OperationResult::Value(Box::new(LiteralValue::from_bool(result)))
@@ -403,8 +403,8 @@ pub fn time_comparison(
                 ComparisonComputation::LessThan => l_utc < r_utc,
                 ComparisonComputation::GreaterThanOrEqual => l_utc >= r_utc,
                 ComparisonComputation::LessThanOrEqual => l_utc <= r_utc,
-                ComparisonComputation::Equal | ComparisonComputation::Is => l_utc == r_utc,
-                ComparisonComputation::NotEqual | ComparisonComputation::IsNot => l_utc != r_utc,
+                ComparisonComputation::Is => l_utc == r_utc,
+                ComparisonComputation::IsNot => l_utc != r_utc,
             };
 
             OperationResult::Value(Box::new(LiteralValue::from_bool(result)))

--- a/engine/src/evaluation/expression.rs
+++ b/engine/src/evaluation/expression.rs
@@ -524,8 +524,8 @@ fn evaluate_single_expression(
                 // Use source text if available, otherwise construct from values for explanation display
                 let original_expr = expr_text
                     .clone()
-                    .unwrap_or_else(|| format!("{} {} {}", left_val, op.symbol(), right_val));
-                let substituted_expr = format!("{} {} {}", left_val, op.symbol(), right_val);
+                    .unwrap_or_else(|| format!("{} {} {}", left_val, op, right_val));
+                let substituted_expr = format!("{} {} {}", left_val, op, right_val);
                 context.push_operation(OperationKind::Computation {
                     kind: ComputationKind::Arithmetic(op.clone()),
                     inputs: vec![left_val.clone(), right_val.clone()],
@@ -595,18 +595,18 @@ fn evaluate_single_expression(
                         right.get_source_text(&context.sources),
                     ) {
                         (Some(l), Some(r)) => {
-                            format!("{} {} {}", l, negated_op.symbol(), r)
+                            format!("{} {} {}", l, negated_op, r)
                         }
-                        _ => format!("{} {} {}", left_val, negated_op.symbol(), right_val),
+                        _ => format!("{} {} {}", left_val, negated_op, right_val),
                     };
-                    let sub = format!("{} {} {}", left_val, negated_op.symbol(), right_val);
+                    let sub = format!("{} {} {}", left_val, negated_op, right_val);
                     (negated_op, orig, sub, LiteralValue::from_bool(true))
                 } else {
                     let expr_text = current.get_source_text(&context.sources);
                     let original_expr = expr_text
                         .clone()
-                        .unwrap_or_else(|| format!("{} {} {}", left_val, op.symbol(), right_val));
-                    let substituted_expr = format!("{} {} {}", left_val, op.symbol(), right_val);
+                        .unwrap_or_else(|| format!("{} {} {}", left_val, op, right_val));
+                    let substituted_expr = format!("{} {} {}", left_val, op, right_val);
                     (
                         op.clone(),
                         original_expr,

--- a/engine/src/evaluation/expression.rs
+++ b/engine/src/evaluation/expression.rs
@@ -112,9 +112,6 @@ pub(crate) fn evaluate_rule(
     for branch_index in (1..exec_rule.branches.len()).rev() {
         let branch = &exec_rule.branches[branch_index];
         if let Some(ref condition) = branch.condition {
-            let condition_expr = condition.get_source_text(&context.sources);
-            let result_expr = branch.result.get_source_text(&context.sources);
-
             let condition_result = evaluate_expression(condition, context);
             let condition_explanation =
                 get_explanation_node_required(context, condition, "condition");
@@ -126,8 +123,6 @@ pub(crate) fn evaluate_rule(
                     context.push_operation(OperationKind::RuleBranchEvaluated {
                         index: Some(unless_clause_index),
                         matched: true,
-                        condition_expr,
-                        result_expr,
                         result_value: Some(OperationResult::Veto(msg.clone())),
                     });
 
@@ -187,8 +182,6 @@ pub(crate) fn evaluate_rule(
                 context.push_operation(OperationKind::RuleBranchEvaluated {
                     index: Some(unless_clause_index),
                     matched: true,
-                    condition_expr,
-                    result_expr,
                     result_value: Some(result.clone()),
                 });
 
@@ -221,8 +214,6 @@ pub(crate) fn evaluate_rule(
             context.push_operation(OperationKind::RuleBranchEvaluated {
                 index: Some(unless_clause_index),
                 matched: false,
-                condition_expr,
-                result_expr,
                 result_value: None,
             });
 
@@ -237,14 +228,11 @@ pub(crate) fn evaluate_rule(
 
     // No unless clause matched - evaluate default expression (first branch)
     let default_branch = &exec_rule.branches[0];
-    let default_expr = default_branch.result.get_source_text(&context.sources);
     let default_result = evaluate_expression(&default_branch.result, context);
 
     context.push_operation(OperationKind::RuleBranchEvaluated {
         index: None,
         matched: true,
-        condition_expr: None,
-        result_expr: default_expr,
         result_value: Some(default_result.clone()),
     });
 
@@ -281,14 +269,11 @@ fn evaluate_rule_without_unless(
     context: &mut crate::evaluation::EvaluationContext,
 ) -> (OperationResult, crate::evaluation::explanation::Explanation) {
     let default_branch = &exec_rule.branches[0];
-    let default_expr = default_branch.result.get_source_text(&context.sources);
     let default_result = evaluate_expression(&default_branch.result, context);
 
     context.push_operation(OperationKind::RuleBranchEvaluated {
         index: None,
         matched: true,
-        condition_expr: None,
-        result_expr: default_expr,
         result_value: Some(default_result.clone()),
     });
 
@@ -520,17 +505,12 @@ fn evaluate_single_expression(
             let right_explanation = get_explanation_node_required(context, right, "right operand");
 
             if let OperationResult::Value(ref val) = result {
-                let expr_text = current.get_source_text(&context.sources);
-                // Use source text if available, otherwise construct from values for explanation display
-                let original_expr = expr_text
-                    .clone()
-                    .unwrap_or_else(|| format!("{} {} {}", left_val, op, right_val));
+                let original_expr = format!("{} {} {}", left_val, op, right_val);
                 let substituted_expr = format!("{} {} {}", left_val, op, right_val);
                 context.push_operation(OperationKind::Computation {
                     kind: ComputationKind::Arithmetic(op.clone()),
                     inputs: vec![left_val.clone(), right_val.clone()],
                     result: val.as_ref().clone(),
-                    expr: expr_text,
                 });
                 let explanation_node = ExplanationNode::Computation {
                     kind: ComputationKind::Arithmetic(op.clone()),
@@ -590,22 +570,11 @@ fn evaluate_single_expression(
                 let is_false = matches!(val.as_ref().value, ValueKind::Boolean(false));
                 let (display_op, original_expr, substituted_expr, display_result) = if is_false {
                     let negated_op = negated_comparison(op.clone());
-                    let orig = match (
-                        left.get_source_text(&context.sources),
-                        right.get_source_text(&context.sources),
-                    ) {
-                        (Some(l), Some(r)) => {
-                            format!("{} {} {}", l, negated_op, r)
-                        }
-                        _ => format!("{} {} {}", left_val, negated_op, right_val),
-                    };
+                    let orig = format!("{} {} {}", left_val, negated_op, right_val);
                     let sub = format!("{} {} {}", left_val, negated_op, right_val);
                     (negated_op, orig, sub, LiteralValue::from_bool(true))
                 } else {
-                    let expr_text = current.get_source_text(&context.sources);
-                    let original_expr = expr_text
-                        .clone()
-                        .unwrap_or_else(|| format!("{} {} {}", left_val, op, right_val));
+                    let original_expr = format!("{} {} {}", left_val, op, right_val);
                     let substituted_expr = format!("{} {} {}", left_val, op, right_val);
                     (
                         op.clone(),
@@ -614,12 +583,10 @@ fn evaluate_single_expression(
                         val.as_ref().clone(),
                     )
                 };
-                let expr_text = current.get_source_text(&context.sources);
                 context.push_operation(OperationKind::Computation {
                     kind: ComputationKind::Comparison(op.clone()),
                     inputs: vec![left_val.clone(), right_val.clone()],
                     result: val.as_ref().clone(),
-                    expr: expr_text,
                 });
                 let explanation_node = ExplanationNode::Computation {
                     kind: ComputationKind::Comparison(display_op),
@@ -926,7 +893,6 @@ fn evaluate_mathematical_operator(
                 kind: ComputationKind::Mathematical(op.clone()),
                 inputs: vec![value.clone()],
                 result: result_value.clone(),
-                expr: None,
             });
             OperationResult::Value(Box::new(result_value))
         }

--- a/engine/src/evaluation/mod.rs
+++ b/engine/src/evaluation/mod.rs
@@ -24,7 +24,6 @@ pub(crate) struct EvaluationContext {
     pub(crate) rule_results: HashMap<RulePath, OperationResult>,
     rule_explanations: HashMap<RulePath, crate::evaluation::explanation::Explanation>,
     operations: Option<Vec<crate::OperationRecord>>,
-    pub(crate) sources: HashMap<String, String>,
     explanation_nodes: HashMap<usize, crate::evaluation::explanation::ExplanationNode>,
     now: LiteralValue,
 }
@@ -45,7 +44,6 @@ impl EvaluationContext {
             } else {
                 None
             },
-            sources: plan.sources.clone(),
             explanation_nodes: HashMap::new(),
             now,
         }

--- a/engine/src/evaluation/operations.rs
+++ b/engine/src/evaluation/operations.rs
@@ -63,17 +63,11 @@ pub enum OperationKind {
         kind: ComputationKind,
         inputs: Vec<LiteralValue>,
         result: LiteralValue,
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        expr: Option<String>,
     },
     RuleBranchEvaluated {
         #[serde(skip_serializing_if = "Option::is_none")]
         index: Option<usize>,
         matched: bool,
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        condition_expr: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        result_expr: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         result_value: Option<OperationResult>,
     },

--- a/engine/src/formatting/mod.rs
+++ b/engine/src/formatting/mod.rs
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn test_format_value_number() {
         let v = Value::Number(Decimal::from_str("42.50").unwrap());
-        assert_eq!(fmt_value(&v), "42.5");
+        assert_eq!(fmt_value(&v), "42.50");
     }
 
     #[test]
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn test_format_value_scale() {
         let v = Value::Scale(Decimal::from_str("99.50").unwrap(), "eur".to_string());
-        assert_eq!(fmt_value(&v), "99.5 eur");
+        assert_eq!(fmt_value(&v), "99.50 eur");
     }
 
     #[test]

--- a/engine/src/formatting/mod.rs
+++ b/engine/src/formatting/mod.rs
@@ -49,7 +49,7 @@ pub fn format_source(source: &str, attribute: &str) -> Result<String, Error> {
 // Spec
 // =============================================================================
 
-fn format_spec(spec: &LemmaSpec, max_cols: usize) -> String {
+pub(crate) fn format_spec(spec: &LemmaSpec, max_cols: usize) -> String {
     let mut out = String::new();
     out.push_str("spec ");
     out.push_str(&spec.name);

--- a/engine/src/formatting/mod.rs
+++ b/engine/src/formatting/mod.rs
@@ -1,10 +1,7 @@
 //! Lemma source code formatting.
 //!
-//! Formats parsed specs into canonical Lemma source text.
-//! Value and constraint formatting is delegated to [`AsLemmaSource`] (in `parsing::ast`),
-//! which emits valid, round-trippable Lemma syntax. The regular `Display` impls on AST
-//! types are for human-readable output (error messages, evaluation); they are **not** used
-//! here. This module handles layout: alignment, line wrapping, and section ordering.
+//! Formats parsed specs into canonical Lemma source text. Uses `AsLemmaSource`
+//! and `Expression::Display` for syntax; this module handles layout only.
 
 use crate::parsing::ast::{
     expression_precedence, AsLemmaSource, Expression, ExpressionKind, FactValue, LemmaFact,
@@ -108,10 +105,6 @@ fn format_spec(spec: &LemmaSpec, max_cols: usize) -> String {
 
     out
 }
-
-// =============================================================================
-// Type definitions — delegated to AsLemmaSource<TypeDef>
-// =============================================================================
 
 // =============================================================================
 // Facts
@@ -255,79 +248,6 @@ fn format_rule(rule: &LemmaRule, max_cols: usize) -> String {
 }
 
 // =============================================================================
-// Expressions — produce valid Lemma source with precedence-based parens
-// =============================================================================
-
-/// Format an expression as valid Lemma source (flat, no wrapping).
-///
-/// Uses `AsLemmaSource<Value>` for literals and the AST types' `Display` impls
-/// for operators, rule references, etc. (those `Display` impls already emit
-/// valid Lemma syntax for these simple tokens).
-fn format_expr(expr: &Expression, parent_prec: u8) -> String {
-    let my_prec = expression_precedence(&expr.kind);
-
-    let needs_parens = parent_prec < 10 && my_prec < parent_prec;
-
-    let inner = match &expr.kind {
-        ExpressionKind::Literal(lit) => format!("{}", AsLemmaSource(lit)),
-        ExpressionKind::Reference(r) => format!("{}", r),
-        ExpressionKind::UnresolvedUnitLiteral(..) => {
-            // Expression::Display already normalizes the decimal.
-            format!("{}", expr)
-        }
-        ExpressionKind::Arithmetic(left, op, right) => {
-            let left_str = format_expr(left, my_prec);
-            let right_str = format_expr(right, my_prec);
-            format!("{} {} {}", left_str, op.symbol(), right_str)
-        }
-        ExpressionKind::Comparison(left, op, right) => {
-            let left_str = format_expr(left, my_prec);
-            let right_str = format_expr(right, my_prec);
-            format!("{} {} {}", left_str, op.symbol(), right_str)
-        }
-        ExpressionKind::UnitConversion(value, target) => {
-            let value_str = format_expr(value, my_prec);
-            format!("{} in {}", value_str, target)
-        }
-        ExpressionKind::LogicalNegation(inner_expr, _) => {
-            let inner_str = format_expr(inner_expr, my_prec);
-            format!("not {}", inner_str)
-        }
-        ExpressionKind::LogicalAnd(left, right) => {
-            let left_str = format_expr(left, my_prec);
-            let right_str = format_expr(right, my_prec);
-            format!("{} and {}", left_str, right_str)
-        }
-        ExpressionKind::MathematicalComputation(op, operand) => {
-            let operand_str = format_expr(operand, my_prec);
-            format!("{} {}", op, operand_str)
-        }
-        ExpressionKind::Veto(veto) => match &veto.message {
-            Some(msg) => format!("veto {}", crate::parsing::ast::quote_lemma_text(msg)),
-            None => "veto".to_string(),
-        },
-        ExpressionKind::Now => "now".to_string(),
-        ExpressionKind::DateRelative(kind, date_expr, tolerance) => {
-            let date_str = format_expr(date_expr, my_prec);
-            match tolerance {
-                Some(tol) => format!("{} {} {}", date_str, kind, format_expr(tol, my_prec)),
-                None => format!("{} {}", date_str, kind),
-            }
-        }
-        ExpressionKind::DateCalendar(kind, unit, date_expr) => {
-            let date_str = format_expr(date_expr, my_prec);
-            format!("{} {} {}", date_str, kind, unit)
-        }
-    };
-
-    if needs_parens {
-        format!("({})", inner)
-    } else {
-        inner
-    }
-}
-
-// =============================================================================
 // Expression wrapping (soft line breaking at max_cols)
 // =============================================================================
 
@@ -373,18 +293,17 @@ fn format_expr_wrapped(
         ExpressionKind::Arithmetic(left, op, right) => {
             let left_str = format_expr_wrapped(left.as_ref(), max_cols, indent, my_prec);
             let right_str = format_expr_wrapped(right.as_ref(), max_cols, indent, my_prec);
-            let op_symbol = op.symbol();
-            let single_line = format!("{} {} {}", left_str, op_symbol, right_str);
+            let single_line = format!("{} {} {}", left_str, op, right_str);
             if single_line.len() <= max_cols && !single_line.contains('\n') {
                 return wrap_in_parens(single_line);
             }
             let continued_right = indent_after_first_line(&right_str, indent);
-            let continuation = format!("{}{} {}", indent, op_symbol, continued_right);
+            let continuation = format!("{}{} {}", indent, op, continued_right);
             let multi_line = format!("{}\n{}", left_str, continuation);
             wrap_in_parens(multi_line)
         }
         _ => {
-            let s = format_expr(expr, parent_prec);
+            let s = expr.to_string();
             wrap_in_parens(s)
         }
     }
@@ -716,6 +635,20 @@ rule total: price
             reparsed.is_ok(),
             "formatted output should re-parse, got: {:?}",
             reparsed
+        );
+    }
+
+    #[test]
+    fn test_format_expression_display_stable_round_trip() {
+        let source = r#"spec test
+fact a: 1.00
+rule r: a + 2.00 * 3
+"#;
+        let formatted = format_source(source, "test.lemma").unwrap();
+        let again = format_source(&formatted, "test.lemma").unwrap();
+        assert_eq!(
+            formatted, again,
+            "AST Display-based format must be idempotent under parse/format"
         );
     }
 }

--- a/engine/src/inversion/constraint.rs
+++ b/engine/src/inversion/constraint.rs
@@ -6,7 +6,7 @@
 //! - Makes invalid states unrepresentable
 //!
 //! Includes BDD-based simplification for contradiction detection.
-//! For semantic analysis (e.g., `x == A and x != B`), use domain extraction.
+//! For semantic analysis (e.g., `x is A and x is not B`), use domain extraction.
 
 use crate::planning::semantics::{
     ArithmeticComputation, ComparisonComputation, Expression, ExpressionKind, FactPath,
@@ -34,7 +34,7 @@ pub enum Constraint {
         op: ComparisonComputation,
         value: Arc<LiteralValue>,
     },
-    /// Boolean fact reference (e.g., `is_employee` meaning `is_employee == true`)
+    /// Boolean fact reference (e.g., `is_employee` meaning `is_employee is true`)
     Fact(FactPath),
     /// Logical AND of two constraints
     And(Box<Constraint>, Box<Constraint>),
@@ -270,7 +270,7 @@ impl Constraint {
             }
         }
 
-        // Case 3: literal op literal (e.g., "bronze" == "silver") - evaluate directly
+        // Case 3: literal op literal (e.g., "bronze" is "silver") - evaluate directly
         if let ExpressionKind::Literal(left_val) = &left.kind {
             if let ExpressionKind::Literal(right_val) = &right.kind {
                 if let Some(result) = evaluate_literal_comparison(left_val, op, right_val) {
@@ -283,19 +283,19 @@ impl Constraint {
             }
         }
 
-        // Case 4: comparison == boolean or comparison != boolean
-        // (age > 18) == true  -> age > 18
-        // (age > 18) == false -> not (age > 18)
-        // (age > 18) != true  -> not (age > 18)
-        // (age > 18) != false -> age > 18
+        // Case 4: comparison is boolean or comparison is not boolean
+        // (age > 18) is true  -> age > 18
+        // (age > 18) is false -> not (age > 18)
+        // (age > 18) is not true  -> not (age > 18)
+        // (age > 18) is not false -> age > 18
         if op.is_equal() || op.is_not_equal() {
             if let ExpressionKind::Comparison(inner_left, inner_op, inner_right) = &left.kind {
                 if let ExpressionKind::Literal(lit) = &right.kind {
                     if let ValueKind::Boolean(bool_val) = &lit.value {
                         let inner_constraint =
                             Self::from_comparison(inner_left, inner_op, inner_right)?;
-                        // For ==: true means keep, false means negate
-                        // For !=: true means negate, false means keep
+                        // For is: true means keep, false means negate
+                        // For is not: true means negate, false means keep
                         let should_negate = if op.is_equal() { !*bool_val } else { *bool_val };
                         if should_negate {
                             return Ok(inner_constraint.not());
@@ -555,8 +555,8 @@ fn flip_inequality(op: &ComparisonComputation) -> ComparisonComputation {
         ComparisonComputation::GreaterThanOrEqual => ComparisonComputation::LessThanOrEqual,
         ComparisonComputation::LessThan => ComparisonComputation::GreaterThan,
         ComparisonComputation::LessThanOrEqual => ComparisonComputation::GreaterThanOrEqual,
-        ComparisonComputation::Equal | ComparisonComputation::Is => op.clone(),
-        ComparisonComputation::NotEqual | ComparisonComputation::IsNot => op.clone(),
+        ComparisonComputation::Is => op.clone(),
+        ComparisonComputation::IsNot => op.clone(),
     }
 }
 
@@ -909,8 +909,8 @@ fn evaluate_literal_comparison(
         }
         // Number comparisons
         (ValueKind::Number(l), ValueKind::Number(r)) => match op {
-            ComparisonComputation::Equal | ComparisonComputation::Is => Some(l == r),
-            ComparisonComputation::NotEqual | ComparisonComputation::IsNot => Some(l != r),
+            ComparisonComputation::Is => Some(l == r),
+            ComparisonComputation::IsNot => Some(l != r),
             ComparisonComputation::LessThan => Some(l < r),
             ComparisonComputation::LessThanOrEqual => Some(l <= r),
             ComparisonComputation::GreaterThan => Some(l > r),
@@ -918,8 +918,8 @@ fn evaluate_literal_comparison(
         },
         // Ratio comparisons
         (ValueKind::Ratio(l, _), ValueKind::Ratio(r, _)) => match op {
-            ComparisonComputation::Equal | ComparisonComputation::Is => Some(l == r),
-            ComparisonComputation::NotEqual | ComparisonComputation::IsNot => Some(l != r),
+            ComparisonComputation::Is => Some(l == r),
+            ComparisonComputation::IsNot => Some(l != r),
             ComparisonComputation::LessThan => Some(l < r),
             ComparisonComputation::LessThanOrEqual => Some(l <= r),
             ComparisonComputation::GreaterThan => Some(l > r),
@@ -932,8 +932,6 @@ fn evaluate_literal_comparison(
 /// Flip a comparison operator (for converting `literal op fact` to `fact flipped_op literal`)
 fn flip_comparison_operator(op: &ComparisonComputation) -> ComparisonComputation {
     match op {
-        ComparisonComputation::Equal => ComparisonComputation::Equal,
-        ComparisonComputation::NotEqual => ComparisonComputation::NotEqual,
         ComparisonComputation::Is => ComparisonComputation::Is,
         ComparisonComputation::IsNot => ComparisonComputation::IsNot,
         ComparisonComputation::LessThan => ComparisonComputation::GreaterThan,
@@ -1325,9 +1323,9 @@ mod tests {
 
     #[test]
     fn test_simplify_contradiction() {
-        // x == 1 and x == 2 cannot both be true.
-        let c1 = comparison("x", ComparisonComputation::Equal, 1);
-        let c2 = comparison("x", ComparisonComputation::Equal, 2);
+        // x is 1 and x is 2 cannot both be true.
+        let c1 = comparison("x", ComparisonComputation::Is, 1);
+        let c2 = comparison("x", ComparisonComputation::Is, 2);
 
         let expr = c1.and(c2);
         let simplified = expr.simplify().unwrap();
@@ -1355,9 +1353,9 @@ mod tests {
 
     #[test]
     fn test_simplify_detects_neq_contradiction() {
-        // x == 5 and x != 5 cannot both be true.
-        let eq = comparison("x", ComparisonComputation::Equal, 5);
-        let neq = comparison("x", ComparisonComputation::NotEqual, 5);
+        // x is 5 and x is not 5 cannot both be true.
+        let eq = comparison("x", ComparisonComputation::Is, 5);
+        let neq = comparison("x", ComparisonComputation::IsNot, 5);
         let simplified = eq.and(neq).simplify().unwrap();
         assert!(
             simplified.is_false(),

--- a/engine/src/inversion/domain.rs
+++ b/engine/src/inversion/domain.rs
@@ -293,7 +293,7 @@ fn extract_domain_for_fact(
         }
 
         Constraint::Not(inner) => {
-            // Handle not (fact == value)
+            // Handle not (fact is value)
             if let Constraint::Comparison { fact, op, value } = inner.as_ref() {
                 if fact == fact_path && op.is_equal() {
                     return Ok(Some(normalize_domain(Domain::Complement(Box::new(
@@ -370,7 +370,7 @@ impl Domain {
     /// Proven subset check for the atom-domain forms we generate from comparisons:
     /// - Range
     /// - Enumeration
-    /// - Complement(Enumeration) (used for != / is not)
+    /// - Complement(Enumeration) (used for `is not`)
     ///
     /// Returns false when the relationship cannot be proven with these forms.
     pub(crate) fn is_subset_of(&self, other: &Domain) -> bool {
@@ -1199,7 +1199,7 @@ mod tests {
     fn test_extract_domain_from_equality() {
         let constraint = Constraint::Comparison {
             fact: fact("status"),
-            op: ComparisonComputation::Equal,
+            op: ComparisonComputation::Is,
             value: Arc::new(LiteralValue::text("active".to_string())),
         };
 

--- a/engine/src/inversion/target.rs
+++ b/engine/src/inversion/target.rs
@@ -18,9 +18,9 @@ pub struct Target {
 /// Comparison operators for targets
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum TargetOp {
-    /// Equal to (=)
+    /// Equal to (`is`)
     Eq,
-    /// Not equal to (!=)
+    /// Not equal to (`is not`)
     Neq,
     /// Less than (<)
     Lt,
@@ -74,7 +74,7 @@ impl Target {
     pub fn format(&self) -> String {
         let op_str = match self.op {
             TargetOp::Eq => "=",
-            TargetOp::Neq => "!=",
+            TargetOp::Neq => "is not",
             TargetOp::Lt => "<",
             TargetOp::Lte => "<=",
             TargetOp::Gt => ">",

--- a/engine/src/inversion/world.rs
+++ b/engine/src/inversion/world.rs
@@ -1068,12 +1068,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts: indexmap::IndexMap::new(),
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: indexmap::IndexSet::new(),
+            sources: indexmap::IndexMap::new(),
         }
     }
 

--- a/engine/src/parsing/ast.rs
+++ b/engine/src/parsing/ast.rs
@@ -173,19 +173,6 @@ impl Expression {
             source_location: Some(source_location),
         }
     }
-
-    /// Get the source text for this expression from the given sources map
-    ///
-    /// Returns `None` if the source is not found.
-    pub fn get_source_text(
-        &self,
-        sources: &std::collections::HashMap<String, String>,
-    ) -> Option<String> {
-        let loc = self.source_location.as_ref()?;
-        sources
-            .get(&loc.attribute)
-            .and_then(|source| loc.extract_text(source))
-    }
 }
 
 /// Semantic equality - compares expressions by structure only, ignoring source location
@@ -1553,10 +1540,6 @@ mod tests {
         let veto_without_message = VetoExpression { message: None };
         assert!(veto_without_message.message.is_none());
     }
-
-    // test_expression_get_source_text_with_location (uses Value instead of LiteralValue now)
-    // test_expression_get_source_text_no_location (uses Value instead of LiteralValue now)
-    // test_expression_get_source_text_source_not_found (uses Value instead of LiteralValue now)
 
     // =====================================================================
     // FactValue / TypeDef Display — constraint formatting

--- a/engine/src/parsing/ast.rs
+++ b/engine/src/parsing/ast.rs
@@ -382,8 +382,6 @@ pub enum ComparisonComputation {
     LessThan,
     GreaterThanOrEqual,
     LessThanOrEqual,
-    Equal,
-    NotEqual,
     Is,
     IsNot,
 }
@@ -397,29 +395,21 @@ impl ComparisonComputation {
             ComparisonComputation::LessThan => "<",
             ComparisonComputation::GreaterThanOrEqual => ">=",
             ComparisonComputation::LessThanOrEqual => "<=",
-            ComparisonComputation::Equal => "==",
-            ComparisonComputation::NotEqual => "!=",
             ComparisonComputation::Is => "is",
             ComparisonComputation::IsNot => "is not",
         }
     }
 
-    /// Check if this is an equality comparison (== or is)
+    /// Check if this is an equality comparison (`is`)
     #[must_use]
     pub fn is_equal(&self) -> bool {
-        matches!(
-            self,
-            ComparisonComputation::Equal | ComparisonComputation::Is
-        )
+        matches!(self, ComparisonComputation::Is)
     }
 
-    /// Check if this is an inequality comparison (!= or is not)
+    /// Check if this is an inequality comparison (`is not`)
     #[must_use]
     pub fn is_not_equal(&self) -> bool {
-        matches!(
-            self,
-            ComparisonComputation::NotEqual | ComparisonComputation::IsNot
-        )
+        matches!(self, ComparisonComputation::IsNot)
     }
 }
 
@@ -995,8 +985,6 @@ impl fmt::Display for ComparisonComputation {
             ComparisonComputation::LessThan => write!(f, "<"),
             ComparisonComputation::GreaterThanOrEqual => write!(f, ">="),
             ComparisonComputation::LessThanOrEqual => write!(f, "<="),
-            ComparisonComputation::Equal => write!(f, "=="),
-            ComparisonComputation::NotEqual => write!(f, "!="),
             ComparisonComputation::Is => write!(f, "is"),
             ComparisonComputation::IsNot => write!(f, "is not"),
         }
@@ -1197,16 +1185,15 @@ pub fn quote_lemma_text(s: &str) -> String {
     format!("\"{}\"", escaped)
 }
 
-/// Format a Decimal for Lemma source: normalize, remove trailing zeros,
-/// strip the fractional part when it is zero (e.g. `100.00` → `"100"`),
-/// and insert underscore separators in the integer part when it has 4+
-/// digits (e.g. `30000000.50` → `"30_000_000.50"`).
+/// Format a Decimal for Lemma source, preserving precision (trailing zeros).
+/// Strips the fractional part only when it is zero (e.g. `100` stays `"100"`,
+/// `1.00` stays `"1.00"`). Inserts underscore separators in the integer part
+/// when it has 4+ digits (e.g. `30000000.50` → `"30_000_000.50"`).
 fn format_decimal_source(n: &Decimal) -> String {
-    let norm = n.normalize();
-    let raw = if norm.fract().is_zero() {
-        norm.trunc().to_string()
+    let raw = if n.fract().is_zero() {
+        n.trunc().to_string()
     } else {
-        norm.to_string()
+        n.to_string()
     };
     group_digits(&raw)
 }

--- a/engine/src/parsing/ast.rs
+++ b/engine/src/parsing/ast.rs
@@ -2,17 +2,13 @@
 //!
 //! Infrastructure (Span, DepthTracker) and spec/fact/rule/expression/value types from parsing.
 //!
-//! # `AsLemmaSource<T>` wrapper
+//! # Human `Display` vs canonical `AsLemmaSource`
 //!
-//! For types that need to emit valid, round-trippable Lemma source (e.g. constraint
-//! args like `help`, `default`, `option`), wrap a reference in [`AsLemmaSource`] and
-//! use its `Display` implementation. The regular `Display` impls on AST types are for
-//! human-readable output (error messages, debug); `AsLemmaSource` emits **valid Lemma syntax**.
-//!
-//! ```ignore
-//! use lemma::parsing::ast::{AsLemmaSource, FactValue};
-//! let s = format!("{}", AsLemmaSource(&fact_value));
-//! ```
+//! [`MetaValue`], [`FactValue`], [`TypeDef`], and [`CommandArg`] use human-oriented
+//! `Display` (stable for `to_string()`, logs, APIs). [`Expression`] and
+//! [`LemmaRule`]/[`LemmaSpec`] use canonical Lemma source for literals via
+//! [`AsLemmaSource`] around [`Value`]. Wrap [`MetaValue`]/[`FactValue`]/[`TypeDef`]
+//! in [`AsLemmaSource`] when emitting round-trippable source (e.g. the formatter).
 
 /// Span representing a location in source code
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -359,21 +355,6 @@ pub enum ArithmeticComputation {
     Power,
 }
 
-impl ArithmeticComputation {
-    /// Returns the operator symbol
-    #[must_use]
-    pub fn symbol(&self) -> &'static str {
-        match self {
-            ArithmeticComputation::Add => "+",
-            ArithmeticComputation::Subtract => "-",
-            ArithmeticComputation::Multiply => "*",
-            ArithmeticComputation::Divide => "/",
-            ArithmeticComputation::Modulo => "%",
-            ArithmeticComputation::Power => "^",
-        }
-    }
-}
-
 /// Comparison computations
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -387,19 +368,6 @@ pub enum ComparisonComputation {
 }
 
 impl ComparisonComputation {
-    /// Returns the operator symbol
-    #[must_use]
-    pub fn symbol(&self) -> &'static str {
-        match self {
-            ComparisonComputation::GreaterThan => ">",
-            ComparisonComputation::LessThan => "<",
-            ComparisonComputation::GreaterThanOrEqual => ">=",
-            ComparisonComputation::LessThanOrEqual => "<=",
-            ComparisonComputation::Is => "is",
-            ComparisonComputation::IsNot => "is not",
-        }
-    }
-
     /// Check if this is an equality comparison (`is`)
     #[must_use]
     pub fn is_equal(&self) -> bool {
@@ -899,7 +867,7 @@ fn write_expression_child(
 impl fmt::Display for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            ExpressionKind::Literal(lit) => write!(f, "{}", lit),
+            ExpressionKind::Literal(lit) => write!(f, "{}", AsLemmaSource(lit)),
             ExpressionKind::Reference(r) => write!(f, "{}", r),
             ExpressionKind::Arithmetic(left, op, right) => {
                 let my_prec = expression_precedence(&self.kind);
@@ -1163,19 +1131,10 @@ impl fmt::Display for TypeDef {
 }
 
 // =============================================================================
-// AsLemmaSource — wrapper for valid, round-trippable Lemma source output
+// AsLemmaSource<Value> — canonical literal formatting
 // =============================================================================
 
-/// Wrapper that selects the "emit valid Lemma source" `Display` implementation.
-///
-/// The regular `Display` on AST types is for human-readable output. Wrap a
-/// reference in `AsLemmaSource` when you need syntactically valid Lemma that
-/// can be parsed back (round-trip).
-///
-/// # Example
-/// ```ignore
-/// let s = format!("{}", AsLemmaSource(&fact_value));
-/// ```
+/// Wrap a value to emit canonical Lemma source (round-trippable). See module docs.
 pub struct AsLemmaSource<'a, T: ?Sized>(pub &'a T);
 
 /// Escape a string and wrap it in double quotes for Lemma source output.
@@ -1229,8 +1188,6 @@ fn group_digits(s: &str) -> String {
     format!("{}{}{}", sign, grouped, frac_part)
 }
 
-// -- Display for AsLemmaSource<CommandArg> ------------------------------------
-
 impl<'a> fmt::Display for AsLemmaSource<'a, CommandArg> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
@@ -1246,9 +1203,6 @@ impl<'a> fmt::Display for AsLemmaSource<'a, CommandArg> {
 }
 
 /// Format a single constraint command and its args as valid Lemma source.
-///
-/// Each `CommandArg` already knows its literal kind (from parsing), so formatting
-/// is simply delegated to `AsLemmaSource<CommandArg>` — no lookup table needed.
 fn format_constraint_as_source(cmd: &TypeConstraintCommand, args: &[CommandArg]) -> String {
     if args.is_empty() {
         cmd.to_string()
@@ -1269,36 +1223,6 @@ fn format_constraints_as_source(constraints: &[Constraint], separator: &str) -> 
         .map(|(cmd, args)| format_constraint_as_source(cmd, args))
         .collect::<Vec<_>>()
         .join(separator)
-}
-
-// -- Display for AsLemmaSource<FactValue> ------------------------------------
-
-impl<'a> fmt::Display for AsLemmaSource<'a, FactValue> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            FactValue::Literal(v) => write!(f, "{}", AsLemmaSource(v)),
-            FactValue::SpecReference(spec_ref) => {
-                write!(f, "spec {}", spec_ref)
-            }
-            FactValue::TypeDeclaration {
-                base,
-                constraints,
-                from,
-            } => {
-                let base_str = if let Some(from_spec) = from {
-                    format!("{} from {}", base, from_spec)
-                } else {
-                    format!("{}", base)
-                };
-                if let Some(ref constraints_vec) = constraints {
-                    let constraint_str = format_constraints_as_source(constraints_vec, " -> ");
-                    write!(f, "[{} -> {}]", base_str, constraint_str)
-                } else {
-                    write!(f, "[{}]", base_str)
-                }
-            }
-        }
-    }
 }
 
 // -- Display for AsLemmaSource<Value> ----------------------------------------
@@ -1351,7 +1275,7 @@ impl<'a> fmt::Display for AsLemmaSource<'a, Value> {
     }
 }
 
-// -- Display for AsLemmaSource<MetaValue> ------------------------------------
+// -- AsLemmaSource: MetaValue, FactValue, TypeDef (formatter / round-trip) ---
 
 impl<'a> fmt::Display for AsLemmaSource<'a, MetaValue> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1362,7 +1286,33 @@ impl<'a> fmt::Display for AsLemmaSource<'a, MetaValue> {
     }
 }
 
-// -- Display for AsLemmaSource<TypeDef> --------------------------------------
+impl<'a> fmt::Display for AsLemmaSource<'a, FactValue> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            FactValue::Literal(v) => write!(f, "{}", AsLemmaSource(v)),
+            FactValue::SpecReference(spec_ref) => {
+                write!(f, "spec {}", spec_ref)
+            }
+            FactValue::TypeDeclaration {
+                base,
+                constraints,
+                from,
+            } => {
+                let base_str = if let Some(from_spec) = from {
+                    format!("{} from {}", base, from_spec)
+                } else {
+                    format!("{}", base)
+                };
+                if let Some(ref constraints_vec) = constraints {
+                    let constraint_str = format_constraints_as_source(constraints_vec, " -> ");
+                    write!(f, "[{} -> {}]", base_str, constraint_str)
+                } else {
+                    write!(f, "[{}]", base_str)
+                }
+            }
+        }
+    }
+}
 
 impl<'a> fmt::Display for AsLemmaSource<'a, TypeDef> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1609,7 +1559,7 @@ mod tests {
     // test_expression_get_source_text_source_not_found (uses Value instead of LiteralValue now)
 
     // =====================================================================
-    // AsLemmaSource — constraint formatting tests
+    // FactValue / TypeDef Display — constraint formatting
     // =====================================================================
 
     #[test]

--- a/engine/src/parsing/lexer.rs
+++ b/engine/src/parsing/lexer.rs
@@ -96,8 +96,6 @@ pub enum TokenKind {
     Lt,
     Gte,
     Lte,
-    EqEq,
-    BangEq,
 
     // Punctuation
     Colon,
@@ -203,8 +201,6 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Lt => write!(f, "'<'"),
             TokenKind::Gte => write!(f, "'>='"),
             TokenKind::Lte => write!(f, "'<='"),
-            TokenKind::EqEq => write!(f, "'=='"),
-            TokenKind::BangEq => write!(f, "'!='"),
             TokenKind::Colon => write!(f, "':'"),
             TokenKind::Arrow => write!(f, "'->'"),
             TokenKind::Tilde => write!(f, "'~'"),
@@ -626,8 +622,6 @@ impl Lexer {
             ('-', Some('>')) => TokenKind::Arrow,
             ('>', Some('=')) => TokenKind::Gte,
             ('<', Some('=')) => TokenKind::Lte,
-            ('=', Some('=')) => TokenKind::EqEq,
-            ('!', Some('=')) => TokenKind::BangEq,
             ('%', Some('%')) => {
                 // Check that it's not followed by a digit (invalid permille like 10%%5)
                 TokenKind::PercentPercent
@@ -1107,9 +1101,9 @@ mod tests {
 
     #[test]
     fn lex_all_operators() {
-        let kinds = lex_kinds("+ - * / % ^ > < >= <= == != -> %%").unwrap();
+        let kinds = lex_kinds("+ - * / % ^ > < >= <= -> %%").unwrap();
         assert_eq!(
-            &kinds[..14],
+            &kinds[..12],
             &[
                 TokenKind::Plus,
                 TokenKind::Minus,
@@ -1121,8 +1115,6 @@ mod tests {
                 TokenKind::Lt,
                 TokenKind::Gte,
                 TokenKind::Lte,
-                TokenKind::EqEq,
-                TokenKind::BangEq,
                 TokenKind::Arrow,
                 TokenKind::PercentPercent,
             ]

--- a/engine/src/parsing/mod.rs
+++ b/engine/src/parsing/mod.rs
@@ -608,6 +608,98 @@ fact a: spec @user/workspace/spec_a"#;
     }
 
     #[test]
+    fn parse_type_import_with_effective() {
+        let input = "spec consumer\ntype money from finance 2026-01-15\nfact p: [money]";
+        let result = parse(input, "test.lemma", &ResourceLimits::default())
+            .unwrap()
+            .specs;
+        match &result[0].types[0] {
+            crate::parsing::ast::TypeDef::Import { from, name, .. } => {
+                assert_eq!(name, "money");
+                assert_eq!(from.name, "finance");
+                assert!(from.hash_pin.is_none());
+                let eff = from
+                    .effective
+                    .as_ref()
+                    .expect("expected effective datetime");
+                assert_eq!(eff.year, 2026);
+                assert_eq!(eff.month, 1);
+                assert_eq!(eff.day, 15);
+            }
+            other => panic!("expected Import, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_type_import_with_hash_and_effective() {
+        let input =
+            "spec consumer\ntype money from finance~a1b2c3d4 2026-01-15T00:00:03\nfact p: [money]";
+        let result = parse(input, "test.lemma", &ResourceLimits::default())
+            .unwrap()
+            .specs;
+        match &result[0].types[0] {
+            crate::parsing::ast::TypeDef::Import { from, name, .. } => {
+                assert_eq!(name, "money");
+                assert_eq!(from.name, "finance");
+                assert_eq!(from.hash_pin.as_deref(), Some("a1b2c3d4"));
+                let eff = from
+                    .effective
+                    .as_ref()
+                    .expect("expected effective datetime");
+                assert_eq!(eff.year, 2026);
+                assert_eq!(eff.month, 1);
+                assert_eq!(eff.day, 15);
+                assert_eq!(eff.second, 3);
+            }
+            other => panic!("expected Import, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_type_import_registry_with_effective() {
+        let input = "spec consumer\ntype money from @lemma/std/finance 2026-03-01\nfact p: [money]";
+        let result = parse(input, "test.lemma", &ResourceLimits::default())
+            .unwrap()
+            .specs;
+        match &result[0].types[0] {
+            crate::parsing::ast::TypeDef::Import { from, name, .. } => {
+                assert_eq!(name, "money");
+                assert_eq!(from.name, "@lemma/std/finance");
+                assert!(from.from_registry);
+                let eff = from
+                    .effective
+                    .as_ref()
+                    .expect("expected effective datetime");
+                assert_eq!(eff.year, 2026);
+                assert_eq!(eff.month, 3);
+            }
+            other => panic!("expected Import, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_inline_type_from_with_effective() {
+        let input = "spec consumer\nfact price: [money from finance 2026-06-01 -> minimum 0]";
+        let result = parse(input, "test.lemma", &ResourceLimits::default())
+            .unwrap()
+            .specs;
+        match &result[0].facts[0].value {
+            crate::parsing::ast::FactValue::TypeDeclaration { from, .. } => {
+                let spec_ref = from.as_ref().expect("expected from spec ref");
+                assert_eq!(spec_ref.name, "finance");
+                assert!(spec_ref.hash_pin.is_none());
+                let eff = spec_ref
+                    .effective
+                    .as_ref()
+                    .expect("expected effective datetime");
+                assert_eq!(eff.year, 2026);
+                assert_eq!(eff.month, 6);
+            }
+            other => panic!("expected TypeDeclaration, got: {:?}", other),
+        }
+    }
+
+    #[test]
     fn parse_type_import_spec_name_with_slashes() {
         let input = "spec consumer\ntype money from @lemma/std/finance\nfact p: [money]";
         let result = parse(input, "test.lemma", &ResourceLimits::default());

--- a/engine/src/parsing/mod.rs
+++ b/engine/src/parsing/mod.rs
@@ -62,7 +62,7 @@ rule is_adult: age >= 18
 fact age: 25
 rule can_drink: age >= 21
 fact status: "active"
-rule is_eligible: is_adult and status == "active""#;
+rule is_eligible: is_adult and status is "active""#;
 
         let result = parse(input, "test.lemma", &ResourceLimits::default())
             .unwrap()
@@ -282,7 +282,7 @@ rule is_adult: age >= 21"#;
                 "duration conversion with lt",
             ),
             (
-                "(delay in seconds) == 60",
+                "(delay in seconds) is 60",
                 "duration conversion with equality",
             ),
             (

--- a/engine/src/parsing/parser.rs
+++ b/engine/src/parsing/parser.rs
@@ -725,11 +725,19 @@ impl Parser {
         let from_registry = from_name.starts_with('@');
         let hash_pin = self.try_parse_hash_pin()?;
 
+        let mut effective = None;
+        if self.at(&TokenKind::NumberLit)? {
+            let peeked = self.peek()?;
+            if peeked.text.len() == 4 && peeked.text.chars().all(|c| c.is_ascii_digit()) {
+                effective = self.try_parse_effective_from()?;
+            }
+        }
+
         let from = SpecRef {
             name: from_name,
             from_registry,
             hash_pin,
-            effective: None,
+            effective,
         };
 
         // Check for arrow chain constraints after import
@@ -776,11 +784,18 @@ impl Parser {
             let (from_name, _) = self.parse_spec_name()?;
             let from_registry = from_name.starts_with('@');
             let hash_pin = self.try_parse_hash_pin()?;
+            let mut effective = None;
+            if self.at(&TokenKind::NumberLit)? {
+                let peeked = self.peek()?;
+                if peeked.text.len() == 4 && peeked.text.chars().all(|c| c.is_ascii_digit()) {
+                    effective = self.try_parse_effective_from()?;
+                }
+            }
             Some(SpecRef {
                 name: from_name,
                 from_registry,
                 hash_pin,
-                effective: None,
+                effective,
             })
         } else {
             None

--- a/engine/src/parsing/parser.rs
+++ b/engine/src/parsing/parser.rs
@@ -1397,7 +1397,7 @@ impl Parser {
         // Check for suffixes
         let peeked = self.peek()?;
 
-        // Comparison suffix: >, <, >=, <=, ==, !=, is, is not
+        // Comparison suffix: >, <, >=, <=, is, is not
         if is_comparison_operator(&peeked.kind) {
             return self.parse_comparison_suffix(base, start_span);
         }
@@ -1457,8 +1457,6 @@ impl Parser {
             TokenKind::Lt => Ok(ComparisonComputation::LessThan),
             TokenKind::Gte => Ok(ComparisonComputation::GreaterThanOrEqual),
             TokenKind::Lte => Ok(ComparisonComputation::LessThanOrEqual),
-            TokenKind::EqEq => Ok(ComparisonComputation::Equal),
-            TokenKind::BangEq => Ok(ComparisonComputation::NotEqual),
             TokenKind::Is => {
                 // Check for "is not"
                 if self.at(&TokenKind::Not)? {
@@ -2013,13 +2011,7 @@ fn parse_decimal_string(text: &str, span: &Span, parser: &Parser) -> Result<Deci
 fn is_comparison_operator(kind: &TokenKind) -> bool {
     matches!(
         kind,
-        TokenKind::Gt
-            | TokenKind::Lt
-            | TokenKind::Gte
-            | TokenKind::Lte
-            | TokenKind::EqEq
-            | TokenKind::BangEq
-            | TokenKind::Is
+        TokenKind::Gt | TokenKind::Lt | TokenKind::Gte | TokenKind::Lte | TokenKind::Is
     )
 }
 

--- a/engine/src/planning/execution_plan.rs
+++ b/engine/src/planning/execution_plan.rs
@@ -19,7 +19,7 @@ use crate::planning::types::ResolvedSpecTypes;
 use crate::Error;
 use crate::ResourceLimits;
 use crate::Source;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
@@ -44,6 +44,9 @@ impl std::fmt::Display for SpecId {
     }
 }
 
+/// Spec sources keyed by (name, effective_from).
+pub type SpecSources = IndexMap<(String, Option<DateTimeValue>), String>;
+
 /// A complete execution plan ready for the evaluator
 ///
 /// Contains the topologically sorted list of rules to execute, along with all facts.
@@ -61,9 +64,6 @@ pub struct ExecutionPlan {
     /// Rules to execute in topological order (sorted by dependencies)
     pub rules: Vec<ExecutableRule>,
 
-    /// Source code for error messages
-    pub sources: HashMap<String, String>,
-
     /// Spec metadata
     pub meta: HashMap<String, MetaValue>,
 
@@ -77,19 +77,67 @@ pub struct ExecutionPlan {
     /// Temporal slice end (exclusive). None = +∞.
     pub valid_to: Option<DateTimeValue>,
 
-    /// Spec dependencies actually used by rules, identified by name + computed plan hash.
-    pub dependencies: IndexSet<SpecId>,
+    /// Canonical source for all specs in this plan, keyed by (name, effective_from).
+    /// Reconstructed from AST — not raw file content.
+    #[serde(default)]
+    #[serde(
+        serialize_with = "serialize_sources",
+        deserialize_with = "deserialize_sources"
+    )]
+    pub sources: SpecSources,
 }
 
 impl ExecutionPlan {
     /// Deterministic 8-char hex plan hash: SHA-256 of `LMFP` + format version + postcard(semantic fingerprint)
-    /// (excluding sources and meta). See [`crate::planning::fingerprint::FINGERPRINT_FORMAT_VERSION`].
+    /// (excluding meta). See [`crate::planning::fingerprint::FINGERPRINT_FORMAT_VERSION`].
     #[must_use]
     pub fn plan_hash(&self) -> String {
         crate::planning::fingerprint::fingerprint_hash(&crate::planning::fingerprint::from_plan(
             self,
         ))
     }
+}
+
+fn serialize_sources<S>(sources: &SpecSources, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeSeq;
+    let mut seq = serializer.serialize_seq(Some(sources.len()))?;
+    for ((name, effective_from), source) in sources {
+        seq.serialize_element(&SpecSourceEntry {
+            name,
+            effective_from,
+            source,
+        })?;
+    }
+    seq.end()
+}
+
+fn deserialize_sources<'de, D>(deserializer: D) -> Result<SpecSources, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let entries: Vec<SpecSourceEntryOwned> = Vec::deserialize(deserializer)?;
+    let mut map = IndexMap::with_capacity(entries.len());
+    for e in entries {
+        map.insert((e.name, e.effective_from), e.source);
+    }
+    Ok(map)
+}
+
+#[derive(Serialize)]
+struct SpecSourceEntry<'a> {
+    name: &'a str,
+    effective_from: &'a Option<DateTimeValue>,
+    source: &'a str,
+}
+
+#[derive(Deserialize)]
+struct SpecSourceEntryOwned {
+    name: String,
+    effective_from: Option<DateTimeValue>,
+    source: String,
 }
 
 /// An executable rule with flattened branches
@@ -146,7 +194,6 @@ pub(crate) fn build_execution_plan(
 
     let mut executable_rules: Vec<ExecutableRule> = Vec::new();
     let mut path_to_index: HashMap<RulePath, usize> = HashMap::new();
-    let mut dependencies: IndexSet<SpecId> = IndexSet::new();
 
     for rule_path in execution_order {
         let rule_node = graph.rules().get(rule_path).expect(
@@ -177,21 +224,6 @@ pub(crate) fn build_execution_plan(
             });
         }
 
-        let is_dependency_rule = !rule_path.segments.is_empty();
-        if is_dependency_rule {
-            let spec_ref_path = FactPath {
-                segments: vec![],
-                fact: rule_path.segments[0].fact.clone(),
-            };
-            if let Some(fact_data) = facts.get(&spec_ref_path) {
-                if let (Some(name), Some(hash)) =
-                    (fact_data.spec_ref(), fact_data.resolved_plan_hash())
-                {
-                    dependencies.insert(SpecId::new(name.to_string(), hash.to_string()));
-                }
-            }
-        }
-
         path_to_index.insert(rule_path.clone(), executable_rules.len());
         executable_rules.push(ExecutableRule {
             path: rule_path.clone(),
@@ -206,11 +238,18 @@ pub(crate) fn build_execution_plan(
     let main_spec = graph.main_spec();
     let named_types = build_type_tables(main_spec, resolved_types);
 
+    let mut sources: SpecSources = IndexMap::new();
+    for spec in resolved_types.keys() {
+        let key = (spec.name.clone(), spec.effective_from.clone());
+        sources
+            .entry(key)
+            .or_insert_with(|| crate::formatting::format_spec(spec, crate::formatting::MAX_COLS));
+    }
+
     ExecutionPlan {
         spec_name: main_spec.name.clone(),
         facts,
         rules: executable_rules,
-        sources: graph.sources().clone(),
         meta: main_spec
             .meta_fields
             .iter()
@@ -219,7 +258,7 @@ pub(crate) fn build_execution_plan(
         named_types,
         valid_from,
         valid_to,
-        dependencies,
+        sources,
     }
 }
 
@@ -950,12 +989,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::from([("<test>".to_string(), "".to_string())]),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let mut values = HashMap::new();
@@ -1008,12 +1046,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::from([("<test>".to_string(), "".to_string())]),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let mut values = HashMap::new();
@@ -1074,12 +1111,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::from([("<test>".to_string(), "".to_string())]),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let mut values = HashMap::new();
@@ -1110,16 +1146,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: {
-                let mut s = HashMap::new();
-                s.insert("test.lemma".to_string(), "fact age: number".to_string());
-                s
-            },
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let json = serde_json::to_string(&plan).expect("Should serialize");
@@ -1128,7 +1159,6 @@ mod tests {
         assert_eq!(deserialized.spec_name, plan.spec_name);
         assert_eq!(deserialized.facts.len(), plan.facts.len());
         assert_eq!(deserialized.rules.len(), plan.rules.len());
-        assert_eq!(deserialized.sources.len(), plan.sources.len());
     }
 
     #[test]
@@ -1154,12 +1184,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts: IndexMap::new(),
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types,
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let json = serde_json::to_string(&plan).expect("Should serialize");
@@ -1206,12 +1235,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let rule = ExecutableRule {
@@ -1271,12 +1299,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let json = serde_json::to_string(&plan).expect("Should serialize");
@@ -1325,12 +1352,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let json = serde_json::to_string(&plan).expect("Should serialize");
@@ -1370,12 +1396,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let rule = ExecutableRule {
@@ -1435,12 +1460,11 @@ mod tests {
             spec_name: "empty".to_string(),
             facts: IndexMap::new(),
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let json = serde_json::to_string(&plan).expect("Should serialize");
@@ -1449,7 +1473,6 @@ mod tests {
         assert_eq!(deserialized.spec_name, "empty");
         assert_eq!(deserialized.facts.len(), 0);
         assert_eq!(deserialized.rules.len(), 0);
-        assert_eq!(deserialized.sources.len(), 0);
     }
 
     #[test]
@@ -1470,12 +1493,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let rule = ExecutableRule {
@@ -1538,16 +1560,11 @@ mod tests {
             spec_name: "test".to_string(),
             facts,
             rules: Vec::new(),
-            sources: {
-                let mut s = HashMap::new();
-                s.insert("test.lemma".to_string(), "fact age: number".to_string());
-                s
-            },
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         };
 
         let rule = ExecutableRule {
@@ -1582,7 +1599,6 @@ mod tests {
         assert_eq!(deserialized2.spec_name, plan.spec_name);
         assert_eq!(deserialized2.facts.len(), plan.facts.len());
         assert_eq!(deserialized2.rules.len(), plan.rules.len());
-        assert_eq!(deserialized2.sources.len(), plan.sources.len());
         assert_eq!(deserialized2.rules[0].name, plan.rules[0].name);
         assert_eq!(
             deserialized2.rules[0].branches.len(),

--- a/engine/src/planning/fingerprint.rs
+++ b/engine/src/planning/fingerprint.rs
@@ -2,7 +2,7 @@
 //!
 //! Projects ExecutionPlan onto a representation that contains only what the plan actually does.
 //! Uses dedicated fingerprint types (no LemmaType, LiteralValue, Arc<LemmaSpec>) so the hash
-//! does not depend on external types or other specs. Excludes sources, meta, source locations.
+//! does not depend on external types or other specs. Excludes meta and source locations.
 //! Schema is explicit and stable: adding Rust fields does not change hashes for unused content.
 //!
 //! **Format versioning:** `fingerprint_hash` hashes `LMFP` + big-endian `FINGERPRINT_FORMAT_VERSION`
@@ -360,7 +360,7 @@ fn literal_value_fingerprint(lv: &LiteralValue) -> LiteralValueFingerprint {
     }
 }
 
-/// Project ExecutionPlan to semantic fingerprint, excluding sources and meta.
+/// Project ExecutionPlan to semantic fingerprint, excluding meta and sources.
 pub fn from_plan(plan: &ExecutionPlan) -> PlanFingerprint {
     let facts: BTreeMap<FactPath, FactFingerprint> = plan
         .facts
@@ -508,7 +508,7 @@ mod tests {
     use crate::parsing::ast::Span;
     use crate::parsing::source::Source;
     use crate::planning::semantics::primitive_number;
-    use indexmap::{IndexMap, IndexSet};
+    use indexmap::IndexMap;
     use std::collections::{BTreeSet, HashMap};
 
     fn empty_plan(spec_name: &str) -> ExecutionPlan {
@@ -516,12 +516,11 @@ mod tests {
             spec_name: spec_name.to_string(),
             facts: IndexMap::new(),
             rules: vec![],
-            sources: HashMap::new(),
             meta: HashMap::new(),
             named_types: BTreeMap::new(),
             valid_from: None,
             valid_to: None,
-            dependencies: IndexSet::new(),
+            sources: IndexMap::new(),
         }
     }
 

--- a/engine/src/planning/fingerprint.rs
+++ b/engine/src/planning/fingerprint.rs
@@ -9,14 +9,17 @@
 //! (u32) + postcard(`PlanFingerprint`). Bump the version when the encoded semantics change in a
 //! way that must not share hashes with prior formats.
 
-use crate::parsing::ast::{CalendarUnit, DateCalendarKind, DateRelativeKind, DateTimeValue};
+use crate::parsing::ast::{
+    CalendarUnit, DateCalendarKind, DateRelativeKind, DateTimeValue, DurationUnit, TimeValue,
+};
 use crate::planning::execution_plan::{Branch, ExecutableRule, ExecutionPlan, SpecId};
 use crate::planning::semantics::{
     ArithmeticComputation, ComparisonComputation, Expression, ExpressionKind, FactData, FactPath,
-    LemmaType, LiteralValue, MathematicalComputation, NegationType, RulePath,
-    SemanticConversionTarget, TypeDefiningSpec, TypeExtends, TypeSpecification, ValueKind,
-    VetoExpression,
+    LemmaType, LiteralValue, MathematicalComputation, NegationType, RatioUnit, RatioUnits,
+    RulePath, ScaleUnit, ScaleUnits, SemanticConversionTarget, TypeDefiningSpec, TypeExtends,
+    TypeSpecification, ValueKind, VetoExpression,
 };
+use rust_decimal::Decimal;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -48,10 +51,72 @@ pub enum TypeExtendsFingerprint {
     },
 }
 
+/// Mirrors [`TypeSpecification`] with order-independent vecs (sorted) for fingerprinting.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TypeSpecificationFingerprint {
+    Boolean {
+        help: String,
+        default: Option<bool>,
+    },
+    Scale {
+        minimum: Option<Decimal>,
+        maximum: Option<Decimal>,
+        decimals: Option<u8>,
+        precision: Option<Decimal>,
+        units: ScaleUnits,
+        help: String,
+        default: Option<(Decimal, String)>,
+    },
+    Number {
+        minimum: Option<Decimal>,
+        maximum: Option<Decimal>,
+        decimals: Option<u8>,
+        precision: Option<Decimal>,
+        help: String,
+        default: Option<Decimal>,
+    },
+    Ratio {
+        minimum: Option<Decimal>,
+        maximum: Option<Decimal>,
+        decimals: Option<u8>,
+        units: RatioUnits,
+        help: String,
+        default: Option<Decimal>,
+    },
+    Text {
+        minimum: Option<usize>,
+        maximum: Option<usize>,
+        length: Option<usize>,
+        options: Vec<String>,
+        help: String,
+        default: Option<String>,
+    },
+    Date {
+        minimum: Option<DateTimeValue>,
+        maximum: Option<DateTimeValue>,
+        help: String,
+        default: Option<DateTimeValue>,
+    },
+    Time {
+        minimum: Option<TimeValue>,
+        maximum: Option<TimeValue>,
+        help: String,
+        default: Option<TimeValue>,
+    },
+    Duration {
+        help: String,
+        default: Option<(Decimal, DurationUnit)>,
+    },
+    Veto {
+        message: Option<String>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct LemmaTypeFingerprint {
     pub name: Option<String>,
-    pub specifications: TypeSpecification,
+    pub specifications: TypeSpecificationFingerprint,
     pub extends: TypeExtendsFingerprint,
 }
 
@@ -66,8 +131,8 @@ pub struct LiteralValueFingerprint {
 pub struct PlanFingerprint {
     pub spec_name: String,
     pub valid_from: Option<DateTimeValue>,
-    pub facts: Vec<(FactPath, FactFingerprint)>,
-    pub rules: Vec<RuleFingerprint>,
+    pub facts: BTreeMap<FactPath, FactFingerprint>,
+    pub rules: BTreeMap<RulePath, RuleFingerprint>,
     pub named_types: BTreeMap<String, LemmaTypeFingerprint>,
 }
 
@@ -91,7 +156,6 @@ pub enum FactFingerprint {
 #[derive(Debug, Clone, Serialize)]
 pub struct RuleFingerprint {
     pub path: RulePath,
-    pub name: String,
     pub branches: Vec<BranchFingerprint>,
     pub needs_facts: Vec<FactPath>,
     pub rule_type: LemmaTypeFingerprint,
@@ -138,6 +202,121 @@ pub enum ExpressionKindFingerprint {
     DateCalendar(DateCalendarKind, CalendarUnit, Box<ExpressionFingerprint>),
 }
 
+fn type_spec_fingerprint(ts: &TypeSpecification) -> TypeSpecificationFingerprint {
+    match ts {
+        TypeSpecification::Boolean { help, default } => TypeSpecificationFingerprint::Boolean {
+            help: help.clone(),
+            default: *default,
+        },
+        TypeSpecification::Scale {
+            minimum,
+            maximum,
+            decimals,
+            precision,
+            units,
+            help,
+            default,
+        } => {
+            let mut sorted: Vec<ScaleUnit> = units.iter().cloned().collect();
+            sorted.sort_by(|a, b| a.name.cmp(&b.name));
+            TypeSpecificationFingerprint::Scale {
+                minimum: *minimum,
+                maximum: *maximum,
+                decimals: *decimals,
+                precision: *precision,
+                units: ScaleUnits::from(sorted),
+                help: help.clone(),
+                default: default.clone(),
+            }
+        }
+        TypeSpecification::Number {
+            minimum,
+            maximum,
+            decimals,
+            precision,
+            help,
+            default,
+        } => TypeSpecificationFingerprint::Number {
+            minimum: *minimum,
+            maximum: *maximum,
+            decimals: *decimals,
+            precision: *precision,
+            help: help.clone(),
+            default: *default,
+        },
+        TypeSpecification::Ratio {
+            minimum,
+            maximum,
+            decimals,
+            units,
+            help,
+            default,
+        } => {
+            let mut sorted: Vec<RatioUnit> = units.iter().cloned().collect();
+            sorted.sort_by(|a, b| a.name.cmp(&b.name));
+            TypeSpecificationFingerprint::Ratio {
+                minimum: *minimum,
+                maximum: *maximum,
+                decimals: *decimals,
+                units: RatioUnits::from(sorted),
+                help: help.clone(),
+                default: *default,
+            }
+        }
+        TypeSpecification::Text {
+            minimum,
+            maximum,
+            length,
+            options,
+            help,
+            default,
+        } => {
+            let mut sorted_opts = options.clone();
+            sorted_opts.sort();
+            TypeSpecificationFingerprint::Text {
+                minimum: *minimum,
+                maximum: *maximum,
+                length: *length,
+                options: sorted_opts,
+                help: help.clone(),
+                default: default.clone(),
+            }
+        }
+        TypeSpecification::Date {
+            minimum,
+            maximum,
+            help,
+            default,
+        } => TypeSpecificationFingerprint::Date {
+            minimum: minimum.clone(),
+            maximum: maximum.clone(),
+            help: help.clone(),
+            default: default.clone(),
+        },
+        TypeSpecification::Time {
+            minimum,
+            maximum,
+            help,
+            default,
+        } => TypeSpecificationFingerprint::Time {
+            minimum: minimum.clone(),
+            maximum: maximum.clone(),
+            help: help.clone(),
+            default: default.clone(),
+        },
+        TypeSpecification::Duration { help, default } => TypeSpecificationFingerprint::Duration {
+            help: help.clone(),
+            default: default.clone(),
+        },
+        TypeSpecification::Veto { message } => TypeSpecificationFingerprint::Veto {
+            message: message.clone(),
+        },
+        TypeSpecification::Undetermined => {
+            unreachable!("fingerprint: Undetermined must not appear in a validated execution plan")
+        }
+    }
+}
+
 fn type_defining_spec_fingerprint(ds: &TypeDefiningSpec) -> TypeDefiningSpecFingerprint {
     match ds {
         TypeDefiningSpec::Local => TypeDefiningSpecFingerprint::Local,
@@ -169,7 +348,7 @@ fn type_extends_fingerprint(e: &TypeExtends) -> TypeExtendsFingerprint {
 fn lemma_type_fingerprint(lt: &LemmaType) -> LemmaTypeFingerprint {
     LemmaTypeFingerprint {
         name: lt.name.clone(),
-        specifications: lt.specifications.clone(),
+        specifications: type_spec_fingerprint(&lt.specifications),
         extends: type_extends_fingerprint(&lt.extends),
     }
 }
@@ -183,13 +362,17 @@ fn literal_value_fingerprint(lv: &LiteralValue) -> LiteralValueFingerprint {
 
 /// Project ExecutionPlan to semantic fingerprint, excluding sources and meta.
 pub fn from_plan(plan: &ExecutionPlan) -> PlanFingerprint {
-    let facts: Vec<(FactPath, FactFingerprint)> = plan
+    let facts: BTreeMap<FactPath, FactFingerprint> = plan
         .facts
         .iter()
         .map(|(path, data)| (path.clone(), fact_fingerprint(data)))
         .collect();
 
-    let rules: Vec<RuleFingerprint> = plan.rules.iter().map(rule_fingerprint).collect();
+    let rules: BTreeMap<RulePath, RuleFingerprint> = plan
+        .rules
+        .iter()
+        .map(|rule| (rule.path.clone(), rule_fingerprint(rule)))
+        .collect();
 
     let named_types: BTreeMap<String, LemmaTypeFingerprint> = plan
         .named_types
@@ -231,7 +414,6 @@ fn fact_fingerprint(data: &FactData) -> FactFingerprint {
 fn rule_fingerprint(rule: &ExecutableRule) -> RuleFingerprint {
     RuleFingerprint {
         path: rule.path.clone(),
-        name: rule.name.clone(),
         branches: rule.branches.iter().map(branch_fingerprint).collect(),
         needs_facts: rule.needs_facts.iter().cloned().collect(),
         rule_type: lemma_type_fingerprint(&rule.rule_type),
@@ -323,8 +505,11 @@ pub fn fingerprint_hash(fp: &PlanFingerprint) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsing::ast::Span;
+    use crate::parsing::source::Source;
+    use crate::planning::semantics::primitive_number;
     use indexmap::{IndexMap, IndexSet};
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
 
     fn empty_plan(spec_name: &str) -> ExecutionPlan {
         ExecutionPlan {
@@ -337,6 +522,40 @@ mod tests {
             valid_from: None,
             valid_to: None,
             dependencies: IndexSet::new(),
+        }
+    }
+
+    fn dummy_source() -> Source {
+        Source::new(
+            "test.lemma",
+            Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                col: 0,
+            },
+        )
+    }
+
+    fn literal_expr_one() -> Expression {
+        Expression::with_source(
+            ExpressionKind::Literal(Box::new(LiteralValue::number(Decimal::ONE))),
+            None,
+        )
+    }
+
+    fn simple_rule(path: RulePath, name: &str) -> ExecutableRule {
+        ExecutableRule {
+            path,
+            name: name.to_string(),
+            branches: vec![Branch {
+                condition: None,
+                result: literal_expr_one(),
+                source: dummy_source(),
+            }],
+            needs_facts: BTreeSet::new(),
+            source: dummy_source(),
+            rule_type: primitive_number().clone(),
         }
     }
 
@@ -383,5 +602,56 @@ mod tests {
             timezone: None,
         });
         assert_eq!(fingerprint_hash(&from_plan(&p)), "b301d0c3");
+    }
+
+    #[test]
+    fn fingerprint_independent_of_fact_rule_and_type_order() {
+        let fa = FactPath::local("a".to_string());
+        let fb = FactPath::local("b".to_string());
+        let fact_a = FactData::Value {
+            value: LiteralValue::number(Decimal::ONE),
+            source: dummy_source(),
+            is_default: false,
+        };
+        let fact_b = FactData::Value {
+            value: LiteralValue::number(Decimal::from(2)),
+            source: dummy_source(),
+            is_default: false,
+        };
+
+        let type_x = LemmaType::new(
+            "age".to_string(),
+            TypeSpecification::number(),
+            TypeExtends::Primitive,
+        );
+        let type_y = LemmaType::new(
+            "weight".to_string(),
+            TypeSpecification::number(),
+            TypeExtends::Primitive,
+        );
+
+        let mut plan1 = empty_plan("order_test");
+        plan1.facts.insert(fa.clone(), fact_a.clone());
+        plan1.facts.insert(fb.clone(), fact_b.clone());
+        plan1.named_types.insert("age".to_string(), type_x.clone());
+        plan1
+            .named_types
+            .insert("weight".to_string(), type_y.clone());
+
+        let mut plan2 = empty_plan("order_test");
+        plan2.facts.insert(fb, fact_b);
+        plan2.facts.insert(fa, fact_a);
+        plan2.named_types.insert("weight".to_string(), type_y);
+        plan2.named_types.insert("age".to_string(), type_x);
+
+        let r1 = RulePath::new(vec![], "r1".to_string());
+        let r2 = RulePath::new(vec![], "r2".to_string());
+        plan1.rules = vec![simple_rule(r1.clone(), "r1"), simple_rule(r2.clone(), "r2")];
+        plan2.rules = vec![simple_rule(r2, "r2"), simple_rule(r1, "r1")];
+
+        assert_eq!(
+            fingerprint_hash(&from_plan(&plan1)),
+            fingerprint_hash(&from_plan(&plan2))
+        );
     }
 }

--- a/engine/src/planning/fingerprint.rs
+++ b/engine/src/planning/fingerprint.rs
@@ -222,10 +222,7 @@ fn fact_fingerprint(data: &FactData) -> FactFingerprint {
             resolved_plan_hash,
             ..
         } => FactFingerprint::SpecRef {
-            spec_id: resolved_plan_hash
-                .as_ref()
-                .map(|h| SpecId::new(spec.name.clone(), h.clone()).to_string())
-                .unwrap_or_else(|| spec.name.clone()),
+            spec_id: SpecId::new(spec.name.clone(), resolved_plan_hash.clone()).to_string(),
             effective_from: spec.effective_from.clone(),
         },
     }

--- a/engine/src/planning/graph.rs
+++ b/engine/src/planning/graph.rs
@@ -37,7 +37,6 @@ pub(crate) struct Graph {
     main_spec: Arc<LemmaSpec>,
     facts: IndexMap<FactPath, FactData>,
     rules: BTreeMap<RulePath, RuleNode>,
-    sources: HashMap<String, String>,
     execution_order: Vec<RulePath>,
 }
 
@@ -52,10 +51,6 @@ impl Graph {
 
     pub(crate) fn rules_mut(&mut self) -> &mut BTreeMap<RulePath, RuleNode> {
         &mut self.rules
-    }
-
-    pub(crate) fn sources(&self) -> &HashMap<String, String> {
-        &self.sources
     }
 
     pub(crate) fn execution_order(&self) -> &[RulePath] {
@@ -326,12 +321,12 @@ impl Graph {
 
         let mut type_errors: Vec<Error> = Vec::new();
         type_errors.extend(type_resolver.register_all(main_spec));
-        type_errors.extend(type_resolver.register_dependency_types(main_spec));
+        type_errors.extend(type_resolver.register_dependency_specs(main_spec));
 
         let (resolved_types, resolve_errors) = type_resolver.resolve_all_registered_specs();
         type_errors.extend(resolve_errors);
 
-        let (facts, rules, builder_sources, graph_errors, local_types) = {
+        let (facts, rules, graph_errors, local_types) = {
             let mut builder = GraphBuilder {
                 facts: IndexMap::new(),
                 rules: BTreeMap::new(),
@@ -349,7 +344,6 @@ impl Graph {
             (
                 builder.facts,
                 builder.rules,
-                builder.sources,
                 builder.errors,
                 builder.local_types,
             )
@@ -358,7 +352,6 @@ impl Graph {
         let mut graph = Graph {
             facts,
             rules,
-            sources: builder_sources,
             execution_order: Vec::new(),
             main_spec: Arc::clone(main_spec),
         };

--- a/engine/src/planning/graph.rs
+++ b/engine/src/planning/graph.rs
@@ -117,7 +117,7 @@ impl Graph {
                     FactData::SpecRef {
                         resolved_plan_hash, ..
                     } => resolved_plan_hash.clone(),
-                    _ => None,
+                    _ => unreachable!("spec_arcs only populated from SpecRef variants"),
                 };
                 facts.insert(
                     path.clone(),
@@ -514,6 +514,10 @@ impl<'a> GraphBuilder<'a> {
     ) -> Option<Arc<LemmaSpec>> {
         if let Some(pin) = &spec_ref.hash_pin {
             if let Some(arc) = self.plan_hashes.get_by_pin(&spec_ref.name, pin) {
+                if let Some(err) = super::validate_effective_for_pin(spec_ref, arc, self.context) {
+                    self.errors.push(err);
+                    return None;
+                }
                 return Some(Arc::clone(arc));
             }
             self.errors.push(self.engine_error(
@@ -617,14 +621,18 @@ impl<'a> GraphBuilder<'a> {
                 .map(String::from)
                 .unwrap_or_else(|| parent_name.to_string());
             let defining_spec = if from.is_some() {
-                let hash = self
-                    .lookup_dependency_hash(source_spec_arc)
-                    .unwrap_or_else(|| {
-                        unreachable!(
-                            "BUG: resolved type-import dependency must have plan hash; \
-                         topological planning guarantees deps are planned first"
-                        )
-                    });
+                let hash = match self.lookup_dependency_hash(source_spec_arc) {
+                    Some(h) => h,
+                    None => {
+                        return Err(vec![self.engine_error(
+                            format!(
+                                "Cannot import types from spec '{}': no plan hash (that spec may have failed validation)",
+                                source_spec_arc.name
+                            ),
+                            decl_source,
+                        )]);
+                    }
+                };
                 TypeDefiningSpec::Import {
                     spec: Arc::clone(source_spec_arc),
                     resolved_plan_hash: hash,
@@ -1040,19 +1048,29 @@ impl<'a> GraphBuilder<'a> {
                         }
                     };
 
-                let resolved_hash = self.lookup_dependency_hash(&effective_spec_arc);
+                let resolved_hash = match self.lookup_dependency_hash(&effective_spec_arc) {
+                    Some(h) => h,
+                    None => {
+                        self.errors.push(self.engine_error(
+                            format!(
+                                "Cannot bind spec reference '{}': no plan hash for that spec (it may have failed validation)",
+                                effective_spec_arc.name
+                            ),
+                            &effective_source,
+                        ));
+                        return;
+                    }
+                };
                 if let Some(pin) = &spec_ref.hash_pin {
-                    if let Some(ref actual) = resolved_hash {
-                        if !pin.trim().eq_ignore_ascii_case(actual.trim()) {
-                            self.errors.push(self.engine_error(
-                                format!(
-                                    "Spec '{}' plan hash mismatch: expected {}, got {}",
-                                    spec_ref.name, pin, actual
-                                ),
-                                &effective_source,
-                            ));
-                            return;
-                        }
+                    if !pin.trim().eq_ignore_ascii_case(resolved_hash.trim()) {
+                        self.errors.push(self.engine_error(
+                            format!(
+                                "Spec '{}' plan hash mismatch: expected {}, got {}",
+                                spec_ref.name, pin, resolved_hash
+                            ),
+                            &effective_source,
+                        ));
+                        return;
                     }
                 }
 
@@ -3201,7 +3219,8 @@ mod tests {
         sources
     }
 
-    /// Test helper: build graph in one call. Types are resolved per-slice inside Graph::build.
+    /// Test helper: build graph in one call. Plans dependency specs first so the
+    /// PlanHashRegistry is populated (mirrors the topological guarantee of plan()).
     fn build_graph(
         main_spec: &LemmaSpec,
         all_specs: &[LemmaSpec],
@@ -3216,7 +3235,35 @@ mod tests {
             .get_spec_effective_from(main_spec.name.as_str(), main_spec.effective_from())
             .expect("main_spec must be in all_specs");
 
-        let plan_hashes = crate::planning::PlanHashRegistry::default();
+        let mut plan_hashes = crate::planning::PlanHashRegistry::default();
+        for spec in all_specs {
+            if spec.name == main_spec.name {
+                continue;
+            }
+            let dep_arc = ctx
+                .get_spec_effective_from(&spec.name, spec.effective_from())
+                .expect("dep spec must be in context");
+            if let Ok((dep_graph, dep_types)) = Graph::build(
+                &dep_arc,
+                &ctx,
+                sources.clone(),
+                dep_arc.effective_from().cloned(),
+                &plan_hashes,
+            ) {
+                let dep_plan = crate::planning::execution_plan::build_execution_plan(
+                    &dep_graph,
+                    &dep_types,
+                    dep_arc.effective_from().cloned(),
+                    None,
+                );
+                plan_hashes.insert(
+                    &dep_arc,
+                    dep_arc.effective_from().cloned(),
+                    dep_plan.plan_hash(),
+                );
+            }
+        }
+
         match Graph::build(
             &main_spec_arc,
             &ctx,

--- a/engine/src/planning/graph.rs
+++ b/engine/src/planning/graph.rs
@@ -2253,20 +2253,14 @@ fn check_comparison_types(
     if left_type.vetoed() || right_type.vetoed() {
         return Ok(());
     }
-    let is_equality_only = matches!(
-        op,
-        ComparisonComputation::Equal
-            | ComparisonComputation::NotEqual
-            | ComparisonComputation::Is
-            | ComparisonComputation::IsNot
-    );
+    let is_equality_only = matches!(op, ComparisonComputation::Is | ComparisonComputation::IsNot);
 
     if left_type.is_boolean() && right_type.is_boolean() {
         if !is_equality_only {
             return Err(vec![engine_error_at_graph(
                 graph,
                 source,
-                format!("Can only use == and != with booleans (got {})", op),
+                format!("Can only use 'is' and 'is not' with booleans (got {})", op),
             )]);
         }
         return Ok(());
@@ -2277,7 +2271,7 @@ fn check_comparison_types(
             return Err(vec![engine_error_at_graph(
                 graph,
                 source,
-                format!("Can only use == and != with text (got {})", op),
+                format!("Can only use 'is' and 'is not' with text (got {})", op),
             )]);
         }
         return Ok(());

--- a/engine/src/planning/mod.rs
+++ b/engine/src/planning/mod.rs
@@ -1056,11 +1056,15 @@ fact imported_value: [amount from a]
     }
 
     // ========================================================================
-    // Dependency tracking
+    // Source transparency
     // ========================================================================
 
+    fn has_source_for(plan: &super::execution_plan::ExecutionPlan, name: &str) -> bool {
+        plan.sources.keys().any(|(n, _)| n == name)
+    }
+
     #[test]
-    fn dependencies_populated_for_cross_spec_rule_reference() {
+    fn sources_contain_main_and_dep_for_cross_spec_rule_reference() {
         let code = r#"
 spec dep
 fact x: 10
@@ -1081,22 +1085,19 @@ rule result: d.val
 
         let plan = plan_single(consumer, &specs, sources).expect("planning should succeed");
 
-        assert_eq!(
-            plan.dependencies.len(),
-            1,
-            "consumer should depend on exactly one spec, got: {:?}",
-            plan.dependencies
-        );
-        let dep_id = plan.dependencies.iter().next().unwrap();
-        assert_eq!(dep_id.name, "dep");
+        assert_eq!(plan.sources.len(), 2, "main + dep, got: {:?}", plan.sources);
         assert!(
-            !dep_id.plan_hash.is_empty(),
-            "dependency plan hash must be non-empty"
+            has_source_for(&plan, "consumer"),
+            "sources must include main spec"
+        );
+        assert!(
+            has_source_for(&plan, "dep"),
+            "sources must include dep spec"
         );
     }
 
     #[test]
-    fn dependencies_empty_for_standalone_spec() {
+    fn sources_contain_only_main_for_standalone_spec() {
         let code = r#"
 spec standalone
 fact age: 25
@@ -1111,15 +1112,16 @@ rule is_adult: age >= 18
 
         let plan = plan_single(&specs[0], &specs, sources).expect("planning should succeed");
 
-        assert!(
-            plan.dependencies.is_empty(),
-            "standalone spec should have no dependencies, got: {:?}",
-            plan.dependencies
+        assert_eq!(
+            plan.sources.len(),
+            1,
+            "standalone should have only main spec"
         );
+        assert!(has_source_for(&plan, "standalone"));
     }
 
     #[test]
-    fn dependencies_contain_multiple_cross_spec_refs() {
+    fn sources_contain_all_cross_spec_refs() {
         let code = r#"
 spec rates
 fact base_rate: 0.05
@@ -1147,18 +1149,51 @@ rule combined: r.rate + c.limit
         let plan = plan_single(calc, &specs, sources).expect("planning should succeed");
 
         assert_eq!(
-            plan.dependencies.len(),
-            2,
-            "calculator should depend on two specs, got: {:?}",
-            plan.dependencies
+            plan.sources.len(),
+            3,
+            "calculator + rates + config, got: {:?}",
+            plan.sources
         );
-        let dep_names: Vec<&str> = plan.dependencies.iter().map(|d| d.name.as_str()).collect();
-        assert!(dep_names.contains(&"rates"), "should depend on rates");
-        assert!(dep_names.contains(&"config"), "should depend on config");
+        assert!(has_source_for(&plan, "calculator"));
+        assert!(has_source_for(&plan, "rates"));
+        assert!(has_source_for(&plan, "config"));
     }
 
     #[test]
-    fn dependency_plan_hash_matches_dep_spec_plan_hash() {
+    fn sources_include_spec_ref_even_without_rules() {
+        let code = r#"
+spec dep
+fact x: 10
+
+spec consumer
+fact d: spec dep
+fact local: 99
+rule result: local
+"#;
+        let specs = parse(code, "test.lemma", &ResourceLimits::default())
+            .unwrap()
+            .specs;
+        let consumer = specs.iter().find(|s| s.name == "consumer").unwrap();
+
+        let mut sources = HashMap::new();
+        sources.insert("test.lemma".to_string(), code.to_string());
+
+        let plan = plan_single(consumer, &specs, sources).expect("planning should succeed");
+
+        assert_eq!(
+            plan.sources.len(),
+            2,
+            "consumer + dep, got: {:?}",
+            plan.sources
+        );
+        assert!(
+            has_source_for(&plan, "dep"),
+            "spec ref dep must be in sources even without rules"
+        );
+    }
+
+    #[test]
+    fn sources_round_trip_to_valid_specs() {
         let code = r#"
 spec dep
 fact x: 42
@@ -1171,108 +1206,22 @@ rule result: d.val
         let specs = parse(code, "test.lemma", &ResourceLimits::default())
             .unwrap()
             .specs;
+        let consumer = specs.iter().find(|s| s.name == "consumer").unwrap();
 
         let mut sources = HashMap::new();
         sources.insert("test.lemma".to_string(), code.to_string());
 
-        let mut ctx = Context::new();
-        for spec in &specs {
-            ctx.insert_spec(Arc::new(spec.clone()), spec.from_registry)
-                .expect("insert spec");
+        let plan = plan_single(consumer, &specs, sources).expect("planning should succeed");
+
+        for ((name, _), source_text) in &plan.sources {
+            let parsed = parse(source_text, "roundtrip.lemma", &ResourceLimits::default());
+            assert!(
+                parsed.is_ok(),
+                "source for '{}' must re-parse: {:?}\nsource:\n{}",
+                name,
+                parsed.err(),
+                source_text
+            );
         }
-        let result = plan(&ctx, sources);
-        assert!(result.global_errors.is_empty());
-
-        let dep_plan = result
-            .per_spec
-            .iter()
-            .find(|r| r.spec.name == "dep")
-            .expect("dep result")
-            .plans
-            .first()
-            .expect("dep must have a plan");
-
-        let consumer_plan = result
-            .per_spec
-            .iter()
-            .find(|r| r.spec.name == "consumer")
-            .expect("consumer result")
-            .plans
-            .first()
-            .expect("consumer must have a plan");
-
-        let recorded_hash = &consumer_plan
-            .dependencies
-            .iter()
-            .find(|d| d.name == "dep")
-            .expect("consumer should depend on dep")
-            .plan_hash;
-
-        assert_eq!(
-            recorded_hash,
-            &dep_plan.plan_hash(),
-            "dependency hash must match the dep's actual computed plan hash"
-        );
-    }
-
-    #[test]
-    fn spec_ref_without_rules_excluded_from_dependencies() {
-        let code = r#"
-spec dep
-fact x: 10
-
-spec consumer
-fact d: spec dep
-fact local: 99
-rule result: local
-"#;
-        let specs = parse(code, "test.lemma", &ResourceLimits::default())
-            .unwrap()
-            .specs;
-        let consumer = specs.iter().find(|s| s.name == "consumer").unwrap();
-
-        let mut sources = HashMap::new();
-        sources.insert("test.lemma".to_string(), code.to_string());
-
-        let plan = plan_single(consumer, &specs, sources).expect("planning should succeed");
-
-        assert!(
-            plan.dependencies.is_empty(),
-            "spec ref whose facts are not used by any rule should not appear in dependencies, got: {:?}",
-            plan.dependencies
-        );
-    }
-
-    #[test]
-    fn spec_ref_with_rules_always_creates_dependency() {
-        // Even if the consumer's own rules don't reference dep rules,
-        // the dep's rules are part of the execution plan and need dep's facts.
-        let code = r#"
-spec dep
-fact x: 10
-rule val: x
-
-spec consumer
-fact d: spec dep
-fact local: 99
-rule result: local
-"#;
-        let specs = parse(code, "test.lemma", &ResourceLimits::default())
-            .unwrap()
-            .specs;
-        let consumer = specs.iter().find(|s| s.name == "consumer").unwrap();
-
-        let mut sources = HashMap::new();
-        sources.insert("test.lemma".to_string(), code.to_string());
-
-        let plan = plan_single(consumer, &specs, sources).expect("planning should succeed");
-
-        assert_eq!(
-            plan.dependencies.len(),
-            1,
-            "dep's rules are in the plan, so dep must be a dependency, got: {:?}",
-            plan.dependencies
-        );
-        assert_eq!(plan.dependencies.iter().next().unwrap().name, "dep");
     }
 }

--- a/engine/src/planning/mod.rs
+++ b/engine/src/planning/mod.rs
@@ -71,6 +71,40 @@ impl PlanHashRegistry {
     }
 }
 
+/// When a SpecRef has both a hash_pin and an explicit effective datetime,
+/// verify the effective falls within the pinned spec's temporal range.
+/// Returns `Some(Error)` if the effective is outside the range.
+pub(crate) fn validate_effective_for_pin(
+    spec_ref: &crate::parsing::ast::SpecRef,
+    resolved_spec: &Arc<LemmaSpec>,
+    context: &Context,
+) -> Option<Error> {
+    let effective = spec_ref.effective.as_ref()?;
+    let (_, eff_to) = context.effective_range(resolved_spec);
+    let from_ok = resolved_spec
+        .effective_from()
+        .map(|f| *effective >= *f)
+        .unwrap_or(true);
+    let to_ok = eff_to.as_ref().map(|t| *effective < *t).unwrap_or(true);
+    if from_ok && to_ok {
+        return None;
+    }
+    Some(Error::validation(
+        format!(
+            "Effective {} is outside the temporal range of pinned spec '{}~{}' ([{}, {}))",
+            effective,
+            spec_ref.name,
+            spec_ref.hash_pin.as_deref().unwrap_or("?"),
+            resolved_spec
+                .effective_from()
+                .map_or("-inf".to_string(), |d| d.to_string()),
+            eff_to.map_or("+inf".to_string(), |d| d.to_string()),
+        ),
+        None,
+        Some("The effective datetime must fall within the pinned version's temporal range"),
+    ))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct SpecName(String);
 

--- a/engine/src/planning/semantics.rs
+++ b/engine/src/planning/semantics.rs
@@ -1908,7 +1908,7 @@ pub enum FactData {
     SpecRef {
         spec: Arc<crate::parsing::ast::LemmaSpec>,
         source: Source,
-        resolved_plan_hash: Option<String>,
+        resolved_plan_hash: String,
     },
 }
 
@@ -1963,7 +1963,7 @@ impl FactData {
             FactData::Value { .. } | FactData::TypeDeclaration { .. } => None,
             FactData::SpecRef {
                 resolved_plan_hash, ..
-            } => resolved_plan_hash.as_deref(),
+            } => Some(resolved_plan_hash.as_str()),
         }
     }
 

--- a/engine/src/planning/semantics.rs
+++ b/engine/src/planning/semantics.rs
@@ -28,8 +28,8 @@ pub fn negated_comparison(op: ComparisonComputation) -> ComparisonComputation {
         ComparisonComputation::LessThanOrEqual => ComparisonComputation::GreaterThan,
         ComparisonComputation::GreaterThan => ComparisonComputation::LessThanOrEqual,
         ComparisonComputation::GreaterThanOrEqual => ComparisonComputation::LessThan,
-        ComparisonComputation::Equal | ComparisonComputation::Is => ComparisonComputation::IsNot,
-        ComparisonComputation::NotEqual | ComparisonComputation::IsNot => ComparisonComputation::Is,
+        ComparisonComputation::Is => ComparisonComputation::IsNot,
+        ComparisonComputation::IsNot => ComparisonComputation::Is,
     }
 }
 
@@ -2251,16 +2251,6 @@ mod tests {
         assert_eq!(
             negated_comparison(ComparisonComputation::GreaterThanOrEqual),
             ComparisonComputation::LessThan
-        );
-        assert_eq!(
-            negated_comparison(ComparisonComputation::Equal),
-            ComparisonComputation::IsNot,
-            "== negates to 'is not'"
-        );
-        assert_eq!(
-            negated_comparison(ComparisonComputation::NotEqual),
-            ComparisonComputation::Is,
-            "!= negates to 'is'"
         );
         assert_eq!(
             negated_comparison(ComparisonComputation::Is),

--- a/engine/src/planning/semantics.rs
+++ b/engine/src/planning/semantics.rs
@@ -1267,14 +1267,6 @@ impl Expression {
         }
     }
 
-    /// Get source text for this expression if available
-    pub fn get_source_text(&self, sources: &HashMap<String, String>) -> Option<String> {
-        let source = self.source_location.as_ref()?;
-        let file_source = sources.get(&source.attribute)?;
-        let span = &source.span;
-        Some(file_source.get(span.start..span.end)?.to_string())
-    }
-
     /// Collect all FactPath references from this resolved expression tree
     pub fn collect_fact_paths(&self, facts: &mut std::collections::HashSet<FactPath>) {
         self.kind.collect_fact_paths(facts);

--- a/engine/src/planning/temporal.rs
+++ b/engine/src/planning/temporal.rs
@@ -1,5 +1,5 @@
 use crate::engine::{Context, TemporalBound};
-use crate::parsing::ast::{DateTimeValue, FactValue, LemmaSpec};
+use crate::parsing::ast::{DateTimeValue, FactValue, LemmaSpec, TypeDef};
 use crate::parsing::source::Source;
 use crate::Error;
 use std::collections::BTreeSet;
@@ -15,19 +15,55 @@ pub struct TemporalSlice {
     pub to: Option<DateTimeValue>,
 }
 
-/// Collect names of implicit (unpinned) spec references with their source locations.
+/// Collect names of implicit (unpinned) dependency references with their source locations.
+/// Includes both fact-level spec refs and type imports (named and inline) that are not hash-pinned.
 fn implicit_spec_refs(spec: &LemmaSpec) -> Vec<(String, Source)> {
-    spec.facts
-        .iter()
-        .filter_map(|fact| {
-            if let FactValue::SpecReference(spec_ref) = &fact.value {
+    let mut refs: Vec<(String, Source)> = Vec::new();
+
+    for fact in &spec.facts {
+        match &fact.value {
+            FactValue::SpecReference(spec_ref) => {
                 if spec_ref.hash_pin.is_none() {
-                    return Some((spec_ref.name.clone(), fact.source_location.clone()));
+                    refs.push((spec_ref.name.clone(), fact.source_location.clone()));
                 }
             }
-            None
-        })
-        .collect()
+            FactValue::TypeDeclaration {
+                from: Some(from_ref),
+                ..
+            } => {
+                if from_ref.hash_pin.is_none() {
+                    refs.push((from_ref.name.clone(), fact.source_location.clone()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for type_def in &spec.types {
+        match type_def {
+            TypeDef::Import {
+                from,
+                source_location,
+                ..
+            } => {
+                if from.hash_pin.is_none() {
+                    refs.push((from.name.clone(), source_location.clone()));
+                }
+            }
+            TypeDef::Inline {
+                from: Some(from_ref),
+                source_location,
+                ..
+            } => {
+                if from_ref.hash_pin.is_none() {
+                    refs.push((from_ref.name.clone(), source_location.clone()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    refs
 }
 
 /// Collect just the names (for callers that don't need locations).

--- a/engine/src/planning/types.rs
+++ b/engine/src/planning/types.rs
@@ -726,7 +726,12 @@ impl<'a> PerSliceTypeResolver<'a> {
     ) -> Result<(Arc<LemmaSpec>, String), Error> {
         if let Some(pin) = &from.hash_pin {
             return match self.plan_hashes.get_by_pin(&from.name, pin) {
-                Some(arc) => Ok((Arc::clone(arc), pin.clone())),
+                Some(arc) => {
+                    if let Some(err) = super::validate_effective_for_pin(from, arc, self.context) {
+                        return Err(err);
+                    }
+                    Ok((Arc::clone(arc), pin.clone()))
+                }
                 None => Err(Error::validation(
                     format!(
                         "No spec '{}' found with plan hash '{}' for type import",
@@ -754,12 +759,16 @@ impl<'a> PerSliceTypeResolver<'a> {
             .plan_hashes
             .get_by_slice(&arc.name, &arc.effective_from)
             .map(std::string::ToString::to_string)
-            .unwrap_or_else(|| {
-                unreachable!(
-                    "BUG: resolved type-import dependency must have plan hash; \
-                     topological planning guarantees deps are planned first"
+            .ok_or_else(|| {
+                Error::validation(
+                    format!(
+                        "Cannot import types from spec '{}': no plan hash (that spec may have failed validation)",
+                        arc.name
+                    ),
+                    None,
+                    None::<String>,
                 )
-            });
+            })?;
         Ok((arc, hash))
     }
 

--- a/engine/src/planning/types.rs
+++ b/engine/src/planning/types.rs
@@ -167,17 +167,23 @@ impl<'a> PerSliceTypeResolver<'a> {
         Ok(())
     }
 
-    /// Register types from all specs transitively reachable from `spec` via type imports,
-    /// fact spec references, and fact type declarations with `from`.
-    pub fn register_dependency_types(&mut self, spec: &Arc<LemmaSpec>) -> Vec<Error> {
+    /// Register ALL specs transitively reachable from `spec`: type imports,
+    /// spec ref facts, and type declarations with `from`.
+    ///
+    /// Walks spec refs (not just type deps) because type resolution is batch:
+    /// every dependency spec must be pre-registered before `resolve_all_registered_specs`.
+    /// A spec ref dep may define types used by its own facts/rules, which the
+    /// graph validator type-checks. After resolution, `resolved_types.keys()` is
+    /// the canonical set of all dependency specs for a plan.
+    pub fn register_dependency_specs(&mut self, spec: &Arc<LemmaSpec>) -> Vec<Error> {
         let mut errors = Vec::new();
         let mut visited_spec_names: HashSet<String> = HashSet::new();
         visited_spec_names.insert(spec.name.clone());
-        self.register_dependency_types_recursive(spec, &mut visited_spec_names, &mut errors);
+        self.register_dependency_specs_recursive(spec, &mut visited_spec_names, &mut errors);
         errors
     }
 
-    fn register_dependency_types_recursive(
+    fn register_dependency_specs_recursive(
         &mut self,
         spec: &Arc<LemmaSpec>,
         visited: &mut HashSet<String>,
@@ -185,14 +191,14 @@ impl<'a> PerSliceTypeResolver<'a> {
     ) {
         for type_def in &spec.types {
             if let TypeDef::Import { from, .. } = type_def {
-                self.try_register_dep_spec(&from.name, from.effective.as_ref(), visited, errors);
+                self.try_register_spec(&from.name, from.effective.as_ref(), visited, errors);
             }
         }
 
         for fact in &spec.facts {
             match &fact.value {
                 ParsedFactValue::SpecReference(spec_ref) => {
-                    self.try_register_dep_spec(
+                    self.try_register_spec(
                         &spec_ref.name,
                         spec_ref.effective.as_ref(),
                         visited,
@@ -203,7 +209,7 @@ impl<'a> PerSliceTypeResolver<'a> {
                     from: Some(from_ref),
                     ..
                 } => {
-                    self.try_register_dep_spec(
+                    self.try_register_spec(
                         &from_ref.name,
                         from_ref.effective.as_ref(),
                         visited,
@@ -215,7 +221,7 @@ impl<'a> PerSliceTypeResolver<'a> {
         }
     }
 
-    fn try_register_dep_spec(
+    fn try_register_spec(
         &mut self,
         name: &str,
         explicit_effective: Option<&DateTimeValue>,
@@ -235,7 +241,7 @@ impl<'a> PerSliceTypeResolver<'a> {
 
         if let Some(dep_spec) = dep_spec {
             errors.extend(self.register_all(&dep_spec));
-            self.register_dependency_types_recursive(&dep_spec, visited, errors);
+            self.register_dependency_specs_recursive(&dep_spec, visited, errors);
         }
     }
 

--- a/engine/src/planning/validation.rs
+++ b/engine/src/planning/validation.rs
@@ -869,8 +869,6 @@ fn normalize_literal_constraint(rule: NumericLiteralConstraint) -> NumericLitera
         ComparisonComputation::LessThan => ComparisonComputation::GreaterThan,
         ComparisonComputation::GreaterThanOrEqual => ComparisonComputation::LessThanOrEqual,
         ComparisonComputation::LessThanOrEqual => ComparisonComputation::GreaterThanOrEqual,
-        ComparisonComputation::Equal => ComparisonComputation::Equal,
-        ComparisonComputation::NotEqual => ComparisonComputation::NotEqual,
         ComparisonComputation::Is => ComparisonComputation::Is,
         ComparisonComputation::IsNot => ComparisonComputation::IsNot,
     };
@@ -898,11 +896,11 @@ fn numeric_literal_constraint_satisfied(
         ComparisonComputation::LessThanOrEqual => {
             minimum.is_none_or(|min| min <= normalized.literal)
         }
-        ComparisonComputation::Equal | ComparisonComputation::Is => {
+        ComparisonComputation::Is => {
             minimum.is_none_or(|min| min <= normalized.literal)
                 && maximum.is_none_or(|max| max >= normalized.literal)
         }
-        ComparisonComputation::NotEqual | ComparisonComputation::IsNot => {
+        ComparisonComputation::IsNot => {
             !(minimum == Some(normalized.literal) && maximum == Some(normalized.literal))
         }
     }

--- a/engine/src/registry.rs
+++ b/engine/src/registry.rs
@@ -87,25 +87,20 @@ impl std::error::Error for RegistryError {}
 /// Implementations must be `Send + Sync` so they can be shared across threads.
 /// Resolution is async so that WASM can use `fetch()` and native can use async HTTP.
 ///
-/// `get_specs` / `get_types` return a bundle containing ALL temporal versions
-/// for the requested identifier. The engine handles temporal resolution
-/// locally using `effective_from` on the parsed specs.
+/// `get` returns a bundle containing ALL temporal versions for the requested
+/// identifier. The engine handles temporal resolution locally using
+/// `effective_from` on the parsed specs. Both `spec @...` references and
+/// `type ... from @...` imports are resolved through the same `get` method.
 ///
 /// `name` is the base identifier **without** the leading `@`.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait Registry: Send + Sync {
-    /// Fetch all temporal versions for a `spec @...` reference.
+    /// Fetch all temporal versions for an `@...` identifier.
     ///
     /// `name` is the base name (e.g. `"user/workspace/somespec"`).
-    /// Returns a bundle whose `lemma_source` contains all temporal versions of the spec.
-    async fn get_specs(&self, name: &str) -> Result<RegistryBundle, RegistryError>;
-
-    /// Fetch all temporal versions for a `type ... from @...` reference.
-    ///
-    /// `name` is the base name (e.g. `"lemma/std/finance"`).
-    /// Returns a bundle whose `lemma_source` contains all temporal versions of the type source.
-    async fn get_types(&self, name: &str) -> Result<RegistryBundle, RegistryError>;
+    /// Returns a bundle whose `lemma_source` contains all temporal versions.
+    async fn get(&self, name: &str) -> Result<RegistryBundle, RegistryError>;
 
     /// Map a Registry identifier to a human-facing address for navigation.
     ///
@@ -318,11 +313,7 @@ impl Default for LemmaBase {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl Registry for LemmaBase {
-    async fn get_specs(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
-        self.fetch_source(name).await
-    }
-
-    async fn get_types(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
+    async fn get(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
         self.fetch_source(name).await
     }
 
@@ -355,7 +346,7 @@ pub async fn resolve_registry_references(
     registry: &dyn Registry,
     limits: &ResourceLimits,
 ) -> Result<(), Vec<Error>> {
-    let mut already_requested: HashSet<(String, RegistryReferenceKind)> = HashSet::new();
+    let mut already_requested: HashSet<String> = HashSet::new();
 
     loop {
         let unresolved = collect_unresolved_registry_references(ctx, &already_requested);
@@ -366,16 +357,12 @@ pub async fn resolve_registry_references(
 
         let mut round_errors: Vec<Error> = Vec::new();
         for reference in &unresolved {
-            let dedup = reference.dedup_key();
-            if already_requested.contains(&dedup) {
+            if already_requested.contains(&reference.name) {
                 continue;
             }
-            already_requested.insert(dedup);
+            already_requested.insert(reference.name.clone());
 
-            let bundle_result = match reference.kind {
-                RegistryReferenceKind::Spec => registry.get_specs(&reference.name).await,
-                RegistryReferenceKind::TypeImport => registry.get_types(&reference.name).await,
-            };
+            let bundle_result = registry.get(&reference.name).await;
 
             let bundle = match bundle_result {
                 Ok(b) => b,
@@ -456,46 +443,38 @@ pub async fn resolve_registry_references(
     Ok(())
 }
 
-/// The kind of `@...` reference: a spec reference or a type import.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum RegistryReferenceKind {
-    Spec,
-    TypeImport,
-}
-
 /// A collected `@...` reference needing registry fetch.
 #[derive(Debug, Clone)]
 struct RegistryReference {
     name: String,
-    kind: RegistryReferenceKind,
     source: Source,
 }
 
-impl RegistryReference {
-    fn dedup_key(&self) -> (String, RegistryReferenceKind) {
-        (self.name.clone(), self.kind.clone())
-    }
-}
-
 /// Collect all unresolved `@...` references from specs in `ctx`.
-/// Unresolved = not satisfied by ctx.get_spec(name, effective) and not already in already_requested.
+/// Collects from both fact-level spec refs and type imports into a single flat set.
 fn collect_unresolved_registry_references(
     ctx: &Context,
-    already_requested: &HashSet<(String, RegistryReferenceKind)>,
+    already_requested: &HashSet<String>,
 ) -> Vec<RegistryReference> {
     let mut unresolved: Vec<RegistryReference> = Vec::new();
-    let mut seen_in_this_round: HashSet<(String, RegistryReferenceKind)> = HashSet::new();
+    let mut seen_in_this_round: HashSet<String> = HashSet::new();
 
     for spec in ctx.iter() {
         let spec = spec.as_ref();
         if spec.attribute.is_none() {
-            let has_registry_refs =
-                spec.facts.iter().any(
-                    |f| matches!(&f.value, FactValue::SpecReference(ref r) if r.from_registry),
-                ) || spec
-                    .types
-                    .iter()
-                    .any(|t| matches!(t, TypeDef::Import { from, .. } if from.from_registry));
+            let has_registry_refs = spec.facts.iter().any(|f| match &f.value {
+                FactValue::SpecReference(ref r) => r.from_registry,
+                FactValue::TypeDeclaration {
+                    from: Some(ref r), ..
+                } => r.from_registry,
+                _ => false,
+            }) || spec.types.iter().any(|t| match t {
+                TypeDef::Import { from, .. } => from.from_registry,
+                TypeDef::Inline {
+                    from: Some(ref r), ..
+                } => r.from_registry,
+                _ => false,
+            });
             if has_registry_refs {
                 panic!(
                     "BUG: spec '{}' must have source attribute when it has registry references",
@@ -505,52 +484,51 @@ fn collect_unresolved_registry_references(
             continue;
         }
 
+        let mut try_collect = |name: &str, source: &Source| {
+            let already_satisfied = ctx.get_spec_effective_from(name, None).is_some();
+            if !already_satisfied
+                && !already_requested.contains(name)
+                && seen_in_this_round.insert(name.to_string())
+            {
+                unresolved.push(RegistryReference {
+                    name: name.to_string(),
+                    source: source.clone(),
+                });
+            }
+        };
+
         for fact in &spec.facts {
-            if let FactValue::SpecReference(spec_ref) = &fact.value {
-                if !spec_ref.from_registry {
-                    continue;
+            match &fact.value {
+                FactValue::SpecReference(spec_ref) if spec_ref.from_registry => {
+                    try_collect(&spec_ref.name, &fact.source_location);
                 }
-                let already_satisfied = ctx
-                    .get_spec_effective_from(spec_ref.name.as_str(), None)
-                    .is_some();
-                let dedup = (spec_ref.name.clone(), RegistryReferenceKind::Spec);
-                if !already_satisfied
-                    && !already_requested.contains(&dedup)
-                    && seen_in_this_round.insert(dedup)
-                {
-                    unresolved.push(RegistryReference {
-                        name: spec_ref.name.clone(),
-                        kind: RegistryReferenceKind::Spec,
-                        source: fact.source_location.clone(),
-                    });
+                FactValue::TypeDeclaration {
+                    from: Some(from_ref),
+                    ..
+                } if from_ref.from_registry => {
+                    try_collect(&from_ref.name, &fact.source_location);
                 }
+                _ => {}
             }
         }
 
         for type_def in &spec.types {
-            if let TypeDef::Import {
-                from,
-                source_location,
-                ..
-            } = type_def
-            {
-                if !from.from_registry {
-                    continue;
+            match type_def {
+                TypeDef::Import {
+                    from,
+                    source_location,
+                    ..
+                } if from.from_registry => {
+                    try_collect(&from.name, source_location);
                 }
-                let already_satisfied = ctx
-                    .get_spec_effective_from(from.name.as_str(), None)
-                    .is_some();
-                let dedup = (from.name.clone(), RegistryReferenceKind::TypeImport);
-                if !already_satisfied
-                    && !already_requested.contains(&dedup)
-                    && seen_in_this_round.insert(dedup)
-                {
-                    unresolved.push(RegistryReference {
-                        name: from.name.clone(),
-                        kind: RegistryReferenceKind::TypeImport,
-                        source: source_location.clone(),
-                    });
+                TypeDef::Inline {
+                    from: Some(from_ref),
+                    source_location,
+                    ..
+                } if from_ref.from_registry => {
+                    try_collect(&from_ref.name, source_location);
                 }
+                _ => {}
             }
         }
     }
@@ -593,22 +571,12 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     impl Registry for TestRegistry {
-        async fn get_specs(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
+        async fn get(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
             self.bundles
                 .get(name)
                 .cloned()
                 .ok_or_else(|| RegistryError {
-                    message: format!("Spec '{}' not found in test registry", name),
-                    kind: RegistryErrorKind::NotFound,
-                })
-        }
-
-        async fn get_types(&self, name: &str) -> Result<RegistryBundle, RegistryError> {
-            self.bundles
-                .get(name)
-                .cloned()
-                .ok_or_else(|| RegistryError {
-                    message: format!("Type source '{}' not found in test registry", name),
+                    message: format!("'{}' not found in test registry", name),
                     kind: RegistryErrorKind::NotFound,
                 })
         }
@@ -692,7 +660,7 @@ fact quantity: 42"#,
     }
 
     #[tokio::test]
-    async fn get_specs_returns_all_zones_and_url_for_id_supports_effective() {
+    async fn get_returns_all_zones_and_url_for_id_supports_effective() {
         let effective = DateTimeValue {
             year: 2026,
             month: 1,
@@ -709,7 +677,7 @@ fact quantity: 42"#,
             "spec org/spec 2025-01-01\nfact x: 1\n\nspec org/spec 2026-01-15\nfact x: 2",
         );
 
-        let bundle = registry.get_specs("org/spec").await.unwrap();
+        let bundle = registry.get("org/spec").await.unwrap();
         assert!(bundle.lemma_source.contains("fact x: 1"));
         assert!(bundle.lemma_source.contains("fact x: 2"));
 
@@ -1372,50 +1340,34 @@ type money: scale
         // -------------------------------------------------------------------
 
         #[tokio::test]
-        async fn get_specs_delegates_to_fetch_source() {
+        async fn get_delegates_to_fetch_source() {
             let registry = LemmaBase::with_fetcher(Box::new(MockHttpFetcher::always_returning(
                 "spec org/resolved\nfact a: 1",
             )));
 
-            let bundle = registry.get_specs("@org/resolved").await.unwrap();
+            let bundle = registry.get("@org/resolved").await.unwrap();
 
             assert_eq!(bundle.lemma_source, "spec org/resolved\nfact a: 1");
             assert_eq!(bundle.attribute, "@org/resolved");
         }
 
         #[tokio::test]
-        async fn get_types_delegates_to_fetch_source() {
-            let registry = LemmaBase::with_fetcher(Box::new(MockHttpFetcher::always_returning(
-                "spec lemma/std/finance\ntype money: scale\n -> unit eur 1.00",
-            )));
-
-            let bundle = registry.get_types("@lemma/std/finance").await.unwrap();
-
-            assert_eq!(bundle.attribute, "@lemma/std/finance");
-            assert!(
-                bundle.lemma_source.contains("type money: scale"),
-                "Expected source to contain 'type money: scale': {}",
-                bundle.lemma_source
-            );
-        }
-
-        #[tokio::test]
-        async fn get_specs_propagates_http_error() {
+        async fn get_propagates_http_error() {
             let registry =
                 LemmaBase::with_fetcher(Box::new(MockHttpFetcher::always_failing_with_status(404)));
 
-            let err = registry.get_specs("@org/missing").await.unwrap_err();
+            let err = registry.get("@org/missing").await.unwrap_err();
 
             assert!(err.message.contains("HTTP 404"));
         }
 
         #[tokio::test]
-        async fn get_types_propagates_network_error() {
+        async fn get_propagates_network_error() {
             let registry = LemmaBase::with_fetcher(Box::new(
                 MockHttpFetcher::always_failing_with_network_error("timeout"),
             ));
 
-            let err = registry.get_types("@lemma/std/types").await.unwrap_err();
+            let err = registry.get("@lemma/std/types").await.unwrap_err();
 
             assert!(err.message.contains("timeout"));
         }

--- a/engine/src/tests/ast.rs
+++ b/engine/src/tests/ast.rs
@@ -323,66 +323,6 @@ fn test_veto_expression() {
 }
 
 #[test]
-fn test_expression_get_source_text_with_location() {
-    use crate::parsing::source::Source;
-    use std::collections::HashMap;
-
-    let source = "fact value: 42";
-    let mut sources = HashMap::new();
-    sources.insert("test.lemma".to_string(), source.to_string());
-
-    let span = Span {
-        start: 12,
-        end: 14,
-        line: 1,
-        col: 12,
-    };
-    let source_location = Source::new("test.lemma", span);
-    let expr = Expression::new(
-        ExpressionKind::Literal(Value::Number(Decimal::new(42, 0))),
-        source_location,
-    );
-
-    assert_eq!(expr.get_source_text(&sources), Some("42".to_string()));
-}
-
-#[test]
-fn test_expression_get_source_text_no_location() {
-    use std::collections::HashMap;
-
-    let mut sources = HashMap::new();
-    sources.insert("test.lemma".to_string(), "fact value: 42".to_string());
-
-    let expr = Expression {
-        kind: ExpressionKind::Literal(Value::Number(Decimal::new(42, 0))),
-        source_location: None,
-    };
-
-    assert_eq!(expr.get_source_text(&sources), None);
-}
-
-#[test]
-fn test_expression_get_source_text_source_not_found() {
-    use crate::parsing::source::Source;
-    use std::collections::HashMap;
-
-    let sources = HashMap::new();
-    let span = Span {
-        start: 0,
-        end: 5,
-        line: 1,
-        col: 0,
-    };
-    let source_location = Source::new("missing.lemma", span);
-    let expr = Expression::new(
-        ExpressionKind::Literal(Value::Number(Decimal::new(42, 0))),
-        source_location,
-    );
-
-    assert_eq!(expr.get_source_text(&sources), None);
-}
-
-#[test]
 fn test_datetime_value_parse_year_and_year_month_equal() {
     let from_year: DateTimeValue = "2026".parse().expect("2026 should parse");
     let from_year_month: DateTimeValue = "2026-01".parse().expect("2026-01 should parse");

--- a/engine/src/tests/ast.rs
+++ b/engine/src/tests/ast.rs
@@ -68,8 +68,6 @@ fn test_comparison_operator_display() {
         ">="
     );
     assert_eq!(format!("{}", ComparisonComputation::LessThanOrEqual), "<=");
-    assert_eq!(format!("{}", ComparisonComputation::Equal), "==");
-    assert_eq!(format!("{}", ComparisonComputation::NotEqual), "!=");
     assert_eq!(format!("{}", ComparisonComputation::Is), "is");
     assert_eq!(format!("{}", ComparisonComputation::IsNot), "is not");
 }

--- a/engine/tests/equal_operator.rs
+++ b/engine/tests/equal_operator.rs
@@ -14,8 +14,8 @@ fact a: 42
 fact b: 42
 fact c: 100
 
-rule equal_true: a == b
-rule equal_false: a == c
+rule equal_true: a is b
+rule equal_false: a is c
 "#,
             lemma::SourceType::Labeled("test.lemma"),
         )
@@ -44,8 +44,8 @@ spec test_equal_text
 fact greeting: "hello"
 fact other: "world"
 
-rule same_greeting: greeting == "hello"
-rule different_greeting: greeting == other
+rule same_greeting: greeting is "hello"
+rule different_greeting: greeting is other
 "#,
             lemma::SourceType::Labeled("test.lemma"),
         )
@@ -75,8 +75,8 @@ fact price_a: 100
 fact price_b: 100
 fact price_c: 50
 
-rule same_price: price_a == price_b
-rule different_price: price_a == price_c
+rule same_price: price_a is price_b
+rule different_price: price_a is price_c
 "#,
             lemma::SourceType::Labeled("test.lemma"),
         )
@@ -106,8 +106,8 @@ fact flag_a: true
 fact flag_b: true
 fact flag_c: false
 
-rule both_true: flag_a == flag_b
-rule mixed: flag_a == flag_c
+rule both_true: flag_a is flag_b
+rule mixed: flag_a is flag_c
 "#,
             lemma::SourceType::Labeled("test.lemma"),
         )
@@ -137,8 +137,8 @@ fact status: "active"
 fact count: 10
 
 rule message: "inactive"
-  unless status == "active" then "active"
-  unless count == 10 then "count is 10"
+  unless status is "active" then "active"
+  unless count is 10 then "count is 10"
 "#,
             lemma::SourceType::Labeled("test.lemma"),
         )

--- a/engine/tests/expression_syntax.rs
+++ b/engine/tests/expression_syntax.rs
@@ -16,7 +16,7 @@ rule not_x: not(x)
 rule sqrt_num: sqrt(num)
 rule sin_zero: sin(0)
 rule log_ten: log(10)
-rule combined: not(x) and sqrt(16) == 4
+rule combined: not(x) and sqrt(16) is 4
 rule with_spaces: not  (  x  )
 "#;
 
@@ -60,13 +60,13 @@ rule with_spaces: not  (  x  )
         v => panic!("Expected number 0, got {:?}", v),
     }
 
-    // combined expression: not(true) and (sqrt(16) == 4) => false and true => false
+    // combined expression: not(true) and (sqrt(16) is 4) => false and true => false
     let combined_rule = response.results.get("combined").unwrap();
     match combined_rule.result.value().unwrap() {
         LiteralValue {
             value: ValueKind::Boolean(b),
             ..
-        } => assert!(!*b, "not(x) and sqrt(16) == 4 with x=true should be false"),
+        } => assert!(!*b, "not(x) and sqrt(16) is 4 with x=true should be false"),
         v => panic!("Expected boolean false, got {:?}", v),
     }
 }

--- a/engine/tests/fingerprint.rs
+++ b/engine/tests/fingerprint.rs
@@ -51,7 +51,7 @@ fn golden_loaded_minimal_fact_and_rule() {
     let eff = date(2025, 1, 1);
     assert_eq!(
         plan_hash_from_loaded_plan(&engine, "golden_loaded_minimal", &eff),
-        "56c29a91"
+        "9d4491bb"
     );
 }
 
@@ -67,7 +67,7 @@ fn golden_loaded_unless_rule() {
     let eff = date(2025, 1, 1);
     assert_eq!(
         plan_hash_from_loaded_plan(&engine, "golden_loaded_unless", &eff),
-        "6a33b890"
+        "d7101147"
     );
 }
 
@@ -102,7 +102,7 @@ rule r: x"#,
     let eff = date(2025, 7, 1);
     assert_eq!(
         plan_hash_from_loaded_plan(&engine, "golden_temporal_adv", &eff),
-        "6d8cc867"
+        "1c22b3a1"
     );
 }
 
@@ -130,7 +130,7 @@ rule total: balance"#,
     let eff = date(2025, 1, 1);
     assert_eq!(
         plan_hash_from_loaded_plan(&engine, "golden_rich_adv", &eff),
-        "d5f0b7ae"
+        "e84294c5"
     );
 }
 
@@ -160,7 +160,7 @@ rule out: link.computed"#,
     let eff = date(2025, 1, 1);
     assert_eq!(
         plan_hash_from_loaded_plan(&engine, "golden_consumer_ref", &eff),
-        "c161b54e"
+        "7463e060"
     );
 }
 

--- a/engine/tests/formatter.rs
+++ b/engine/tests/formatter.rs
@@ -334,3 +334,89 @@ fn idempotency_precedence_expressions() {
         );
     }
 }
+
+// =============================================================================
+// Type import round-trip tests
+// =============================================================================
+
+#[test]
+fn round_trip_type_import_with_effective() {
+    let source = "spec consumer\ntype money from finance 2026-01-15\nfact p: [money]";
+    let formatted = format_source(source, "test.lemma").unwrap();
+    assert!(
+        formatted.contains("type money from finance 2026-01-15"),
+        "expected effective datetime in formatted output: {}",
+        formatted
+    );
+    let reformatted = format_source(&formatted, "test.lemma").unwrap();
+    assert_eq!(
+        formatted, reformatted,
+        "type import with effective is not idempotent"
+    );
+}
+
+#[test]
+fn round_trip_type_import_with_hash_and_effective() {
+    let source =
+        "spec consumer\ntype money from finance~a1b2c3d4 2026-01-15T00:00:03\nfact p: [money]";
+    let formatted = format_source(source, "test.lemma").unwrap();
+    assert!(
+        formatted.contains("type money from finance~a1b2c3d4 2026-01-15T00:00:03"),
+        "expected hash+effective in formatted output: {}",
+        formatted
+    );
+    let reformatted = format_source(&formatted, "test.lemma").unwrap();
+    assert_eq!(
+        formatted, reformatted,
+        "type import with hash+effective is not idempotent"
+    );
+}
+
+#[test]
+fn round_trip_type_import_with_hash_only() {
+    let source = "spec consumer\ntype money from finance~a1b2c3d4\nfact p: [money]";
+    let formatted = format_source(source, "test.lemma").unwrap();
+    assert!(
+        formatted.contains("type money from finance~a1b2c3d4"),
+        "expected hash in formatted output: {}",
+        formatted
+    );
+    let reformatted = format_source(&formatted, "test.lemma").unwrap();
+    assert_eq!(
+        formatted, reformatted,
+        "type import with hash is not idempotent"
+    );
+}
+
+#[test]
+fn round_trip_type_import_registry_with_effective() {
+    let source = "spec consumer\ntype money from @lemma/std/finance 2026-01-15\nfact p: [money]";
+    let formatted = format_source(source, "test.lemma").unwrap();
+    assert!(
+        formatted.contains("type money from @lemma/std/finance 2026-01-15"),
+        "expected registry+effective in formatted output: {}",
+        formatted
+    );
+    let reformatted = format_source(&formatted, "test.lemma").unwrap();
+    assert_eq!(
+        formatted, reformatted,
+        "registry type import with effective is not idempotent"
+    );
+}
+
+#[test]
+fn round_trip_type_import_registry_with_hash_and_effective() {
+    let source =
+        "spec consumer\ntype money from @lemma/std/finance~ab12cd34 2026-03-01\nfact p: [money]";
+    let formatted = format_source(source, "test.lemma").unwrap();
+    assert!(
+        formatted.contains("type money from @lemma/std/finance~ab12cd34 2026-03-01"),
+        "expected registry+hash+effective in formatted output: {}",
+        formatted
+    );
+    let reformatted = format_source(&formatted, "test.lemma").unwrap();
+    assert_eq!(
+        formatted, reformatted,
+        "registry type import with hash+effective is not idempotent"
+    );
+}

--- a/engine/tests/meta_fields.rs
+++ b/engine/tests/meta_fields.rs
@@ -31,8 +31,6 @@ fact x: 1
         .get_plan("meta_test", Some(&effective))
         .expect("Plan not found");
 
-    // Check meta fields
-    // Note: Display for Text literal is unquoted in Value::Display
     assert_eq!(
         plan.meta.get("title").map(|v| v.to_string()),
         Some("Test Spec".to_string())

--- a/engine/tests/modulo_power.rs
+++ b/engine/tests/modulo_power.rs
@@ -78,8 +78,8 @@ fn test_modulo_in_expression() {
             r#"
 spec test
 fact value: 17
-rule is_even: (value % 2) == 0
-rule is_odd: (value % 2) == 1
+rule is_even: (value % 2) is 0
+rule is_odd: (value % 2) is 1
 "#,
             lemma::SourceType::Labeled("test"),
         )

--- a/engine/tests/property_based.rs
+++ b/engine/tests/property_based.rs
@@ -101,7 +101,7 @@ rule result: x + 0
         let code = format!(r#"
 spec test
 fact x: {}
-rule eq_self: x == x
+rule eq_self: x is x
 rule lte_self: x <= x
 "#, n);
         engine.load(&code, lemma::SourceType::Labeled("test")).unwrap();
@@ -548,7 +548,7 @@ fact c: 30
 rule a_lt_b: a < b
 rule b_lt_c: b < c
 rule a_lt_c: a < c
-rule a_eq_a: a == a
+rule a_eq_a: a is a
 rule a_lte_a: a <= a
 rule a_gte_a: a >= a
 "#;

--- a/engine/tests/scale_number_refactoring.rs
+++ b/engine/tests/scale_number_refactoring.rs
@@ -369,7 +369,7 @@ fact price1: [money]
 fact price2: [money]
 
 rule is_greater: price1 > price2
-rule is_equal: price1 == price2"#;
+rule is_equal: price1 is price2"#;
 
     let mut engine = Engine::new();
     engine

--- a/engine/tests/timezone.rs
+++ b/engine/tests/timezone.rs
@@ -26,7 +26,7 @@ fn test_timezone_comparison_same_instant() {
 spec test
 fact time_nyc: 2024-03-15T10:00:00-05:00
 fact time_london: 2024-03-15T15:00:00+00:00
-rule are_equal: time_nyc == time_london
+rule are_equal: time_nyc is time_london
     "#;
 
     engine
@@ -257,9 +257,6 @@ rule preserved: nepal_time
 // Note: Time literals with timezones are not supported by chrono parser
 // (time-only strings can't be parsed with timezone offsets)
 // Use full datetime if timezone is needed
-
-// Note: Datetime equality comparison requires using comparison operators like < or >
-// == operator on datetime values has parser limitations
 
 #[test]
 fn test_extreme_western_timezone() {

--- a/engine/tests/type_aware_arithmetic.rs
+++ b/engine/tests/type_aware_arithmetic.rs
@@ -15,7 +15,7 @@ fact discount_rate: 25%
 rule price_after_discount: base_price - discount_rate
 rule expected: 150
 
-rule test_passes: price_after_discount == expected
+rule test_passes: price_after_discount is expected
 "#;
 
     engine
@@ -54,7 +54,7 @@ fact markup: 10%
 rule price_with_markup: base + markup
 rule expected: 110
 
-rule test_passes: price_with_markup == expected
+rule test_passes: price_with_markup is expected
 "#;
 
     engine
@@ -90,7 +90,7 @@ fact rate: 15%
 rule result: amount * rate
 rule expected: 150
 
-rule test_passes: result == expected
+rule test_passes: result is expected
 "#;
 
     engine
@@ -127,7 +127,7 @@ rule discount_amount: base_price * discount_rate
 rule final_price: base_price - discount_amount
 rule expected: 150
 
-rule test_passes: final_price == expected
+rule test_passes: final_price is expected
 "#;
 
     engine
@@ -166,7 +166,7 @@ rule after_second: after_first - second_discount
 
 rule expected: 72
 
-rule test_passes: after_second == expected
+rule test_passes: after_second is expected
 "#;
 
     engine

--- a/engine/tests/type_import_temporal.rs
+++ b/engine/tests/type_import_temporal.rs
@@ -1,0 +1,634 @@
+//! Regression test: type-only dependencies must respect temporal versioning.
+//!
+//! When spec B depends on spec A *only* via `type money from A` (no fact-level
+//! spec ref), and A has multiple temporal versions with different type
+//! definitions, B must produce separate temporal slices — one per version of A
+//! that falls within B's effective range.
+
+use lemma::{DateTimeValue, Engine};
+use std::collections::HashMap;
+
+fn date(year: i32, month: u32, day: u32) -> DateTimeValue {
+    DateTimeValue {
+        year,
+        month,
+        day,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: 0,
+        timezone: None,
+    }
+}
+
+fn eval_with(
+    engine: &Engine,
+    spec_name: &str,
+    effective: &DateTimeValue,
+    facts: Vec<(&str, &str)>,
+) -> lemma::Response {
+    let map: HashMap<String, String> = facts
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    engine.run(spec_name, Some(effective), map, false).unwrap()
+}
+
+fn assert_rule_value(response: &lemma::Response, rule: &str, expected: &str) {
+    let result = response
+        .results
+        .get(rule)
+        .unwrap_or_else(|| panic!("rule '{}' not in results", rule));
+    let val = result
+        .result
+        .value()
+        .unwrap_or_else(|| panic!("rule '{}' is Veto, expected Value", rule));
+    assert_eq!(
+        val.to_string(),
+        expected,
+        "rule '{}': expected {}, got {}",
+        rule,
+        expected,
+        val
+    );
+}
+
+/// Type-only dependency where the source spec's type definition changes between
+/// temporal versions. The consumer has NO fact-level spec ref — only
+/// `type money from finance`.
+///
+/// finance v1 (before 2025-07-01): money has only `eur`
+/// finance v2 (from 2025-07-01):  money has `eur` + `usd`
+///
+/// consumer is active from 2025-01-01 and uses `eur` literals.
+/// Both slices should plan successfully with the correct version of the type.
+/// Crucially, evaluating *after* the boundary must see finance v2's type (which
+/// includes `usd`), not finance v1's.
+#[test]
+fn type_only_dep_must_produce_temporal_slices() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .load(
+            r#"
+spec shop 2025-01-01
+type money from finance
+fact price: [money]
+rule doubled: price * 2
+"#,
+            lemma::SourceType::Labeled("shop.lemma"),
+        )
+        .unwrap();
+
+    // Before boundary: finance v1 type (eur only). 10 eur * 2 = 20.00 eur.
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 3, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "doubled",
+        "20.00 eur",
+    );
+
+    // After boundary: finance v2 type (eur + usd). 10 eur * 2 = 20.00 eur.
+    // This must use v2's type — if temporal slicing worked, this slice would
+    // resolve finance at 2025-07-01 and get the eur+usd version.
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "doubled",
+        "20.00 eur",
+    );
+
+    // The definitive check: after the boundary, `usd` must be a valid unit
+    // because finance v2 defines it. If temporal slicing is broken, this will
+    // fail with "unknown unit 'usd'" because the single slice resolved
+    // finance v1 (which only has eur).
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 usd")],
+        ),
+        "doubled",
+        "20.00 usd",
+    );
+}
+
+/// Same scenario but the consumer spec is unranged (no effective_from).
+/// The type-only dependency should still produce slices based on finance's
+/// version boundary.
+#[test]
+fn unranged_spec_with_type_only_dep_must_slice() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec units
+type weight: scale
+ -> unit kg 1.00
+ -> decimals 1
+
+spec units 2025-06-01
+type weight: scale
+ -> unit kg 1.00
+ -> unit lb 2.205
+ -> decimals 1
+"#,
+            lemma::SourceType::Labeled("units.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .load(
+            r#"
+spec warehouse
+type weight from units
+fact item_weight: [weight]
+rule heavy: item_weight > 100.0 kg
+"#,
+            lemma::SourceType::Labeled("warehouse.lemma"),
+        )
+        .unwrap();
+
+    // Before boundary: only kg is available
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "warehouse",
+            &date(2025, 3, 1),
+            vec![("item_weight", "150.0 kg")],
+        ),
+        "heavy",
+        "true",
+    );
+
+    // After boundary: lb must also be available (units v2 adds it).
+    // If slicing is broken, this fails with "unknown unit 'lb'".
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "warehouse",
+            &date(2025, 9, 1),
+            vec![("item_weight", "250.0 lb")],
+        ),
+        "heavy",
+        "true",
+    );
+}
+
+/// The plan hashes for the consumer spec must differ across slices when the
+/// type-only dependency changes, proving that separate plans were built.
+#[test]
+fn type_only_dep_produces_distinct_plan_hashes_per_slice() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec types_lib
+type score: number -> minimum 0 -> maximum 100
+
+spec types_lib 2025-06-01
+type score: number -> minimum 0 -> maximum 1000
+"#,
+            lemma::SourceType::Labeled("types_lib.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .load(
+            r#"
+spec grader 2025-01-01
+type score from types_lib
+fact student_score: [score]
+rule passed: student_score >= 50
+"#,
+            lemma::SourceType::Labeled("grader.lemma"),
+        )
+        .unwrap();
+
+    let hash_before = engine
+        .get_plan_hash("grader", &date(2025, 3, 1))
+        .ok()
+        .flatten()
+        .expect("grader should have a plan hash before boundary");
+
+    let hash_after = engine
+        .get_plan_hash("grader", &date(2025, 9, 1))
+        .ok()
+        .flatten()
+        .expect("grader should have a plan hash after boundary");
+
+    assert_ne!(
+        hash_before, hash_after,
+        "plan hashes must differ across slices when the type-only dependency changes \
+         (maximum changed from 100 to 1000). Got same hash: {}",
+        hash_before
+    );
+}
+
+/// Hash-pinned type import must NOT create slice boundaries.
+/// The consumer should get exactly one plan hash regardless of dep versions.
+#[test]
+fn hash_pinned_type_import_does_not_create_slices() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    let finance_hash = engine
+        .get_plan_hash("finance", &date(2025, 3, 1))
+        .ok()
+        .flatten()
+        .expect("finance should have a plan hash")
+        .to_string();
+
+    let consumer_src = format!(
+        "spec shop 2025-01-01\ntype money from finance~{}\nfact price: [money]\nrule doubled: price * 2",
+        finance_hash
+    );
+    engine
+        .load(&consumer_src, lemma::SourceType::Labeled("shop.lemma"))
+        .unwrap();
+
+    let hash_before = engine
+        .get_plan_hash("shop", &date(2025, 3, 1))
+        .ok()
+        .flatten()
+        .expect("shop should have a plan hash before boundary");
+
+    let hash_after = engine
+        .get_plan_hash("shop", &date(2025, 9, 1))
+        .ok()
+        .flatten()
+        .expect("shop should have a plan hash after boundary");
+
+    assert_eq!(
+        hash_before, hash_after,
+        "hash-pinned type import must NOT create slice boundaries; hashes should be identical"
+    );
+}
+
+/// Mixed scenario: consumer has both a fact-level spec ref and a type import
+/// to the same dependency. Consumer needs separate temporal versions to satisfy
+/// the cross-spec interface contract (dep's interface changes between slices).
+#[test]
+fn mixed_spec_ref_and_type_import_to_same_dep() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .load(
+            r#"
+spec shop 2025-01-01
+type money from finance
+fact ref: spec finance
+fact price: [money]
+rule total: ref.base_price + price
+
+spec shop 2025-07-01
+type money from finance
+fact ref: spec finance
+fact price: [money]
+rule total: ref.base_price + price
+"#,
+            lemma::SourceType::Labeled("shop.lemma"),
+        )
+        .unwrap();
+
+    // Before boundary: finance v1, base_price=50, only eur
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 3, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "total",
+        "60.00 eur",
+    );
+
+    // After boundary: finance v2, base_price=75, eur+usd available
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "total",
+        "85.00 eur",
+    );
+
+    // After boundary: usd must be available from the type import
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 usd")],
+        ),
+        "total",
+        "84.09 eur",
+    );
+}
+
+/// Inline type import (`fact price: [money from finance]`) must also produce
+/// temporal slices when the source spec has multiple versions.
+#[test]
+fn inline_type_import_creates_temporal_slices() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .load(
+            r#"
+spec shop 2025-01-01
+fact price: [money from finance]
+rule doubled: price * 2
+"#,
+            lemma::SourceType::Labeled("shop.lemma"),
+        )
+        .unwrap();
+
+    // Before boundary: finance v1 (eur only)
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 3, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "doubled",
+        "20.00 eur",
+    );
+
+    // After boundary: finance v2, usd must be available
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 usd")],
+        ),
+        "doubled",
+        "20.00 usd",
+    );
+}
+
+/// Type import with explicit effective datetime pins resolution to that version.
+#[test]
+fn type_import_with_effective_datetime_pins_version() {
+    let mut engine = Engine::new();
+
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    // Pin the type import to a date before the v2 boundary;
+    // even when evaluated after 2025-07-01, only eur should be available
+    engine
+        .load(
+            r#"
+spec shop 2025-01-01
+type money from finance 2025-03-01
+fact price: [money]
+rule doubled: price * 2
+"#,
+            lemma::SourceType::Labeled("shop.lemma"),
+        )
+        .unwrap();
+
+    // Evaluate after the finance boundary — but the type import is pinned
+    // to 2025-03-01 which resolves finance v1 (eur only).
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 9, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "doubled",
+        "20.00 eur",
+    );
+}
+
+// ============================================================================
+// Hash pin + effective datetime validation
+// ============================================================================
+
+fn load_finance(engine: &mut Engine) -> String {
+    engine
+        .load(
+            r#"
+spec finance
+type money: scale
+ -> unit eur 1.00
+ -> decimals 2
+fact base_price: 50.00 eur
+
+spec finance 2025-07-01
+type money: scale
+ -> unit eur 1.00
+ -> unit usd 1.10
+ -> decimals 2
+fact base_price: 75.00 eur
+"#,
+            lemma::SourceType::Labeled("finance.lemma"),
+        )
+        .unwrap();
+
+    engine
+        .get_plan_hash("finance", &date(2025, 3, 1))
+        .ok()
+        .flatten()
+        .expect("finance v1 should have a plan hash")
+        .to_string()
+}
+
+/// Hash-pinned type import with effective IN the pinned version's range succeeds.
+#[test]
+fn type_import_hash_pin_with_effective_in_range_succeeds() {
+    let mut engine = Engine::new();
+    let hash = load_finance(&mut engine);
+
+    let consumer_src = format!(
+        "spec shop 2025-01-01\ntype money from finance~{} 2025-03-01\nfact price: [money]\nrule doubled: price * 2",
+        hash
+    );
+    engine
+        .load(&consumer_src, lemma::SourceType::Labeled("shop.lemma"))
+        .unwrap();
+
+    assert_rule_value(
+        &eval_with(
+            &engine,
+            "shop",
+            &date(2025, 3, 1),
+            vec![("price", "10.00 eur")],
+        ),
+        "doubled",
+        "20.00 eur",
+    );
+}
+
+fn assert_load_fails_with(engine: &mut Engine, src: &str, expected_substr: &str) {
+    let result = engine.load(src, lemma::SourceType::Labeled("shop.lemma"));
+    assert!(
+        result.is_err(),
+        "should fail with error containing '{}'",
+        expected_substr
+    );
+    let msgs: Vec<String> = result
+        .unwrap_err()
+        .errors
+        .iter()
+        .map(|e| format!("{:?}", e))
+        .collect();
+    let combined = msgs.join(" ");
+    assert!(
+        combined.contains(expected_substr),
+        "expected error containing '{}', got: {}",
+        expected_substr,
+        combined
+    );
+}
+
+/// Hash-pinned type import with effective OUTSIDE the pinned version's range is a hard error.
+#[test]
+fn type_import_hash_pin_with_effective_out_of_range_fails() {
+    let mut engine = Engine::new();
+    let hash = load_finance(&mut engine);
+
+    let consumer_src = format!(
+        "spec shop 2025-01-01\ntype money from finance~{} 2099-01-01\nfact price: [money]\nrule doubled: price * 2",
+        hash
+    );
+    assert_load_fails_with(&mut engine, &consumer_src, "outside the temporal range");
+}
+
+/// Fact-level spec ref with hash pin + out-of-range effective is a hard error.
+#[test]
+fn fact_spec_ref_hash_pin_with_effective_out_of_range_fails() {
+    let mut engine = Engine::new();
+    let hash = load_finance(&mut engine);
+
+    let consumer_src = format!(
+        "spec shop 2025-01-01\nfact ref: spec finance~{} 2099-01-01\nrule x: ref.base_price",
+        hash
+    );
+    assert_load_fails_with(&mut engine, &consumer_src, "outside the temporal range");
+}
+
+/// Inline type import with hash pin + out-of-range effective is a hard error.
+#[test]
+fn inline_type_import_hash_pin_with_effective_out_of_range_fails() {
+    let mut engine = Engine::new();
+    let hash = load_finance(&mut engine);
+
+    let consumer_src = format!(
+        "spec shop 2025-01-01\nfact price: [money from finance~{} 2099-01-01]\nrule doubled: price * 2",
+        hash
+    );
+    assert_load_fails_with(&mut engine, &consumer_src, "outside the temporal range");
+}

--- a/engine/tests/validator_type_checking.rs
+++ b/engine/tests/validator_type_checking.rs
@@ -51,7 +51,7 @@ fn test_text_number_comparison_allowed() {
 spec test
 fact name: "Alice"
 fact age: 30
-rule check: name == "Bob" and age > 25
+rule check: name is "Bob" and age > 25
 "#;
 
     let mut engine = Engine::new();
@@ -198,7 +198,7 @@ spec test
 fact x: 5
 fact y: 10
 rule check: x < y
-  unless x == 0 then y > 0
+  unless x is 0 then y > 0
 "#;
 
     let mut engine = Engine::new();
@@ -217,7 +217,7 @@ spec test
 fact a: 10
 fact b: 20
 rule sum: a + b
-  unless a == 0 then 0
+  unless a is 0 then 0
 "#;
 
     let mut engine = Engine::new();
@@ -237,7 +237,7 @@ fact x: 5
 rule value: 10
   unless x < 0 then 0
   unless x > 100 then 100
-  unless x == 5 then 5
+  unless x is 5 then 5
 "#;
 
     let mut engine = Engine::new();

--- a/engine/tests/veto.rs
+++ b/engine/tests/veto.rs
@@ -203,7 +203,7 @@ fact country: "US"
 fact has_license: false
 rule can_drive: age >= 16
     unless age < 16 then veto "Too young to drive"
-    unless country != "US" then false
+    unless country is not "US" then false
     unless not has_license then false
 "#;
 
@@ -417,8 +417,8 @@ fn test_veto_with_string_equality() {
     let code = r#"
 spec status_check
 fact status: "cancelled"
-rule is_active: status == "active"
-    unless status == "cancelled" then veto "Cannot process cancelled items"
+rule is_active: status is "active"
+    unless status is "cancelled" then veto "Cannot process cancelled items"
 "#;
 
     let mut engine = Engine::new();
@@ -502,7 +502,7 @@ fn test_veto_with_empty_string_message() {
 spec edge_case
 fact value: 0
 rule is_valid: value > 0
-    unless value == 0 then veto ""
+    unless value is 0 then veto ""
 "#;
 
     let mut engine = Engine::new();
@@ -564,7 +564,7 @@ fn test_veto_with_very_long_message() {
 spec long_message
 fact value: 0
 rule valid: value > 0
-    unless value == 0 then veto "{}"
+    unless value is 0 then veto "{}"
 "#,
         message
     );
@@ -597,7 +597,7 @@ spec priority_test
 fact value: 5
 rule check: value > 10
     unless value < 10 then veto "Value too small"
-    unless value != 5 then false
+    unless value is not 5 then false
 "#;
 
     let mut engine = Engine::new();

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774840424,
+        "narHash": "sha256-3Oi4mBKzOCFQYLUyEjyc0s5cnlNj1MzmhpVKoLptpe8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d9f52b51548e76ab8b6e7d647763047ebdec835c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Lemma — dev shell (Rust, Node/npm, Elixir)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, rust-overlay, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              rustToolchain
+              pkgs.cargo-nextest
+              pkgs.cargo-deny
+              pkgs.wasm-pack
+              pkgs.nodejs_24
+              pkgs.elixir
+              pkgs.pkg-config
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+
+            shellHook = ''
+              export LC_ALL=en_US.UTF-8
+            '';
+          };
+        }
+      );
+
+      formatter = forSystems (system: nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
+    };
+}

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.9", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.10", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.92.0"
 components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]

--- a/xtask/src/versions_diff.rs
+++ b/xtask/src/versions_diff.rs
@@ -22,7 +22,7 @@ pub(crate) fn parse_cli_v_version(tag: &str) -> Option<Version> {
 
 fn git_fetch_tags(root: &Path) -> Result<(), String> {
     let o = Command::new("git")
-        .args(["fetch", "--tags", "--quiet"])
+        .args(["fetch", "--tags", "--quiet", "-f"])
         .current_dir(root)
         .output()
         .map_err(|e| format!("failed to run git fetch --tags: {e}"))?;


### PR DESCRIPTION
### Added

- Nix flake dev shell (Rust from `rust-toolchain.toml`, cargo-nextest, cargo-deny, wasm-pack, Node 24, Elixir, nixpkgs-fmt formatter) plus `flake.lock`.
- `rust-toolchain.toml`: `wasm32-unknown-unknown` target.
- Test cases for temporal type imports.
- `ExecutionPlan.sources`: keyed `SpecSources` map (`IndexMap<(name, effective_from), source>`) with AST-reconstructed canonical source for every spec in the plan. Custom serde serializes as `[{name, effective_from, source}]` for downstream consumers.

### Changed

- CLI: workspace or `.lemma` file is a positional argument (`run`/`schema`/`get [source] [spec]…`, `list`/`server`/`mcp [source]`); `-d`/`--dir` removed. Spec auto-selected when the source defines exactly one spec; multiple specs without a name yield an error listing names (or use `-i`). Lemma source from filesystem only; positional `-` is rejected (not a valid path).
- Planning: `FactData::SpecRef.resolved_plan_hash` is a required `String`; fingerprints always build `SpecId` from it (no optional fallback to bare spec name).
- Graph / types: missing plan hash on type-import or spec-reference binding yields validation errors instead of `unreachable!` when a dependency spec failed validation or is absent from the hash registry.
- `build_graph` test helper pre-plans dependency specs so `PlanHashRegistry` matches topological `plan()` behavior.
- `.gitignore`: `result` / `result-*` (Nix build outputs).
- Fixes for temporal type imports, to properly pin and resolve them.
- Fix for docker image building in CI.
- Formatter cleanup: deterministic output improvements.
- Deterministic fingerprinting on semantics.
- Type resolver: rename contributing-spec registration to `register_dependency_specs` to clarify scope.

### Removed

- `==` / `!=` syntax (use `=` and `!=` was already removed).
- Raw source text from operation records and expression evaluation (replaced by plan-level `sources`).