### PR TITLE
Release/0.8.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,20 +388,10 @@ jobs:
           elixir-version: '1.19.5'
 
       - name: Rewrite NIF Cargo.toml for standalone build
-        working-directory: engine/packages/hex
-        run: |
-          VERSION="${{ needs.detect-version-changes.outputs.version }}"
-          cd native/lemma_hex
-          sed -i 's|^version\.workspace = true|version = "'"${VERSION}"'"|' Cargo.toml
-          sed -i 's|^edition\.workspace = true|edition = "2021"|' Cargo.toml
-          sed -i '/^authors\.workspace/d' Cargo.toml
-          sed -i '/^license\.workspace/d' Cargo.toml
-          sed -i '/^repository\.workspace/d' Cargo.toml
-          sed -i 's|^lemma-engine = { path = "../../../../" }|lemma-engine = "='"${VERSION}"'"|' Cargo.toml
-          sed -i 's|^lemma-openapi = { path = "../../../../../openapi" }|lemma-openapi = "='"${VERSION}"'"|' Cargo.toml
-          sed -i 's|^serde_json\.workspace = true|serde_json = "1.0"|' Cargo.toml
-          echo "--- Cargo.toml after rewrite ---"
-          cat Cargo.toml
+        run: cargo run -p xtask -- hex-standalone
+
+      - name: Show rewritten NIF Cargo.toml
+        run: cat engine/packages/hex/native/lemma_hex/Cargo.toml
 
       - name: Install mix deps
         working-directory: engine/packages/hex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,7 @@ jobs:
           sed -i '/^license\.workspace/d' Cargo.toml
           sed -i '/^repository\.workspace/d' Cargo.toml
           sed -i 's|^lemma-engine = { path = "../../../../" }|lemma-engine = "='"${VERSION}"'"|' Cargo.toml
+          sed -i 's|^lemma-openapi = { path = "../../../../../openapi" }|lemma-openapi = "='"${VERSION}"'"|' Cargo.toml
           sed -i 's|^serde_json\.workspace = true|serde_json = "1.0"|' Cargo.toml
           echo "--- Cargo.toml after rewrite ---"
           cat Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,9 @@ jobs:
       needs.create-release.result == 'success' &&
       needs.detect-version-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       WASM_PACK_VERSION: 0.14.0
     steps:
@@ -324,14 +327,13 @@ jobs:
 
       - name: Build WASM
         working-directory: engine/packages/npm
-        run: |
-          node build.js
+        run: node build.js
 
       - name: Publish to npm
-        working-directory: engine/packages/npm/dist
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: npm/publish@v1.0.1
+        with:
+          package: engine/packages/npm/dist
+          provenance: true
 
   publish-vscode:
     name: Publish VS Code Extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `cli-v{version}` (for example `cli-v0.8.5`). Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
