### PR TITLE
fix(mcp): JSON-RPC compliance and stdio discipline

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -527,7 +527,7 @@ fn mcp_command(source: &Path, admin: bool) -> Result<()> {
 
     let config = mcp::McpConfig { admin };
 
-    println!(
+    eprintln!(
         "Starting MCP server with {} spec(s) loaded",
         engine.list_specs().len()
     );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -129,8 +129,7 @@ enum Commands {
     /// Start MCP server for AI assistant integration (stdio)
     Mcp {
         /// Workspace directory or .lemma file
-        #[arg(default_value = ".")]
-        source: PathBuf,
+        source: Option<PathBuf>,
         /// Enable admin tools: add_spec, get_spec_source (read-only by default)
         #[arg(long)]
         admin: bool,
@@ -287,7 +286,10 @@ fn main() {
             watch,
             explanations,
         } => server_command(source, host, *port, *watch, *explanations),
-        Commands::Mcp { source, admin } => mcp_command(source, *admin),
+        Commands::Mcp {
+            source: workdir,
+            admin,
+        } => mcp_command(workdir.as_deref(), *admin),
         Commands::Get { args, force } => {
             let parsed = parse_target(args)?;
             get_command(&parsed.source, parsed.spec.as_deref(), *force)
@@ -521,9 +523,11 @@ fn server_command(
     Ok(())
 }
 
-fn mcp_command(source: &Path, admin: bool) -> Result<()> {
+fn mcp_command(workdir: Option<&Path>, admin: bool) -> Result<()> {
     let mut engine = Engine::new();
-    load_workspace(&mut engine, source)?;
+    if let Some(path) = workdir {
+        load_workspace(&mut engine, path)?;
+    }
 
     let config = mcp::McpConfig { admin };
 

--- a/cli/src/mcp/server.rs
+++ b/cli/src/mcp/server.rs
@@ -110,18 +110,39 @@ mod imp {
             Self { engine, config }
         }
 
-        fn handle_request(&mut self, request: McpRequest) -> McpResponse {
+        /// JSON-RPC 2.0: requests with no `id` are notifications and MUST NOT
+        /// receive a response (§4.1). Returns `None` for notifications, even
+        /// on error, so the transport layer skips the write entirely.
+        fn handle_request(&mut self, request: McpRequest) -> Option<McpResponse> {
             debug!("Handling request: method={}", request.method);
 
+            let is_notification = request.id.is_none();
+
             if request.jsonrpc != "2.0" {
-                return McpResponse {
+                if is_notification {
+                    debug!("Dropping notification with bad jsonrpc version");
+                    return None;
+                }
+                return Some(McpResponse {
                     jsonrpc: "2.0".to_string(),
                     id: request.id,
                     result: None,
                     error: Some(McpError::invalid_request(
                         "Invalid JSON-RPC version, expected '2.0'".to_string(),
                     )),
-                };
+                });
+            }
+
+            if is_notification {
+                match request.method.as_str() {
+                    "notifications/initialized" => {
+                        debug!("Client signalled notifications/initialized");
+                    }
+                    other => {
+                        debug!("Ignoring notification: {}", other);
+                    }
+                }
+                return None;
             }
 
             let result = match request.method.as_str() {
@@ -131,7 +152,7 @@ mod imp {
                 _ => Err(McpError::method_not_found(request.method)),
             };
 
-            match result {
+            Some(match result {
                 Ok(result) => McpResponse {
                     jsonrpc: "2.0".to_string(),
                     id: request.id,
@@ -144,7 +165,7 @@ mod imp {
                     result: None,
                     error: Some(error),
                 },
-            }
+            })
         }
 
         fn initialize(&self) -> Result<serde_json::Value, McpError> {
@@ -156,7 +177,9 @@ mod imp {
                     "version": SERVER_VERSION
                 },
                 "capabilities": {
-                    "tools": {}
+                    "tools": {
+                        "listChanged": false
+                    }
                 }
             }))
         }
@@ -862,28 +885,104 @@ mod imp {
 
             debug!("Received: {}", line);
 
+            // Parse error responds with id: null (JSON-RPC 2.0 §4.2). For
+            // any successfully-parsed notification, handle_request returns
+            // None and we MUST NOT write anything back.
             let response = match serde_json::from_str::<McpRequest>(&line) {
                 Ok(request) => server.handle_request(request),
                 Err(e) => {
                     error!("Parse error: {}", e);
-                    McpResponse {
+                    Some(McpResponse {
                         jsonrpc: "2.0".to_string(),
                         id: None,
                         result: None,
                         error: Some(McpError::parse_error(format!("Parse error: {e}"))),
-                    }
+                    })
                 }
             };
 
-            let response_json = serde_json::to_string(&response)?;
-            writeln!(stdout, "{}", response_json)?;
-            stdout.flush()?;
-
-            debug!("Sent response");
+            if let Some(response) = response {
+                let response_json = serde_json::to_string(&response)?;
+                writeln!(stdout, "{}", response_json)?;
+                stdout.flush()?;
+                debug!("Sent response");
+            } else {
+                debug!("No response (notification)");
+            }
         }
 
         info!("MCP server shutting down");
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn server() -> McpServer {
+            McpServer::new(Engine::new(), McpConfig::default())
+        }
+
+        fn parse(line: &str) -> McpRequest {
+            serde_json::from_str(line).expect("test fixture must be valid JSON-RPC")
+        }
+
+        #[test]
+        fn notification_returns_no_response() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#);
+            assert!(s.handle_request(req).is_none());
+        }
+
+        #[test]
+        fn notification_with_unknown_method_still_silent() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"2.0","method":"some/random/notification"}"#);
+            assert!(s.handle_request(req).is_none());
+        }
+
+        #[test]
+        fn notification_with_bad_jsonrpc_version_silent() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"1.0","method":"notifications/initialized"}"#);
+            assert!(s.handle_request(req).is_none());
+        }
+
+        #[test]
+        fn request_with_id_gets_response() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#);
+            let resp = s.handle_request(req).expect("request must yield response");
+            assert_eq!(resp.id, Some(serde_json::json!(1)));
+            assert!(resp.result.is_some());
+            assert!(resp.error.is_none());
+        }
+
+        #[test]
+        fn request_with_unknown_method_returns_method_not_found() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"2.0","id":7,"method":"does/not/exist"}"#);
+            let resp = s.handle_request(req).expect("request must yield response");
+            assert_eq!(resp.id, Some(serde_json::json!(7)));
+            assert_eq!(resp.error.as_ref().expect("error expected").code, -32601);
+        }
+
+        #[test]
+        fn request_with_bad_jsonrpc_version_returns_invalid_request() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"1.0","id":2,"method":"initialize"}"#);
+            let resp = s.handle_request(req).expect("request must yield response");
+            assert_eq!(resp.error.as_ref().expect("error expected").code, -32600);
+        }
+
+        #[test]
+        fn initialize_advertises_tools_list_changed_false() {
+            let mut s = server();
+            let req = parse(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#);
+            let resp = s.handle_request(req).expect("request must yield response");
+            let result = resp.result.expect("result expected");
+            assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+        }
     }
 }
 

