### PR TITLE
fix(mcp): resolve protocol violations and handshake issues

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -527,7 +527,7 @@ fn mcp_command(source: &Path, admin: bool) -> Result<()> {
 
     let config = mcp::McpConfig { admin };
 
-    println!(
+    eprintln!(
         "Starting MCP server with {} spec(s) loaded",
         engine.list_specs().len()
     );

--- a/cli/src/mcp/server.rs
+++ b/cli/src/mcp/server.rs
@@ -1,891 +1,735 @@
-mod imp {
-    use anyhow::Result;
+pub mod http {
+    use crate::response;
+    use axum::{
+        extract::{Form, Path, Query, State},
+        http::{HeaderMap, HeaderValue, StatusCode},
+        response::{Html, IntoResponse, Json},
+        routing::get,
+        Router,
+    };
     use lemma::parsing::ast::DateTimeValue;
     use lemma::Engine;
-    use serde::{Deserialize, Serialize};
-    use std::io::{self, BufRead, Write};
-    use tracing::{debug, error, info};
+    use serde::Deserialize;
 
-    const PROTOCOL_VERSION: &str = "2024-11-05";
-    const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower_http::cors::CorsLayer;
+    use tracing::{error, info, warn};
 
-    #[derive(Debug, Deserialize)]
-    struct McpRequest {
-        jsonrpc: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        id: Option<serde_json::Value>,
-        method: String,
-        #[serde(default)]
-        params: Option<serde_json::Value>,
+    type SharedEngine = Arc<RwLock<Engine>>;
+
+    fn parse_spec_path(path: &str) -> String {
+        path.trim_matches('/').to_string()
     }
 
-    #[derive(Debug, Serialize)]
-    struct McpResponse {
-        jsonrpc: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        id: Option<serde_json::Value>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        result: Option<serde_json::Value>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        error: Option<McpError>,
+    /// Read Accept-Datetime (RFC 7089) from headers; fallback to now.
+    fn accept_datetime_from_headers(
+        headers: &HeaderMap,
+    ) -> Result<DateTimeValue, (StatusCode, Json<ErrorResponse>)> {
+        let raw = headers
+            .get("Accept-Datetime")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.trim());
+        resolve_effective(raw)
     }
 
-    #[derive(Debug, Serialize)]
-    struct McpError {
-        code: i32,
-        message: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        data: Option<serde_json::Value>,
+    #[derive(Deserialize, Default)]
+    struct EffectiveQuery {
+        effective: Option<String>,
     }
 
-    impl McpError {
-        fn parse_error(message: String) -> Self {
-            Self {
-                code: -32700,
-                message,
-                data: None,
-            }
-        }
-
-        fn invalid_request(message: String) -> Self {
-            Self {
-                code: -32600,
-                message,
-                data: None,
-            }
-        }
-
-        fn method_not_found(method: String) -> Self {
-            Self {
-                code: -32601,
-                message: format!("Method not found: {method}"),
-                data: None,
-            }
-        }
-
-        fn invalid_params(message: String) -> Self {
-            Self {
-                code: -32602,
-                message,
-                data: None,
-            }
-        }
-
-        fn internal_error(message: String) -> Self {
-            Self {
-                code: -32603,
-                message,
-                data: None,
-            }
-        }
+    #[derive(Deserialize, Default)]
+    struct SpecQuery {
+        rules: Option<String>,
     }
 
-    fn resolve_effective(args: &serde_json::Value) -> Result<DateTimeValue, McpError> {
-        match args.get("effective").and_then(|v| v.as_str()) {
-            Some(s) if !s.trim().is_empty() => s.trim().parse::<DateTimeValue>().ok().ok_or_else(|| {
-                McpError::invalid_params(format!(
-                    "Invalid effective value '{}'. Expected: YYYY, YYYY-MM, YYYY-MM-DD, or ISO 8601 datetime",
-                    s
-                ))
+    fn resolve_effective(
+        raw: Option<&str>,
+    ) -> Result<DateTimeValue, (StatusCode, Json<ErrorResponse>)> {
+        match raw {
+            Some(s) => s.parse::<DateTimeValue>().ok().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!("Invalid effective value '{}'. Expected: YYYY, YYYY-MM, YYYY-MM-DD, or ISO 8601 datetime", s),
+                    }),
+                )
             }),
-            _ => Ok(DateTimeValue::now()),
+            None => Ok(DateTimeValue::now()),
         }
     }
 
-    /// Configuration for the MCP server.
-    #[derive(Default)]
-    pub struct McpConfig {
-        /// When true, admin tools (`add_spec`, `get_spec_source`) are
-        /// advertised and allowed. When false (default), the server is read-only.
-        pub admin: bool,
+    #[derive(Clone)]
+    struct AppState {
+        engine: SharedEngine,
+        explanations_enabled: bool,
     }
 
-    struct McpServer {
+    #[derive(Debug, serde::Serialize)]
+    struct ErrorResponse {
+        error: String,
+    }
+
+    #[derive(serde::Serialize)]
+    struct GetSpecResponse {
+        spec_id: String,
+        effective_from: Option<String>,
+        hash: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        facts: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rules: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        meta: Option<serde_json::Value>,
+        versions: Vec<VersionEntry>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct VersionEntry {
+        effective_from: Option<String>,
+        hash: String,
+    }
+
+    /// Build ETag, Memento-Datetime, Vary for the resolved spec.
+    fn spec_response_headers(
+        _spec_name: &String,
+        effective_from: Option<&DateTimeValue>,
+        hash: &String,
+    ) -> Vec<(axum::http::header::HeaderName, HeaderValue)> {
+        let mut h = Vec::new();
+        if let Ok(v) = HeaderValue::from_str(&format!("\"{}\"", hash)) {
+            h.push((axum::http::header::ETAG, v));
+        }
+        if let Some(af) = effective_from {
+            if let Ok(v) = HeaderValue::from_str(&af.to_string()) {
+                h.push((
+                    axum::http::header::HeaderName::from_static("memento-datetime"),
+                    v,
+                ));
+            }
+        }
+        h.push((
+            axum::http::header::VARY,
+            HeaderValue::from_static("Accept-Datetime"),
+        ));
+        h
+    }
+
+    /// Start the Lemma HTTP server.
+    ///
+    ///         The server auto-generates typed REST endpoints for each loaded spec:
+    /// - `GET /{spec}/{rules?}` — evaluate rules (all if rules omitted), facts as query params
+    /// - `POST /{spec}/{rules?}` — evaluate rules (all if rules omitted), facts as JSON body
+    ///
+    /// Meta routes:
+    /// - `GET /` — list all specs
+    /// - `GET /health` — health check
+    /// - `GET /openapi.json` — OpenAPI 3.1 specification
+    /// - `GET /docs` — Scalar interactive documentation
+    pub async fn start_server(
         engine: Engine,
-        config: McpConfig,
-    }
-
-    impl McpServer {
-        fn new(engine: Engine, config: McpConfig) -> Self {
-            Self { engine, config }
-        }
-
-        fn handle_request(&mut self, request: McpRequest) -> McpResponse {
-            debug!("Handling request: method={}", request.method);
-
-            if request.jsonrpc != "2.0" {
-                return McpResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: None,
-                    error: Some(McpError::invalid_request(
-                        "Invalid JSON-RPC version, expected '2.0'".to_string(),
-                    )),
-                };
-            }
-
-            let result = match request.method.as_str() {
-                "initialize" => self.initialize(),
-                "tools/list" => self.list_tools(),
-                "tools/call" => self.call_tool(request.params),
-                _ => Err(McpError::method_not_found(request.method)),
-            };
-
-            match result {
-                Ok(result) => McpResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: Some(result),
-                    error: None,
-                },
-                Err(error) => McpResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: None,
-                    error: Some(error),
-                },
-            }
-        }
-
-        fn initialize(&self) -> Result<serde_json::Value, McpError> {
-            info!("Initializing MCP server");
-            Ok(serde_json::json!({
-                "protocolVersion": PROTOCOL_VERSION,
-                "serverInfo": {
-                    "name": "lemma-mcp-server",
-                    "version": SERVER_VERSION
-                },
-                "capabilities": {
-                    "tools": {}
-                }
-            }))
-        }
-
-        fn list_tools(&self) -> Result<serde_json::Value, McpError> {
-            debug!("Listing tools");
-
-            let mut tools = vec![
-                serde_json::json!({
-                    "name": "evaluate",
-                "description": "Evaluate rules in a Lemma spec. Returns the result and a step-by-step reasoning trace showing which facts were used and which conditions matched. Omit 'rule' to evaluate all rules.",
-                            "inputSchema": {
-                                "type": "object",
-                                "properties": {
-                                    "spec": {
-                                        "type": "string",
-                                        "description": "Spec id: name or name~hash (8 hex) to pin content, e.g. pricing or pricing~a1b2c3d4"
-                            },
-                            "rule": {
-                                "type": "string",
-                                "description": "Optional: name of a specific rule to evaluate. Omit to evaluate all rules."
-                            },
-                            "facts": {
-                                "type": "array",
-                                "items": { "type": "string" },
-                                "description": "Optional fact values as 'name=value' (e.g. ['price=100', 'quantity=5'])",
-                                "default": []
-                            },
-                            "effective": {
-                                "type": "string",
-                                "description": "Optional: evaluate at a specific effective datetime (e.g. '2026', '2026-03', '2026-03-04', '2026-03-04T10:30:00Z')"
-                            }
-                        },
-                        "required": ["spec"]
-                    }
-                }),
-                serde_json::json!({
-                    "name": "list_specs",
-                    "description": "List all loaded Lemma specs with their schemas: fact names, types, defaults, and rule names with return types.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "effective": {
-                                "type": "string",
-                                "description": "Optional: list specs at a specific effective datetime (e.g. '2026', '2026-03-04')"
-                            }
-                        }
-                    }
-                }),
-                serde_json::json!({
-                    "name": "get_schema",
-                "description": "Get a spec's schema: its facts (inputs with types, constraints, and defaults) and rules (outputs with types). Optionally scope to a specific rule to see only the facts it needs. Use this before calling evaluate to know which facts to provide.",
-                            "inputSchema": {
-                                "type": "object",
-                                "properties": {
-                                    "spec": {
-                                        "type": "string",
-                                        "description": "Spec id: name or name~hash (8 hex), e.g. pricing or pricing~a1b2c3d4"
-                                    },
-                                    "rule": {
-                                        "type": "string",
-                                        "description": "Optional: name of a specific rule. Omit to get the full spec schema."
-                                    },
-                            "effective": {
-                                "type": "string",
-                                "description": "Optional: get schema at a specific effective datetime"
-                            }
-                        },
-                        "required": ["spec"]
-                    }
-                }),
-            ];
-
-            if self.config.admin {
-                tools.push(serde_json::json!({
-                    "name": "add_spec",
-                    "description": "Add a Lemma spec to the engine. Returns the spec schema on success.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "code": {
-                                "type": "string",
-                                "description": "The complete Lemma code to add"
-                            },
-                            "source_id": {
-                                "type": "string",
-                                "description": "Optional identifier for this spec source"
-                            }
-                        },
-                        "required": ["code"]
-                    }
-                }));
-                tools.push(serde_json::json!({
-                    "name": "get_spec_source",
-"description": "Return the Lemma source code for a spec. Useful for inspecting or debugging the rules that produce evaluation results.",
-                            "inputSchema": {
-                                "type": "object",
-                                "properties": {
-                                    "spec": {
-                                        "type": "string",
-                                        "description": "Name of the spec"
-                                    },
-                            "effective": {
-                                "type": "string",
-                                "description": "Optional: get source at a specific effective datetime"
-                            }
-                        },
-                        "required": ["spec"]
-                    }
-                }));
-            }
-
-            Ok(serde_json::json!({ "tools": tools }))
-        }
-
-        fn call_tool(
-            &mut self,
-            params: Option<serde_json::Value>,
-        ) -> Result<serde_json::Value, McpError> {
-            let params =
-                params.ok_or_else(|| McpError::invalid_params("Missing params".to_string()))?;
-
-            let tool_name = params["name"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing tool name".to_string()))?;
-
-            let arguments = params
-                .get("arguments")
-                .ok_or_else(|| McpError::invalid_params("Missing arguments".to_string()))?;
-
-            debug!("Calling tool: {}", tool_name);
-
-            match tool_name {
-                "add_spec" | "get_spec_source" if !self.config.admin => {
-                    Err(McpError::invalid_params(
-                        "Admin tools are disabled. Start the server with --admin to enable them."
-                            .to_string(),
-                    ))
-                }
-                "add_spec" => self.tool_add_spec(arguments),
-                "get_spec_source" => self.tool_get_spec_source(arguments),
-                "evaluate" => self.tool_evaluate(arguments),
-                "list_specs" => self.tool_list_specs(arguments),
-                "get_schema" => self.tool_get_schema(arguments),
-                _ => Err(McpError::invalid_params(format!(
-                    "Unknown tool: {}",
-                    tool_name
-                ))),
-            }
-        }
-
-        fn tool_add_spec(
-            &mut self,
-            args: &serde_json::Value,
-        ) -> Result<serde_json::Value, McpError> {
-            let code = args["code"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing 'code' field".to_string()))?;
-
-            if code.trim().is_empty() {
-                return Err(McpError::invalid_params(
-                    "Spec code cannot be empty".to_string(),
-                ));
-            }
-
-            let source_id = args["source_id"]
-                .as_str()
-                .map(String::from)
-                .unwrap_or_else(|| format!("spec_{}", chrono::Utc::now().timestamp_millis()));
-
-            let names_before: std::collections::HashSet<String> = self
-                .engine
-                .list_specs()
-                .iter()
-                .map(|d| d.name.clone())
-                .collect();
-
-            self.engine
-                .load(code, lemma::SourceType::Labeled(&source_id))
-                .map_err(|load_err| {
-                    for e in load_err.iter() {
-                        error!(
-                            "{}",
-                            crate::error_formatter::format_error(e, &load_err.sources)
-                        );
-                    }
-                    McpError::internal_error(format!(
-                        "Failed to parse spec ({} error(s))",
-                        load_err.errors.len()
-                    ))
-                })?;
-
-            let new_spec_names: Vec<String> = self
-                .engine
-                .list_specs()
-                .iter()
-                .filter(|d| !names_before.contains(&d.name))
-                .map(|d| d.name.clone())
-                .collect();
-
-            let mut output = String::from("Spec added successfully.\n\n");
-
-            let now = DateTimeValue::now();
-            for spec_name in &new_spec_names {
-                if let Ok(plan) = self.engine.get_plan(spec_name, Some(&now)) {
-                    output.push_str(&plan.schema().to_string());
-                    output.push('\n');
-                }
-            }
-
-            info!(
-                "Spec added from source '{}': {:?}",
-                source_id, new_spec_names
-            );
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            }))
-        }
-
-        fn tool_get_spec_source(
-            &self,
-            args: &serde_json::Value,
-        ) -> Result<serde_json::Value, McpError> {
-            let spec_name = args["spec"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing 'spec' field".to_string()))?;
-
-            let now = resolve_effective(args)?;
-            let spec = self.engine.get_spec(spec_name, Some(&now)).map_err(|e| {
-                McpError::invalid_params(format!(
-                    "Spec '{}' not found: {}. Use list_specs to see available specs.",
-                    spec_name, e
-                ))
-            })?;
-
-            let source = lemma::format_specs(std::slice::from_ref(spec.as_ref()));
-
-            debug!("Returned source for spec '{}'", spec_name);
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": source
-                }]
-            }))
-        }
-
-        fn tool_evaluate(
-            &mut self,
-            args: &serde_json::Value,
-        ) -> Result<serde_json::Value, McpError> {
-            let spec_id = args["spec"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing 'spec' field".to_string()))?;
-
-            if spec_id.trim().is_empty() {
-                return Err(McpError::invalid_params(
-                    "Spec id cannot be empty".to_string(),
-                ));
-            }
-
-            let (_base_name, _) = lemma::parse_spec_id(spec_id.trim())
-                .map_err(|e| McpError::invalid_params(format!("{}", e)))?;
-
-            let rule_names: Vec<String> = match args.get("rule").and_then(|v| v.as_str()) {
-                Some(rule) if !rule.trim().is_empty() => vec![rule.trim().to_string()],
-                _ => Vec::new(),
-            };
-
-            let facts: Vec<&str> = args["facts"]
-                .as_array()
-                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
-                .unwrap_or_default();
-
-            let fact_values: std::collections::HashMap<String, String> = facts
-                .iter()
-                .filter_map(|s| {
-                    s.split_once('=')
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
-                })
-                .collect();
-
-            let now = resolve_effective(args)?;
-            let mut response = self
-                .engine
-                .run(spec_id.trim(), Some(&now), fact_values, false)
-                .map_err(|e| {
-                    error!("Evaluation failed: {}", e);
-                    McpError::internal_error(format!("Evaluation failed: {e}"))
-                })?;
-            if !rule_names.is_empty() {
-                response.filter_rules(&rule_names);
-            }
-
-            let hash = self
-                .engine
-                .get_plan(spec_id.trim(), Some(&now))
-                .map_err(|e| {
-                    McpError::internal_error(format!("BUG: run succeeded but get_plan failed: {e}"))
-                })?
-                .plan_hash();
-
-            let mut output = String::new();
-            output.push_str(&format!("spec: {}\n", spec_id.trim()));
-            output.push_str(&format!("effective: {}\n", now));
-            output.push_str(&format!("hash: {}\n", hash));
-            output.push('\n');
-
-            for result in response.results.values() {
-                output.push_str(&format!("{}: ", result.rule.name));
-                match &result.result {
-                    lemma::OperationResult::Value(value) => {
-                        output.push_str(&value.to_string());
-                    }
-                    lemma::OperationResult::Veto(msg) => {
-                        if let Some(veto) = msg {
-                            output.push_str(&format!("veto ({})", veto));
-                        } else {
-                            output.push_str("veto");
-                        }
-                    }
-                }
-                output.push('\n');
-
-                if let Some(explanation) = &result.explanation {
-                    let steps = format_explanation_steps(explanation);
-                    if !steps.is_empty() {
-                        output.push_str("\nReasoning:\n");
-                        output.push_str(&steps);
-                        output.push('\n');
-                    }
-                }
-            }
-
-            info!(
-                "Evaluated spec '{}' with {} results",
-                spec_id.trim(),
-                response.results.len()
-            );
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            }))
-        }
-
-        fn tool_list_specs(&self, args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
-            let now = resolve_effective(args)?;
-            let specs_list = self.engine.list_specs_effective(&now);
-
-            let output = if specs_list.is_empty() {
-                if self.config.admin {
-                    "No specs loaded.\n\nUse the 'add_spec' tool to load Lemma code.".to_string()
-                } else {
-                    "No specs loaded.".to_string()
-                }
-            } else {
-                let schemas: Vec<lemma::SpecSchema> = specs_list
-                    .iter()
-                    .filter_map(|s| self.engine.schema(&s.name, Some(&now)).ok())
-                    .collect();
-
-                schemas
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n\n")
-            };
-
-            debug!("Listed {} specs", specs_list.len());
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            }))
-        }
-
-        fn tool_get_schema(&self, args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
-            let spec_id = args["spec"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing 'spec' field".to_string()))?;
-
-            if spec_id.trim().is_empty() {
-                return Err(McpError::invalid_params(
-                    "Spec id cannot be empty".to_string(),
-                ));
-            }
-
-            lemma::parse_spec_id(spec_id.trim())
-                .map_err(|e| McpError::invalid_params(format!("{}", e)))?;
-
-            let now = resolve_effective(args)?;
-            let plan = self
-                .engine
-                .get_plan(spec_id.trim(), Some(&now))
-                .map_err(|_| {
-                    McpError::invalid_params(format!(
-                        "Spec '{}' not found. Use list_specs to see available specs.",
-                        spec_id.trim()
-                    ))
-                })?;
-
-            let rule_names: Vec<String> = match args.get("rule").and_then(|v| v.as_str()) {
-                Some(rule) if !rule.trim().is_empty() => vec![rule.trim().to_string()],
-                _ => Vec::new(),
-            };
-
-            let schema = if rule_names.is_empty() {
-                plan.schema()
-            } else {
-                plan.schema_for_rules(&rule_names).map_err(|e| {
-                    error!("schema_for_rules failed: {}", e);
-                    McpError::internal_error(format!("Failed to get schema for rules: {e}"))
-                })?
-            };
-
-            let scope = if rule_names.is_empty() {
-                format!("{} (all rules)", spec_id.trim())
-            } else {
-                format!("{}.{}", spec_id.trim(), rule_names[0])
-            };
-
-            let output = format!("Schema for {}:\n\n{}", scope, schema);
-
-            info!(
-                "Returned schema for '{}' ({} facts, {} rules)",
-                scope,
-                schema.facts.len(),
-                schema.rules.len()
-            );
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            }))
-        }
-    }
-
-    // ── Explanation formatting ─────────────────────────────────────────────
-
-    /// Linearise an explanation tree into plain-English reasoning steps.
-    fn format_explanation_steps(explanation: &lemma::explanation::Explanation) -> String {
-        let mut steps = Vec::new();
-        let mut seen_facts = std::collections::HashSet::new();
-        let mut seen_rules = std::collections::HashSet::new();
-        walk_explanation_node(
-            &explanation.tree,
-            &mut steps,
-            &mut seen_facts,
-            &mut seen_rules,
-        );
-        steps.join("\n")
-    }
-
-    fn walk_explanation_node(
-        node: &lemma::explanation::ExplanationNode,
-        steps: &mut Vec<String>,
-        seen_facts: &mut std::collections::HashSet<String>,
-        seen_rules: &mut std::collections::HashSet<String>,
-    ) {
-        use lemma::explanation::{ExplanationNode, ValueSource};
-
-        match node {
-            ExplanationNode::Value {
-                value,
-                source: ValueSource::Fact { fact_ref },
-                ..
-            } => {
-                let key = fact_ref.to_string();
-                if seen_facts.insert(key.clone()) {
-                    steps.push(format!("{}: {}", key, value));
-                }
-            }
-
-            ExplanationNode::Value { .. } => {}
-
-            ExplanationNode::RuleReference {
-                rule_path,
-                result,
-                expansion,
-                ..
-            } => {
-                let key = rule_path.to_string();
-                if !seen_rules.insert(key) {
-                    return;
-                }
-                walk_explanation_node(expansion, steps, seen_facts, seen_rules);
-                match result {
-                    lemma::OperationResult::Value(v) => {
-                        steps.push(format!("{}: {}", rule_path.rule, v));
-                    }
-                    lemma::OperationResult::Veto(msg) => match msg {
-                        Some(reason) => {
-                            steps.push(format!("{}: veto ({})", rule_path.rule, reason));
-                        }
-                        None => {
-                            steps.push(format!("{}: veto", rule_path.rule));
-                        }
-                    },
-                }
-            }
-
-            ExplanationNode::Computation {
-                original_expression,
-                expression,
-                result,
-                operands,
-                ..
-            } => {
-                for op in operands {
-                    walk_explanation_node(op, steps, seen_facts, seen_rules);
-                }
-                let expr = if original_expression != expression && !original_expression.is_empty() {
-                    original_expression.as_str()
-                } else {
-                    expression.as_str()
-                };
-                steps.push(format!("{}: {}", expr, result));
-            }
-
-            ExplanationNode::Branches {
-                matched,
-                non_matched,
-                ..
-            } => {
-                // Collect facts from all branch conditions first
-                for branch in non_matched {
-                    collect_branch_facts(&branch.condition, steps, seen_facts);
-                }
-                if let Some(cond) = &matched.condition {
-                    collect_branch_facts(cond, steps, seen_facts);
-                }
-
-                // Emit non-matched branch decisions
-                for branch in non_matched {
-                    let cond_text = node_expression(&branch.condition);
-                    let clause = match branch.clause_index {
-                        Some(i) => format!("unless clause {}", i + 1),
-                        None => "default".to_string(),
-                    };
-                    steps.push(format!("{}: {} is false, skipped", clause, cond_text));
-                }
-
-                // Emit matched branch decision
-                if let Some(cond) = &matched.condition {
-                    let cond_text = node_expression(cond);
-                    let clause = match matched.clause_index {
-                        Some(i) => format!("unless clause {}", i + 1),
-                        None => "clause".to_string(),
-                    };
-                    steps.push(format!("{}: {} is true, matched", clause, cond_text));
-                } else {
-                    steps.push("default value applies".to_string());
-                }
-
-                // Walk the matched result
-                walk_explanation_node(&matched.result, steps, seen_facts, seen_rules);
-            }
-
-            ExplanationNode::Condition {
-                original_expression,
-                expression,
-                result,
-                operands,
-                ..
-            } => {
-                for op in operands {
-                    walk_explanation_node(op, steps, seen_facts, seen_rules);
-                }
-                let expr = if original_expression != expression && !original_expression.is_empty() {
-                    original_expression.as_str()
-                } else {
-                    expression.as_str()
-                };
-                let verdict = if *result { "true" } else { "false" };
-                steps.push(format!("{} is {}", expr, verdict));
-            }
-
-            ExplanationNode::Veto { message, .. } => match message {
-                Some(msg) => steps.push(format!("veto: {}", msg)),
-                None => steps.push("veto".to_string()),
-            },
-        }
-    }
-
-    /// Walk an explanation node collecting only fact values (no reasoning steps).
-    /// Used to gather facts from branch conditions before emitting branch decisions.
-    fn collect_branch_facts(
-        node: &lemma::explanation::ExplanationNode,
-        steps: &mut Vec<String>,
-        seen_facts: &mut std::collections::HashSet<String>,
-    ) {
-        use lemma::explanation::{ExplanationNode, ValueSource};
-
-        match node {
-            ExplanationNode::Value {
-                value,
-                source: ValueSource::Fact { fact_ref },
-                ..
-            } => {
-                let key = fact_ref.to_string();
-                if seen_facts.insert(key.clone()) {
-                    steps.push(format!("{}: {}", key, value));
-                }
-            }
-            ExplanationNode::Condition { operands, .. }
-            | ExplanationNode::Computation { operands, .. } => {
-                for op in operands {
-                    collect_branch_facts(op, steps, seen_facts);
-                }
-            }
-            ExplanationNode::RuleReference { expansion, .. } => {
-                collect_branch_facts(expansion, steps, seen_facts);
-            }
-            ExplanationNode::Branches {
-                matched,
-                non_matched,
-                ..
-            } => {
-                for b in non_matched {
-                    collect_branch_facts(&b.condition, steps, seen_facts);
-                }
-                if let Some(c) = &matched.condition {
-                    collect_branch_facts(c, steps, seen_facts);
-                }
-                collect_branch_facts(&matched.result, steps, seen_facts);
-            }
-            _ => {}
-        }
-    }
-
-    /// Extract the human-readable expression from any explanation node.
-    fn node_expression(node: &lemma::explanation::ExplanationNode) -> String {
-        use lemma::explanation::{ExplanationNode, ValueSource};
-
-        match node {
-            ExplanationNode::Condition {
-                original_expression,
-                expression,
-                ..
-            }
-            | ExplanationNode::Computation {
-                original_expression,
-                expression,
-                ..
-            } => {
-                if original_expression != expression && !original_expression.is_empty() {
-                    original_expression.clone()
-                } else {
-                    expression.clone()
-                }
-            }
-            ExplanationNode::RuleReference { rule_path, .. } => rule_path.rule.to_string(),
-            ExplanationNode::Value {
-                source: ValueSource::Fact { fact_ref },
-                ..
-            } => fact_ref.to_string(),
-            ExplanationNode::Value { value, .. } => value.to_string(),
-            ExplanationNode::Branches { .. } => "branch".to_string(),
-            ExplanationNode::Veto { message, .. } => {
-                message.clone().unwrap_or_else(|| "veto".to_string())
-            }
-        }
-    }
-
-    pub fn start_server(engine: Engine, config: McpConfig) -> Result<()> {
+        host: &str,
+        port: u16,
+        watch: bool,
+        explanations: bool,
+        workdir: PathBuf,
+    ) -> anyhow::Result<()> {
         tracing_subscriber::fmt()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "lemma_mcp=info".into()),