+## [0.8.12] - 2026-04-28
+
+Release-pipeline fixes only. No engine, CLI, or language changes.
+
+### Fixed
+
+- **Hex publish**: the standalone `Cargo.toml` rewrite for the published Hex tarball now also rewrites `lemma-openapi` from a workspace path dep to the matching registry version, mirroring the existing `lemma-engine` rewrite. Without this, end users compiling from the Hex tarball (or `mix hex.publish`'s own verification compile) saw two distinct `lemma-engine` instances — one pulled from crates.io via `lemma_hex`, one from the local path via `lemma-openapi` — producing type mismatches on shared types like `Engine` and `DateTimeValue`.
+
+### Changed
+
+- **npm release workflow**: `publish-npm` now uses npm Trusted Publishing (OIDC) via `npm/publish@v1.0.1` with `id-token: write`, eliminating the long-lived `NPM_TOKEN` secret and the `EOTP` 2FA failure mode for automation.
+- **npm package metadata**: `engine/packages/npm/build.js` emits `repository.url` as `git+https://github.com/lemma/lemma.git`, silencing npm's autocorrect warning on publish.
+
 ## [0.8.11] - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,21 +432,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1406,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1530,27 +1524,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1584,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-core",
@@ -1629,7 +1628,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-cli"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1663,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "boolean_expression",
@@ -1688,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1698,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "lemma-engine",
  "lemma-openapi",
@@ -1709,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1764,7 +1763,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -2105,7 +2104,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2388,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2538,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2564,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2574,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2837,6 +2836,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -3126,6 +3135,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -3135,14 +3150,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3151,8 +3178,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3470,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3484,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3494,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3504,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3517,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3573,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3692,15 +3725,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3724,21 +3748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3776,12 +3785,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3794,12 +3797,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3809,12 +3806,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3842,12 +3833,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3857,12 +3842,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3878,12 +3857,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3893,12 +3866,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3914,9 +3881,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -4036,6 +4012,7 @@ version = "0.1.0"
 dependencies = [
  "semver",
  "serde_json",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.11"
+version = "0.8.12"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,8 +12,8 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.11", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.11", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.12", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.12", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.11"
+lemma-engine = "0.8.12"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.11", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.12", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.11"
+  @version "0.8.12"
   @source_url "https://github.com/lemma/lemma"
 
   def project do

--- a/engine/packages/npm/README.md
+++ b/engine/packages/npm/README.md
@@ -1,8 +1,50 @@
 # @lemmabase/lemma-engine
 
-Embeddable Lemma engine (WebAssembly).
+> [Lemma](https://github.com/lemma/lemma) is a declarative language for business rules. **This package is the engine, compiled to WebAssembly** - runs in the browser, on Node, Bun, Deno, Cloudflare Workers, Vercel Edge, etc.
 
-npm `description` / `keywords` / `homepage`: edit **`NPM_BRANDING`** in `build.js` (not Cargo).
+Pricing tiers, tax brackets, leave entitlement, eligibility checks, discount stacks: the rules that change, that auditors ask about, that legal writes in PDFs and engineers re-implement in operational code... Lemma is a language built specifically for your business rules. It is readable by stakeholders, executable anywhere, and impossible to drift out of sync.
+
+```lemma
+spec pricing 2026-01-01
+
+data money: scale
+  -> unit eur 1.00
+  -> decimals 2
+
+data quantity : number
+data is_vip   : false
+
+rule unit_price:
+  20 eur
+  unless quantity >= 10 then 18 eur
+  unless quantity >= 50 then 16 eur
+  unless is_vip         then 15 eur
+
+rule total:
+  unit_price * quantity
+```
+
+```javascript
+import { Lemma } from '@lemmabase/lemma-engine';
+
+const engine = await Lemma();
+await engine.load(pricing, 'pricing.lemma');
+
+const response = engine.run('pricing', [], { quantity: 50, is_vip: false }, null);
+// response.results.unit_price → 16 eur
+// response.results.total      → 800 eur
+```
+
+The `Response` carries every rule's value (or `veto` if no result could be computed), the input snapshot, and the source location of every rule that fired, allowing you to render an audit trail in your UI.
+
+## Why use it from JavaScript?
+
+- **Deterministic.** `(spec, data, effective_date) → result`. No DB, no clock, no ambient state. Same inputs → same outputs, every time.
+- **Explainable.** The `Response` tells you which rules contributed and why; pair it with the [CLI](https://github.com/lemma/lemma) for a full reasoning trace.
+- **Time-aware.** Multiple versions of the same spec coexist. Pass an `effective` date and the engine resolves the version in force on that day.
+- **Statically checked.** Type errors, missing data, cycles, scale-family mismatches - all caught at `load()` time. Bad specs never reach `run()`.
+- **Runs anywhere V8 does.** ~2 MB WASM, no native binary, no postinstall script.
+- **Editor in a tab.** Includes an in-process language server and a Monaco adapter, so you can build a real Lemma editor experience client-side - diagnostics, completion, formatting... even without setting up a server.
 
 ## Install
 
@@ -10,7 +52,7 @@ npm `description` / `keywords` / `homepage`: edit **`NPM_BRANDING`** in `build.j
 npm install @lemmabase/lemma-engine
 ```
 
-## Browser / bundler
+## Browser
 
 ```javascript
 import { Lemma } from '@lemmabase/lemma-engine';
@@ -18,39 +60,35 @@ import { Lemma } from '@lemmabase/lemma-engine';
 const engine = await Lemma();
 ```
 
-`Lemma()` initializes WASM once and returns an `Engine`. Serve over **http(s)** (not `file://`). For manual init: `init()` then `new Engine()`.
+`Lemma()` initializes the WASM module once and returns an `Engine`. Serve over **http(s)**, not `file://`. For manual control: `init()` then `new Engine()`.
 
-If your bundler outputs IIFE (or otherwise breaks `import.meta.url`), use:
+If your bundler emits IIFE, can't resolve `import.meta.url`, or refuses to ship `lemma_bg.wasm` as a separate asset, use the inlined entry - it embeds the wasm bytes in the JS bundle:
 
 ```javascript
 import { Lemma } from '@lemmabase/lemma-engine/iife';
-
-const engine = await Lemma();
 ```
 
-This entry embeds WASM bytes and avoids external wasm URL handling.
-
-## esbuild auto-handler
-
-If you use esbuild JS API, plugin rewrites root import to `/iife` automatically:
+esbuild users get an auto-rewriting plugin:
 
 ```javascript
 import { lemmaEngineEsbuildPlugin } from '@lemmabase/lemma-engine/esbuild';
+
+esbuild.build({ /* ... */ plugins: [lemmaEngineEsbuildPlugin()] });
 ```
 
 ## Node
 
+Identical to the browser path:
+
 ```javascript
 import { Lemma } from '@lemmabase/lemma-engine';
 
 const engine = await Lemma();
 ```
 
-Or with a preloaded buffer (e.g. no async fetch): `initSync({ module })` then `new Engine()`.
+For zero-fetch startup with a preloaded module: `initSync({ module })` then `new Engine()`.
 
-## LSP (browser streams)
-
-Call `init()` first. Use `LspClient`; `start()` uses the bundled LSP (no need to pass `serve`/`ServerConfig`). Optional: `start(serve, ServerConfig)` to override.
+## In-process LSP + Monaco
 
 ```javascript
 import { init } from '@lemmabase/lemma-engine';
@@ -60,23 +98,38 @@ await init();
 const client = new LspClient(monaco);
 await client.start();
 await client.initialize();
-client.onDiagnostics((uri, diagnostics) => { /* ... */ });
-client.didOpen(uri, 'lemma', 1, documentText);
+
+client.onDiagnostics((uri, diagnostics) => { /* render */ });
+client.didOpen('file:///pricing.lemma', 'lemma', 1, source);
 ```
 
-## API (`Engine`)
+A pre-wired Monaco adapter ships at `@lemmabase/lemma-engine/monaco`.
 
-| Method | |
-|--------|--|
-| `load(code, attribute)` | Promise; reject → `string[]` |
-| `list()` | Spec entries |
-| `schema(spec, effective?)` | `SpecSchema` |
-| `run(spec, rules, data, effective?)` | `Response` |
-| `format(code, attribute?)` | string or throw |
+## API
 
-## Build (maintainers)
+`Engine` (returned by `Lemma()` or `new Engine()`):
 
-`node build.js`: wasm-pack → `lemma.bindings.js` + `lemma_bg.wasm` → copy checked-in `lemma-entry.js` / `lsp-entry.js` / `*.d.ts` into `dist/`. Do not edit generated bindings by hand.
+| Method | Description |
+|--------|-------------|
+| `load(code, attribute?)` | Parse and validate a `.lemma` spec set. Resolves on success; rejects with `EngineError[]`. |
+| `list()` | All loaded specs with metadata and an inlined `SpecSchema`. |
+| `schema(spec, effective?)` | `SpecSchema` for the spec at the given effective date. |
+| `run(spec, rules, data, effective?)` | Evaluate. `rules: []` runs everything; pass an array to filter. Returns a `Response`. |
+| `format(code, attribute?)` | Canonical formatting; throws `EngineError` on parse error. |
+
+Full TypeScript types are bundled - see `lemma.d.ts`.
+
+## Status
+
+Lemma is in early development. Expect breaking changes between minor versions; **don't put it in front of paying customers yet**. Production-readiness tracking lives in the [main repo](https://github.com/lemma/lemma).
+
+## Related
+
+- [`lemmabase.com`](https://lemmabase.com): public database for Lemma Specs
+- [`lemma-cli`](https://crates.io/crates/lemma-cli): REPL, HTTP server, MCP server, formatter
+- [`lemma-engine`](https://crates.io/crates/lemma-engine): same engine as a Rust crate
+- [`lemma_engine` on Hex](https://hex.pm/packages/lemma_engine): Elixir bindings via Rustler
+- VS Code / Cursor extension: search "Lemma Language" in the marketplace
 
 ## License
 

--- a/engine/packages/npm/build.js
+++ b/engine/packages/npm/build.js
@@ -230,7 +230,7 @@ export function build() {
     keywords: [...NPM_BRANDING.keywords],
     author: meta.author,
     license: meta.license,
-    repository: { type: 'git', url: meta.repository },
+    repository: { type: 'git', url: `git+${meta.repository}.git` },
     homepage: NPM_BRANDING.homepage,
     bugs: { url: `${meta.repository}/issues` },
   };

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.11", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.12", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 semver = "1"
 serde_json.workspace = true
+toml_edit = "0.22"
 
 [[bin]]
 name = "xtask"

--- a/xtask/src/hex_standalone.rs
+++ b/xtask/src/hex_standalone.rs
@@ -1,0 +1,457 @@
+//! Rewrite `engine/packages/hex/native/lemma_hex/Cargo.toml` into a self-contained
+//! manifest suitable for the published Hex tarball.
+//!
+//! End users of the `lemma_engine` Hex package on platforms without a precompiled
+//! NIF binary fall back to compiling the bundled Rust source. The bundle does not
+//! contain the workspace root or sibling crates, so any workspace inheritance or
+//! path dependency in `lemma_hex/Cargo.toml` would prevent compilation. The same
+//! manifest is also what `mix hex.publish` compiles for verification, so a
+//! mismatch between path and registry deps there causes the dep graph to carry
+//! two distinct copies of `lemma-engine` and explodes at type-check time.
+//!
+//! This rewrite:
+//!
+//! 1. Inlines every `[package].X.workspace = true` from `[workspace.package].X`.
+//! 2. Inlines every `[dependencies].X.workspace = true` from `[workspace.dependencies].X`.
+//! 3. Converts every `[dependencies].X = { path = ... }` into a registry version
+//!    pin `X = "=VERSION"` (or, if the dep table carries other keys like
+//!    `features`, drops the `path` and inserts `version = "=VERSION"`).
+//!
+//! Post-conditions: no `.workspace = true` and no `path = ...` survives.
+
+use std::fs;
+use std::path::Path;
+
+use toml_edit::{DocumentMut, Item, Value};
+
+const HEX_CARGO_REL: &str = "engine/packages/hex/native/lemma_hex/Cargo.toml";
+const ROOT_CARGO_REL: &str = "Cargo.toml";
+
+pub fn run(root: &Path) -> Result<(), String> {
+    let hex_path = root.join(HEX_CARGO_REL);
+    let root_path = root.join(ROOT_CARGO_REL);
+
+    let hex_raw =
+        fs::read_to_string(&hex_path).map_err(|e| format!("{}: {e}", hex_path.display()))?;
+    let root_raw =
+        fs::read_to_string(&root_path).map_err(|e| format!("{}: {e}", root_path.display()))?;
+
+    let updated = rewrite(&hex_raw, &root_raw)?;
+
+    fs::write(&hex_path, updated).map_err(|e| format!("{}: {e}", hex_path.display()))?;
+    eprintln!("hex-standalone: rewrote {}", hex_path.display());
+    Ok(())
+}
+
+fn rewrite(hex_raw: &str, root_raw: &str) -> Result<String, String> {
+    let root_doc: DocumentMut = root_raw
+        .parse()
+        .map_err(|e| format!("workspace Cargo.toml: parse error: {e}"))?;
+    let mut hex_doc: DocumentMut = hex_raw
+        .parse()
+        .map_err(|e| format!("hex Cargo.toml: parse error: {e}"))?;
+
+    let workspace_version = workspace_version(&root_doc)?;
+
+    inline_package_inheritance(&mut hex_doc, &root_doc)?;
+    inline_dep_inheritance(&mut hex_doc, &root_doc)?;
+    pin_path_deps_to_workspace_version(&mut hex_doc, &workspace_version);
+
+    assert_no_workspace_inheritance(&hex_doc)?;
+    assert_no_path_deps(&hex_doc)?;
+
+    Ok(hex_doc.to_string())
+}
+
+fn workspace_version(root: &DocumentMut) -> Result<String, String> {
+    root.get("workspace")
+        .and_then(|w| w.get("package"))
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "workspace Cargo.toml: missing [workspace.package].version".to_string())
+}
+
+fn inline_package_inheritance(hex: &mut DocumentMut, root: &DocumentMut) -> Result<(), String> {
+    let workspace_pkg = root
+        .get("workspace")
+        .and_then(|w| w.get("package"))
+        .and_then(Item::as_table_like)
+        .ok_or_else(|| "workspace Cargo.toml: missing [workspace.package]".to_string())?;
+
+    let pkg = hex
+        .get_mut("package")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| "hex Cargo.toml: missing [package]".to_string())?;
+
+    let inherited_keys: Vec<String> = pkg
+        .iter()
+        .filter(|(_, v)| value_is_workspace_inheritance(v))
+        .map(|(k, _)| k.to_string())
+        .collect();
+
+    for key in inherited_keys {
+        let workspace_value = workspace_pkg.get(&key).cloned().ok_or_else(|| {
+            format!("[package].{key}.workspace = true but [workspace.package].{key} is missing")
+        })?;
+        pkg.insert(&key, workspace_value);
+    }
+
+    Ok(())
+}
+
+fn inline_dep_inheritance(hex: &mut DocumentMut, root: &DocumentMut) -> Result<(), String> {
+    let workspace_deps = root
+        .get("workspace")
+        .and_then(|w| w.get("dependencies"))
+        .and_then(Item::as_table_like);
+
+    let Some(deps) = hex
+        .get_mut("dependencies")
+        .and_then(Item::as_table_like_mut)
+    else {
+        return Ok(());
+    };
+
+    let inherited_keys: Vec<String> = deps
+        .iter()
+        .filter(|(_, v)| value_is_workspace_inheritance(v))
+        .map(|(k, _)| k.to_string())
+        .collect();
+
+    for key in inherited_keys {
+        let workspace_dep = workspace_deps
+            .and_then(|d| d.get(&key))
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "[dependencies].{key}.workspace = true but \
+                     [workspace.dependencies].{key} is missing"
+                )
+            })?;
+        deps.insert(&key, workspace_dep);
+    }
+
+    Ok(())
+}
+
+fn pin_path_deps_to_workspace_version(hex: &mut DocumentMut, version: &str) {
+    let Some(deps) = hex
+        .get_mut("dependencies")
+        .and_then(Item::as_table_like_mut)
+    else {
+        return;
+    };
+
+    let pin = format!("={version}");
+
+    let path_only: Vec<String> = deps
+        .iter()
+        .filter(|(_, v)| value_is_path_only_dep(v))
+        .map(|(k, _)| k.to_string())
+        .collect();
+    for key in path_only {
+        deps.insert(&key, Item::Value(Value::from(pin.as_str())));
+    }
+
+    let path_with_extras: Vec<String> = deps
+        .iter()
+        .filter(|(_, v)| value_has_path_key(v))
+        .map(|(k, _)| k.to_string())
+        .collect();
+    for key in path_with_extras {
+        let table = deps
+            .get_mut(&key)
+            .and_then(Item::as_table_like_mut)
+            .expect("BUG: filter matched key whose value is no longer a table");
+        table.remove("path");
+        table.insert("version", Item::Value(Value::from(pin.as_str())));
+    }
+}
+
+fn assert_no_workspace_inheritance(hex: &DocumentMut) -> Result<(), String> {
+    let mut offenders = Vec::new();
+    if let Some(pkg) = hex.get("package").and_then(Item::as_table_like) {
+        for (k, v) in pkg.iter() {
+            if value_is_workspace_inheritance(v) {
+                offenders.push(format!("[package].{k}.workspace"));
+            }
+        }
+    }
+    if let Some(deps) = hex.get("dependencies").and_then(Item::as_table_like) {
+        for (k, v) in deps.iter() {
+            if value_is_workspace_inheritance(v) {
+                offenders.push(format!("[dependencies].{k}.workspace"));
+            }
+        }
+    }
+    if offenders.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "rewrite did not eliminate all workspace inheritance: {}",
+            offenders.join(", ")
+        ))
+    }
+}
+
+fn assert_no_path_deps(hex: &DocumentMut) -> Result<(), String> {
+    let Some(deps) = hex.get("dependencies").and_then(Item::as_table_like) else {
+        return Ok(());
+    };
+    let offenders: Vec<String> = deps
+        .iter()
+        .filter(|(_, v)| value_has_path_key(v))
+        .map(|(k, _)| format!("[dependencies].{k}"))
+        .collect();
+    if offenders.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "rewrite did not eliminate all path deps: {}",
+            offenders.join(", ")
+        ))
+    }
+}
+
+fn value_is_workspace_inheritance(item: &Item) -> bool {
+    let Some(t) = item.as_table_like() else {
+        return false;
+    };
+    t.get("workspace")
+        .and_then(|v| v.as_value())
+        .and_then(|v| v.as_bool())
+        == Some(true)
+}
+
+fn value_is_path_only_dep(item: &Item) -> bool {
+    let Some(t) = item.as_table_like() else {
+        return false;
+    };
+    t.len() == 1 && t.contains_key("path")
+}
+
+fn value_has_path_key(item: &Item) -> bool {
+    let Some(t) = item.as_table_like() else {
+        return false;
+    };
+    t.contains_key("path")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace_fixture() -> &'static str {
+        r#"
+[workspace]
+members = ["engine"]
+
+[workspace.package]
+version = "0.8.12"
+edition = "2021"
+authors = ["Test <test@example.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/lemma/lemma"
+
+[workspace.dependencies]
+serde_json = "1.0"
+"#
+    }
+
+    fn hex_fixture() -> &'static str {
+        r#"[package]
+name = "lemma_hex"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lemma engine NIF crate for Elixir/Erlang"
+publish = false
+
+[lib]
+name = "lemma_hex"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+lemma-engine = { path = "../../../../" }
+lemma-openapi = { path = "../../../../../openapi" }
+rustler = "0.37"
+rust_decimal = "1"
+serde_json.workspace = true
+"#
+    }
+
+    #[test]
+    fn inlines_package_workspace_inheritance() {
+        let out = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        assert!(
+            out.contains(r#"version = "0.8.12""#),
+            "version inlined:\n{out}"
+        );
+        assert!(
+            out.contains(r#"edition = "2021""#),
+            "edition inlined:\n{out}"
+        );
+        assert!(
+            out.contains("Test <test@example.com>"),
+            "authors inlined:\n{out}"
+        );
+        assert!(out.contains("Apache-2.0"), "license inlined:\n{out}");
+        assert!(
+            out.contains("https://github.com/lemma/lemma"),
+            "repository inlined:\n{out}"
+        );
+    }
+
+    #[test]
+    fn inlines_dep_workspace_inheritance() {
+        let out = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        assert!(
+            out.contains(r#"serde_json = "1.0""#),
+            "serde_json inlined to literal version:\n{out}"
+        );
+    }
+
+    #[test]
+    fn pins_path_deps_to_workspace_version() {
+        let out = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        assert!(
+            out.contains(r#"lemma-engine = "=0.8.12""#),
+            "lemma-engine pinned:\n{out}"
+        );
+        assert!(
+            out.contains(r#"lemma-openapi = "=0.8.12""#),
+            "lemma-openapi pinned:\n{out}"
+        );
+    }
+
+    #[test]
+    fn no_workspace_inheritance_or_path_deps_remain() {
+        let out = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        assert!(
+            !out.contains(".workspace"),
+            "no .workspace = true survives:\n{out}"
+        );
+        let parsed: DocumentMut = out.parse().expect("output is valid TOML");
+        assert!(
+            assert_no_path_deps(&parsed).is_ok(),
+            "no path deps survive in [dependencies]:\n{out}"
+        );
+    }
+
+    #[test]
+    fn errors_when_workspace_dep_is_missing() {
+        let workspace = r#"
+[workspace.package]
+version = "0.8.12"
+edition = "2021"
+authors = ["A"]
+license = "A"
+repository = "R"
+"#;
+        let hex = r#"[package]
+name = "x"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde_json.workspace = true
+"#;
+        let err = rewrite(hex, workspace).unwrap_err();
+        assert!(err.contains("serde_json"), "missing dep is reported: {err}");
+    }
+
+    #[test]
+    fn errors_when_workspace_package_field_is_missing() {
+        let workspace = r#"
+[workspace.package]
+version = "0.8.12"
+"#;
+        let hex = r#"[package]
+name = "x"
+version.workspace = true
+edition.workspace = true
+"#;
+        let err = rewrite(hex, workspace).unwrap_err();
+        assert!(
+            err.contains("edition"),
+            "missing package key is reported: {err}"
+        );
+    }
+
+    #[test]
+    fn errors_when_workspace_version_is_missing() {
+        let workspace = r#"
+[workspace.package]
+edition = "2021"
+"#;
+        let hex = hex_fixture();
+        let err = rewrite(hex, workspace).unwrap_err();
+        assert!(
+            err.contains("version"),
+            "missing version is reported: {err}"
+        );
+    }
+
+    #[test]
+    fn pins_path_dep_with_extra_fields() {
+        let workspace = workspace_fixture();
+        let hex = r#"[package]
+name = "x"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+lemma-engine = { path = "../../../../", features = ["wasm"] }
+"#;
+        let out = rewrite(hex, workspace).unwrap();
+        assert!(!out.contains("path"), "path key dropped:\n{out}");
+        assert!(
+            out.contains(r#"version = "=0.8.12""#),
+            "version inserted alongside features:\n{out}"
+        );
+        assert!(out.contains("features"), "features preserved:\n{out}");
+    }
+
+    #[test]
+    fn rewrite_is_idempotent() {
+        let once = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        let twice = rewrite(&once, workspace_fixture()).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn preserves_unrelated_keys() {
+        let out = rewrite(hex_fixture(), workspace_fixture()).unwrap();
+        assert!(
+            out.contains(r#"description = "Lemma engine NIF crate for Elixir/Erlang""#),
+            "description preserved:\n{out}"
+        );
+        assert!(
+            out.contains("publish = false"),
+            "publish flag preserved:\n{out}"
+        );
+        assert!(
+            out.contains(r#"name = "lemma_hex""#),
+            "name preserved:\n{out}"
+        );
+        assert!(out.contains("crate-type"), "[lib] preserved:\n{out}");
+        assert!(
+            out.contains(r#"rustler = "0.37""#),
+            "rustler preserved:\n{out}"
+        );
+        assert!(
+            out.contains(r#"rust_decimal = "1""#),
+            "rust_decimal preserved:\n{out}"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,4 @@
+mod hex_standalone;
 mod versions;
 mod versions_diff;
 
@@ -118,7 +119,7 @@ fn precommit() {
 
 fn usage() {
     eprintln!(
-        "usage:\n  cargo precommit | cargo run -p xtask\n  cargo verify   | cargo run -p xtask -- versions-verify\n  cargo bump <version> | cargo run -p xtask -- versions-bump <version>\n  cargo changelog | cargo run -p xtask -- versions-diff [semver]"
+        "usage:\n  cargo precommit | cargo run -p xtask\n  cargo verify   | cargo run -p xtask -- versions-verify\n  cargo bump <version> | cargo run -p xtask -- versions-bump <version>\n  cargo changelog | cargo run -p xtask -- versions-diff [semver]\n  cargo run -p xtask -- hex-standalone"
     );
 }
 
@@ -147,6 +148,18 @@ fn main() {
                 std::process::exit(1);
             }
             eprintln!("versions-bump: set to {new_v}");
+        }
+        Some("hex-standalone") => {
+            if args.next().is_some() {
+                eprintln!("hex-standalone: takes no arguments");
+                usage();
+                std::process::exit(1);
+            }
+            let root = versions::workspace_root();
+            if let Err(e) = hex_standalone::run(&root) {
+                eprintln!("hex-standalone: {e}");
+                std::process::exit(1);
+            }
         }
         Some("versions-diff") => {
             let ver = args.next();


### PR DESCRIPTION
## [0.8.12] - 2026-04-28

Release-pipeline fixes only. No engine, CLI, or language changes.

### Fixed

- **Hex publish**: the standalone `Cargo.toml` rewrite for the published Hex tarball now also rewrites `lemma-openapi` from a workspace path dep to the matching registry version, mirroring the existing `lemma-engine` rewrite. Without this, end users compiling from the Hex tarball (or `mix hex.publish`'s own verification compile) saw two distinct `lemma-engine` instances — one pulled from crates.io via `lemma_hex`, one from the local path via `lemma-openapi` — producing type mismatches on shared types like `Engine` and `DateTimeValue`.

### Changed

- **npm release workflow**: `publish-npm` now uses npm Trusted Publishing (OIDC) via `npm/publish@v1.0.1` with `id-token: write`, eliminating the long-lived `NPM_TOKEN` secret and the `EOTP` 2FA failure mode for automation.
- **npm package metadata**: `engine/packages/npm/build.js` emits `repository.url` as `git+https://github.com/lemma/lemma.git`, silencing npm's autocorrect warning on publish.