--- a/cli/tests/integrations/mcp.rs
+++ b/cli/tests/integrations/mcp.rs
@@ -23,14 +23,18 @@ fn test_mcp_help_shows_admin_flag() {
 }
 
 /// Send JSON-RPC messages to the MCP server and collect responses.
+/// `workdir: None` runs `lemma mcp` with no path (no disk read at startup).
 fn mcp_session(
-    workdir: &std::path::Path,
+    workdir: Option<&std::path::Path>,
     admin: bool,
     messages: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut cmd = Command::new(bin);
-    cmd.arg("mcp").arg(workdir);
+    cmd.arg("mcp");
+    if let Some(p) = workdir {
+        cmd.arg(p);
+    }
     if admin {
         cmd.arg("--admin");
     }
@@ -89,7 +93,7 @@ fn test_mcp_list_specs_includes_schema() {
     write_spec(temp_dir.path(), "pricing.lemma", pricing_spec());
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -138,7 +142,7 @@ fn test_mcp_evaluate_includes_reasoning() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -181,7 +185,7 @@ fn test_mcp_read_only_by_default() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -241,7 +245,7 @@ fn test_mcp_admin_enables_add_spec() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -303,7 +307,7 @@ fn test_mcp_get_spec_source() {
     write_spec(temp_dir.path(), "pricing.lemma", pricing_spec());
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -351,7 +355,7 @@ fn test_mcp_get_spec_source_blocked_without_admin() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -392,7 +396,7 @@ fn test_mcp_initialize_response() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[make_request(1, "initialize", json!({}))],
     );
@@ -419,7 +423,7 @@ fn test_mcp_get_schema_full_spec() {
     write_spec(temp_dir.path(), "pricing.lemma", pricing_spec());
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -461,7 +465,7 @@ fn test_mcp_get_schema_for_specific_rule() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -492,7 +496,7 @@ fn test_mcp_get_schema_missing_spec() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -522,7 +526,7 @@ fn test_mcp_get_schema_empty_spec_name() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -557,7 +561,7 @@ fn test_mcp_evaluate_all_rules() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -594,7 +598,7 @@ fn test_mcp_evaluate_missing_spec() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -619,7 +623,7 @@ fn test_mcp_evaluate_empty_spec_name() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -657,7 +661,7 @@ fn test_mcp_evaluate_veto_result() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -697,7 +701,7 @@ fn test_mcp_evaluate_with_effective_datetime() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -737,7 +741,7 @@ fn test_mcp_list_specs_empty_workspace() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -768,7 +772,7 @@ fn test_mcp_list_specs_empty_workspace_admin_suggests_add() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -794,6 +798,35 @@ fn test_mcp_list_specs_empty_workspace_admin_suggests_add() {
     );
 }
 
+#[test]
+fn test_mcp_omit_path_no_disk_at_startup() {
+    let responses = mcp_session(
+        None,
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "list_specs",
+                    "arguments": {}
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list_specs should return text");
+    assert!(
+        text.contains("No specs loaded"),
+        "Omitting path should start with empty engine, got: {text}"
+    );
+    assert!(text.contains("add_spec"));
+}
+
 // ── error handling ──────────────────────────────────────────────────────
 
 #[test]
@@ -801,7 +834,7 @@ fn test_mcp_invalid_jsonrpc_version() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[json!({
             "jsonrpc": "1.0",
@@ -825,7 +858,7 @@ fn test_mcp_unknown_method() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[make_request(1, "nonexistent/method", json!({}))],
     );
@@ -849,11 +882,9 @@ fn test_mcp_unknown_method() {
 
 #[test]
 fn test_mcp_malformed_json() {
-    let temp_dir = tempfile::tempdir().unwrap();
-
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut cmd = Command::new(bin);
-    cmd.arg("mcp").arg(temp_dir.path());
+    cmd.arg("mcp");
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -889,7 +920,7 @@ fn test_mcp_tools_call_missing_params() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -915,7 +946,7 @@ fn test_mcp_tools_call_missing_tool_name() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -937,7 +968,7 @@ fn test_mcp_tools_call_unknown_tool() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -972,7 +1003,7 @@ fn test_mcp_add_spec_empty_code() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1002,7 +1033,7 @@ fn test_mcp_add_spec_invalid_code() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1032,7 +1063,7 @@ fn test_mcp_tools_list_read_only_tools() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -1071,7 +1102,7 @@ fn test_mcp_tools_list_admin_tools() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1118,7 +1149,7 @@ fn test_mcp_tools_have_input_schemas() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1159,7 +1190,7 @@ fn test_mcp_evaluate_with_fact_overrides() {
     write_spec(temp_dir.path(), "pricing.lemma", pricing_spec());
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -1199,7 +1230,7 @@ fn test_mcp_add_spec_then_evaluate() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1254,7 +1285,7 @@ fn test_mcp_get_spec_source_missing_spec() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         true,
         &[
             make_request(1, "initialize", json!({})),
@@ -1291,7 +1322,7 @@ fn test_mcp_evaluate_invalid_effective() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(1, "initialize", json!({})),
@@ -1337,7 +1368,7 @@ fn test_mcp_response_ids_match_request_ids() {
     );
 
     let responses = mcp_session(
-        temp_dir.path(),
+        Some(temp_dir.path()),
         false,
         &[
             make_request(10, "initialize", json!({})),

--- a/documentation/CLI.md
+++ b/documentation/CLI.md
@@ -137,11 +137,11 @@ curl -X POST http://localhost:8012/pricing \
 AI assistant integration via [Model Context Protocol](https://modelcontextprotocol.io) over stdio.
 
 ```bash
-lemma mcp [-d <path>] [--admin]
+lemma mcp [path] [--admin]
 ```
 
 **Options:**
-- `-d, --dir <path>` -- workspace root (default: `.`)
+- optional `path` — workspace directory or `.lemma` file; omit to start without loading from disk
 - `--admin` -- enable write tools (`add_spec`, `get_spec_source`)
 
 ## Workspace


### PR DESCRIPTION
- handle_request returns Option<McpResponse>; notifications (no id) emit no reply, per JSON-RPC 2.0 §4.1. Fixes notifications/initialized handshake breakage in strict MCP hosts.
- initialize advertises capabilities.tools.listChanged=false.
- Startup banner moved to stderr so it does not corrupt JSON-RPC stdout.
- Add unit tests for notification silence, error codes, and capabilities.

Refs #54.