+                    .unwrap_or_else(|_| "lemma=info,tower_http=info".into()),
             )
-            .with_writer(io::stderr)
             .init();
 
-        info!("Starting Lemma MCP server v{}", SERVER_VERSION);
-        info!("Protocol version: {}", PROTOCOL_VERSION);
-        if config.admin {
-            info!("Admin mode enabled (--admin)");
-        } else {
-            info!("Read-only mode (default)");
+        let shared_engine: SharedEngine = Arc::new(RwLock::new(engine));
+
+        if watch {
+            start_file_watcher(shared_engine.clone(), workdir)?;
         }
 
-        let mut server = McpServer::new(engine, config);
-        let stdin = io::stdin();
-        let mut stdout = io::stdout();
+        let state = AppState {
+            engine: shared_engine,
+            explanations_enabled: explanations,
+        };
 
-        for line in stdin.lock().lines() {
-            let line = line?;
+        let app = Router::new()
+            .route("/", get(list_specs))
+            .route("/health", get(health_check))
+            .route("/openapi.json", get(openapi_spec))
+            .route("/docs", get(scalar_docs))
+            .route("/scalar.js", get(scalar_js))
+            .route("/schema/{spec_name}", get(schema_all_rules))
+            .route("/schema/{spec_name}/{rules}", get(schema_for_rules))
+            .route("/{*path}", get(spec_get_schema).post(spec_post_evaluate))
+            .fallback(fallback_404)
+            .layer(CorsLayer::permissive())
+            .with_state(state);
 
-            if line.trim().is_empty() {
-                continue;
-            }
+        let addr: SocketAddr = format!("{host}:{port}").parse()?;
+        info!("Lemma server listening on http://{}", addr);
+        info!("Interactive docs at http://{}/docs", addr);
 
-            debug!("Received: {}", line);
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, app).await?;
 
-            let response = match serde_json::from_str::<McpRequest>(&line) {
-                Ok(request) => server.handle_request(request),
-                Err(e) => {
-                    error!("Parse error: {}", e);
-                    McpResponse {
-                        jsonrpc: "2.0".to_string(),
-                        id: None,
-                        result: None,
-                        error: Some(McpError::parse_error(format!("Parse error: {e}"))),
-                    }
-                }
-            };
-
-            let response_json = serde_json::to_string(&response)?;
-            writeln!(stdout, "{}", response_json)?;
-            stdout.flush()?;
-
-            debug!("Sent response");
-        }
-
-        info!("MCP server shutting down");
         Ok(())
     }
-}
 
-pub use imp::start_server;
-pub use imp::McpConfig;
+    // -----------------------------------------------------------------------
+    // Meta routes
+    // -----------------------------------------------------------------------
+
+    async fn list_specs(
+        State(state): State<AppState>,
+        Query(q): Query<EffectiveQuery>,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let now = resolve_effective(q.effective.as_deref())?;
+        let engine = state.engine.read().await;
+
+        let specs: Vec<lemma::SpecSchema> = engine
+            .list_specs_effective(&now)
+            .iter()
+            .filter_map(|s| engine.schema(&s.name, Some(&now)).ok())
+            .collect();
+
+        Ok(Json(specs))
+    }
+
+    async fn health_check() -> impl IntoResponse {
+        Json(serde_json::json!({
+            "status": "ok",
+            "service": "lemma",
+            "version": env!("CARGO_PKG_VERSION")
+        }))
+    }
+
+    /// Fallback when no route matches — return 404 with JSON body (never empty).
+    async fn fallback_404() -> (StatusCode, Json<ErrorResponse>) {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Not found. Use GET / for spec list, GET /docs for API docs.".to_string(),
+            }),
+        )
+    }
+
+    async fn openapi_spec(
+        State(state): State<AppState>,
+        Query(q): Query<EffectiveQuery>,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let effective = resolve_effective(q.effective.as_deref())?;
+        let engine = state.engine.read().await;
+        let spec = lemma_openapi::generate_openapi_effective(
+            &engine,
+            state.explanations_enabled,
+            &effective,
+        );
+        Ok(Json(spec))
+    }
+
+    async fn scalar_docs(State(state): State<AppState>) -> impl IntoResponse {
+        let engine = state.engine.read().await;
+        let sources = lemma_openapi::temporal_api_sources(&engine);
+
+        let shared_opts = r#"layout: 'modern',
+      theme: 'solarized',
+      agent: { disabled: true },
+      hideClientButton: true,
+      hideTestRequestButton: false,
+      showSidebar: true,
+      showDeveloperTools: 'never',
+      operationTitleSource: 'summary',
+      persistAuth: false,
+      telemetry: false,
+      hideModels: true,
+      documentDownloadType: 'both', // Scalar UI option, not Lemma
+      hideSearch: false,
+      showOperationId: false,
+      hideDarkModeToggle: false,
+      withDefaultFonts: false,
+      defaultOpenAllTags: false,
+      expandAllModelSections: true,
+      expandAllResponses: true,
+      orderSchemaPropertiesBy: 'alpha',
+      orderRequiredPropertiesFirst: true,
+      customCss: `
+        a[href="https://www.scalar.com"] {
+          font-size: 0 !important;
+        }
+        a[href="https://www.scalar.com"]::after {
+          content: 'Powered by Lemma';
+          font-size: var(--scalar-mini, 10px);
+        }
+      `"#;
+
+        let config_js = if sources.len() == 1 {
+            format!("{{ url: '{}', {} }}", sources[0].url, shared_opts)
+        } else {
+            let sources_js: Vec<String> = sources
+                .iter()
+                .map(|s| {
+                    format!(
+                        "{{ title: '{}', slug: '{}', url: '{}' }}",
+                        s.title, s.slug, s.url
+                    )
+                })
+                .collect();
+            format!(
+                "{{ sources: [{}], {} }}",
+                sources_js.join(", "),
+                shared_opts
+            )
+        };
+
+        let html = format!(
+            r#"<!doctype html>
+<html>
+<head>
+  <title>Lemma API</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <div id="app"></div>
+  <script src="/scalar.js"></script>
+  <script>
+    Scalar.createApiReference('#app', {config_js})
+  </script>
+</body>
+</html>"#
+        );
+
+        Html(html)
+    }
+
+    /// Serve the vendored Scalar API reference JavaScript bundle.
+    /// Embedded at compile time so the server has zero external dependencies.
+    async fn scalar_js() -> impl IntoResponse {
+        static SCALAR_JS: &str = include_str!("../vendor/scalar-api-reference.js");
+
+        (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/javascript; charset=utf-8",
+            )],
+            SCALAR_JS,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Doc path (wildcard): GET = schema with versions, POST = evaluate
+    // -----------------------------------------------------------------------
+
+    /// `GET /{*path}` — schema of resolved version; path = spec id (name or name~hash). `Accept-Datetime` for temporal, `?rules=` to scope.
+    async fn spec_get_schema(
+        State(state): State<AppState>,
+        Path(path): Path<String>,
+        Query(q): Query<SpecQuery>,
+        headers: HeaderMap,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let spec_id = parse_spec_path(&path);
+        let effective = accept_datetime_from_headers(&headers)?;
+        let engine = state.engine.read().await;
+
+        let schema = engine.schema(&spec_id, Some(&effective)).map_err(|e| {
+            (
+                lemma_error_to_status(&e),
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
+
+        let rule_names = q.rules.as_deref().map(parse_rule_names).unwrap_or_default();
+        let schema = if rule_names.is_empty() {
+            schema
+        } else {
+            let plan = engine.get_plan(&spec_id, Some(&effective)).map_err(|e| {
+                (
+                    lemma_error_to_status(&e),
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+            })?;
+            plan.schema_for_rules(&rule_names).map_err(|err| {
+                (
+                    lemma_error_to_status(&err),
+                    Json(ErrorResponse {
+                        error: err.to_string(),
+                    }),
+                )
+            })?
+        };
+
+        let spec_arc = engine.get_spec(&spec_id, Some(&effective)).map_err(|e| {
+            (
+                lemma_error_to_status(&e),
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
+
+        let versions: Vec<VersionEntry> = engine
+            .list_specs()
+            .into_iter()
+            .filter(|s| s.name == spec_arc.name)
+            .map(|arc| {
+                let effective_from = arc.effective_from().cloned();
+                let hash = engine
+                    .get_plan(&arc.name, effective_from.as_ref())
+                    .expect("BUG: loaded spec has no plan")
+                    .plan_hash();
+                VersionEntry {
+                    effective_from: effective_from.map(|d| d.to_string()),
+                    hash,
+                }
+            })
+            .collect();
+
+        let effective_from_str = spec_arc.effective_from().map(|d| d.to_string());
+        let hash = engine
+            .get_plan(&spec_id, Some(&effective))
+            .map_err(|e| {
+                (
+                    lemma_error_to_status(&e),
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+            })?
+            .plan_hash();
+
+        let body = GetSpecResponse {
+            spec_id,
+            effective_from: effective_from_str,
+            hash: hash.clone(),
+            facts: Some(
+                serde_json::to_value(&schema.facts).expect("BUG: failed to serialize schema facts"),
+            ),
+            rules: Some(
+                serde_json::to_value(&schema.rules).expect("BUG: failed to serialize schema rules"),
+            ),
+            meta: Some(
+                serde_json::to_value(&schema.meta).expect("BUG: failed to serialize schema meta"),
+            ),
+            versions,
+        };
+
+        let mut response = Json(body).into_response();
+        let headers_mut = response.headers_mut();
+        for (k, v) in spec_response_headers(&spec_arc.name, spec_arc.effective_from(), &hash) {
+            headers_mut.insert(k, v);
+        }
+        Ok(response)
+    }
+
+    /// `POST /{*path}` — evaluate; path = spec id (name or name~hash). `Accept-Datetime` for temporal, `?rules=` to limit. Body = form-encoded facts.
+    async fn spec_post_evaluate(
+        State(state): State<AppState>,
+        Path(path): Path<String>,
+        Query(q): Query<SpecQuery>,
+        headers: HeaderMap,
+        Form(fact_values): Form<std::collections::HashMap<String, String>>,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let spec_id = parse_spec_path(&path);
+        let effective = accept_datetime_from_headers(&headers)?;
+        let rule_names = q.rules.as_deref().map(parse_rule_names).unwrap_or_default();
+        let engine = state.engine.read().await;
+
+        let mut response = engine
+            .run(&spec_id, Some(&effective), fact_values, false)
+            .map_err(|err| {
+                (
+                    lemma_error_to_status(&err),
+                    Json(ErrorResponse {
+                        error: err.to_string(),
+                    }),
+                )
+            })?;
+        if !rule_names.is_empty() {
+            response.filter_rules(&rule_names);
+        }
+
+        let spec_arc = engine.get_spec(&spec_id, Some(&effective)).ok();
+        let effective_from = spec_arc.as_ref().and_then(|a| a.effective_from());
+        let hash = engine
+            .get_plan(&spec_id, Some(&effective))
+            .expect("BUG: run succeeded but get_plan failed")
+            .plan_hash();
+        let results = response::convert_response_with_hash(
+            &response,
+            want_explanations(&state, &headers),
+            &response.spec_name,
+            &effective,
+            &hash,
+        );
+        let mut axum_response = Json(results).into_response();
+        let headers_mut = axum_response.headers_mut();
+        for (k, v) in spec_response_headers(&response.spec_name, effective_from, &hash) {
+            headers_mut.insert(k, v);
+        }
+        Ok(axum_response)
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema routes (legacy)
+    // -----------------------------------------------------------------------
+
+    /// `GET /schema/{spec_name}` — full spec schema (all facts and rules).
+    async fn schema_all_rules(
+        State(state): State<AppState>,
+        Path(spec_name): Path<String>,
+        Query(q): Query<EffectiveQuery>,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let now = resolve_effective(q.effective.as_deref())?;
+        schema_inner(&state.engine, &spec_name, &[], &now).await
+    }
+
+    /// `GET /schema/{spec_name}/{rules}` — schema scoped to specific rules and
+    /// only the facts those rules need.
+    async fn schema_for_rules(
+        State(state): State<AppState>,
+        Path((spec_name, rules)): Path<(String, String)>,
+        Query(q): Query<EffectiveQuery>,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let now = resolve_effective(q.effective.as_deref())?;
+        let rule_names = parse_rule_names(&rules);
+        schema_inner(&state.engine, &spec_name, &rule_names, &now).await
+    }
+
+    async fn schema_inner(
+        engine: &SharedEngine,
+        spec_name: &str,
+        rule_names: &[String],
+        now: &DateTimeValue,
+    ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+        let engine = engine.read().await;
+
+        let plan = engine.get_plan(spec_name, Some(now)).map_err(|e| {
+            (
+                lemma_error_to_status(&e),
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
+
+        if rule_names.is_empty() {
+            return Ok(Json(plan.schema()));
+        }
+
+        let schema = plan.schema_for_rules(rule_names).map_err(|err| {
+            (
+                lemma_error_to_status(&err),
+                Json(ErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        })?;
+
+        Ok(Json(schema))
+    }
+
+    fn want_explanations(state: &AppState, headers: &HeaderMap) -> bool {
+        state.explanations_enabled
+            && headers
+                .get("x-explanations")
+                .and_then(|v: &axum::http::HeaderValue| v.to_str().ok())
+                .map(|s: &str| !s.trim().is_empty())
+                .unwrap_or(false)
+    }
+
+    /// Map a `Error` to an HTTP status code.
+    ///
+    /// SpecNotFound → 404; InvalidRequest → 400.
+    fn lemma_error_to_status(err: &lemma::Error) -> StatusCode {
+        use lemma::RequestErrorKind;
+        match err {
+            lemma::Error::Request {
+                kind: RequestErrorKind::SpecNotFound,
+                ..
+            } => StatusCode::NOT_FOUND,
+            _ => StatusCode::BAD_REQUEST,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Parse comma-separated rule names from a URL path segment.
+    /// Filters out empty strings and the literal `{rules}` placeholder that
+    /// Scalar sends when the path parameter is left blank.
+    fn parse_rule_names(rules_segment: &str) -> Vec<String> {
+        rules_segment
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty() && s != "{rules}")
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // File watcher (--watch mode)
+    // -----------------------------------------------------------------------
+
+    /// Snapshot of the last-modified timestamps for all `.lemma` files in the
+    /// workspace. Used to detect whether files have actually changed between
+    /// watcher callbacks, avoiding needless reloads from access-only events.
+    type ModifiedSnapshot = std::collections::BTreeMap<PathBuf, std::time::SystemTime>;
+
+    /// Walk the workspace and collect `(path, modified)` for every `.lemma` file.
+    fn collect_modified_times(workdir: &std::path::Path) -> ModifiedSnapshot {
+        use walkdir::WalkDir;
+
+        let mut snapshot = std::collections::BTreeMap::new();
+        for entry in WalkDir::new(workdir).into_iter().flatten() {
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("lemma") {
+                if let Ok(metadata) = entry.path().metadata() {
+                    if let Ok(modified) = metadata.modified() {
+                        snapshot.insert(entry.path().to_path_buf(), modified);
+                    }
+                }
+            }
+        }
+        snapshot
+    }
+
+    fn start_file_watcher(shared_engine: SharedEngine, workdir: PathBuf) -> anyhow::Result<()> {
+        use notify_debouncer_mini::new_debouncer;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let watch_dir = workdir.clone();
+
+        // Track the last-known modified timestamps so we only reload when
+        // file contents have actually changed, not on access-only events.
+        let last_snapshot: Arc<Mutex<ModifiedSnapshot>> =
+            Arc::new(Mutex::new(collect_modified_times(&workdir)));
+
+        // The debouncer thread runs in the background. We intentionally
+        // "forget" the handle so the watcher stays alive for the lifetime
+        // of the process. Dropping it would stop watching.
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(500),
+            move |result: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+                match result {
+                    Ok(events) => {
+                        let has_lemma_events = events.iter().any(|event| {
+                            event
+                                .path
+                                .extension()
+                                .and_then(|ext| ext.to_str())
+                                .map(|ext| ext == "lemma")
+                                .unwrap_or(false)
+                        });
+
+                        if !has_lemma_events {
+                            return;
+                        }
+
+                        // Check if any file was actually modified by comparing
+                        // the current timestamps to the last known snapshot.
+                        let current_snapshot = collect_modified_times(&workdir);
+
+                        let files_changed = {
+                            let previous = match last_snapshot.lock() {
+                                Ok(guard) => guard,
+                                Err(poisoned) => poisoned.into_inner(),
+                            };
+                            current_snapshot != *previous
+                        };
+
+                        if !files_changed {
+                            return;
+                        }
+
+                        // Store the new snapshot before starting the reload so
+                        // that subsequent callbacks see the up-to-date times.
+                        {
+                            let mut previous = match last_snapshot.lock() {
+                                Ok(guard) => guard,
+                                Err(poisoned) => poisoned.into_inner(),
+                            };
+                            *previous = current_snapshot;
+                        }
+
+                        info!("Detected .lemma file changes, reloading...");
+                        let engine_clone = shared_engine.clone();
+                        let workdir_clone = workdir.clone();
+
+                        // Spawn a dedicated OS thread for reloading. The notify
+                        // callback is synchronous, so we create a fresh tokio
+                        // runtime on a new thread to run the async reload.
+                        std::thread::spawn(move || {
+                            let runtime = match tokio::runtime::Runtime::new() {
+                                Ok(rt) => rt,
+                                Err(err) => {
+                                    error!("Failed to create tokio runtime for reload: {}", err);
+                                    return;
+                                }
+                            };
+
+                            runtime.block_on(async {
+                                match reload_engine(&workdir_clone).await {
+                                    Ok(new_engine) => {
+                                        let spec_count = new_engine.list_specs().len();
+                                        let mut engine = engine_clone.write().await;
+                                        *engine = new_engine;
+                                        info!("Reloaded engine with {} spec(s)", spec_count);
+                                    }
+                                    Err(err) => {
+                                        warn!("Reload failed (keeping previous state): {}", err);
+                                    }
+                                }
+                            });
+                        });
+                    }
+                    Err(err) => {
+                        error!("File watcher error: {}", err);
+                    }
+                }
+            },
+        )?;
+
+        debouncer
+            .watcher()
+            .watch(&watch_dir, notify::RecursiveMode::Recursive)?;
+
+        info!("Watching {:?} for .lemma file changes", watch_dir);
+
+        // Leak the debouncer so the watcher thread stays alive.
+        // This is intentional: the watcher should run for the lifetime of the process.
+        std::mem::forget(debouncer);
+
+        Ok(())
+    }
+
+    /// Create a fresh engine by loading all .lemma files from the workspace
+    /// directory (including `.deps/` for cached registry dependencies).
+    async fn reload_engine(workdir: &std::path::Path) -> anyhow::Result<Engine> {
+        use walkdir::WalkDir;
+
+        let mut engine = Engine::new();
+        let mut paths: Vec<std::path::PathBuf> = Vec::new();
+        for entry in WalkDir::new(workdir) {
+            let entry = entry?;
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("lemma") {
+                paths.push(entry.path().to_path_buf());
+            }
+        }
+        if let Err(load_err) = engine.load_from_paths(&paths, false) {
+            for e in load_err.iter() {
+                tracing::error!(
+                    "{}",
+                    crate::error_formatter::format_error(e, &load_err.sources)
+                );
+            }
+            anyhow::bail!("Workspace load failed ({} error(s))", load_err.errors.len());
+        }
+        Ok(engine)
+    }
+}


### PR DESCRIPTION
Hi @benrogmans,

I've been using Lemma as an MCP server and encountered a couple of protocol violations that were preventing the server from connecting correctly to MCP hosts (like Claude Desktop and Antigravity). This PR addresses those issues:

### Key Changes
1.  **Stdout Pollution Fix:** Information messages like *"Starting MCP server..."* were being printed to `stdout`. Since MCP uses `stdio` for JSON-RPC communication, these non-JSON strings caused parse errors on clients (e.g., `invalid character 'S'`). I've redirected these to `stderr` using `eprintln!`.
2.  **JSON-RPC Notification Handling:** According to the JSON-RPC 2.0 spec, notifications (requests without an `id`) **must not** receive a response. Lemma was returning a `method_not_found` error for the `notifications/initialized` notification, which disrupted the handshake flow for many clients. I've updated the handler to process notifications silently without sending any response.
3.  **Standardized Initialize Response:** Added `listChanged: false` to the tools capability in the `initialize` response to meet the expectations of stricter MCP hosts.

These changes make the Lemma MCP server fully stable and compatible with various environments.

Thanks for this great project!
