### PR TITLE
Release/0.8.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `cli-v{version}` (for example `cli-v0.8.5`). Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest `cli-v*` tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
+## [0.8.19] - 2026-06-11
+
+0.8.19 fixes registry resolution and quantity planning/materialization bugs; removes a redundant SDK method.
+
+### Added
+
+- **Quantity ceil/floor/round/abs**: preserve operand unit.
+
+### Fixed
+
+- **Registry resolve skips non-`@` repository qualifiers**: workspace-local repository references no longer trigger registry fetches.
+- **Decomposition promotion**: binding aliases no longer collide across quantity families.
+- **Materialization**: converted quantities honor type `decimals`; decimal overflow vetoes the rule.
+- **Inherited units**: conflicting inherited unit definitions rejected at planning.
+- **Unit-index validation**: structural plan checks run at planning and deserialize, not first `run`.
+
+### Removed
+
+- **`Engine.repositories()` / `Lemma.repositories/1`**: returned only `{ name, dependency }` per loaded repository — the same fields already on `list()[].repository`. Use `list()` for loaded-repo discovery.
+
 ## [0.8.18] - 2026-06-10
 
 0.8.18 completes the recorded-execution explanation architecture: explanations now read all runtime facts (register values, branch decisions, winning arm) from a recorded execution of the rule's source-shaped instruction stream — they never re-evaluate expressions. The language server is unified into the `lemma` CLI binary, eliminating the standalone `lsp` crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-lsp"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "lemma-engine",
  "lemma-openapi",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2204,9 +2204,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3225,9 +3225,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3854,18 +3854,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.8.18"
+version = "0.8.19"
 edition = "2021"
 authors = ["Ben Rogmans <ben@amrai.nl>"]
 description = "A language that means business."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,8 +16,8 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.18", path = "../engine", default-features = false }
-lemma-openapi = { version = "=0.8.18", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.8.19", path = "../engine", default-features = false }
+lemma-openapi = { version = "=0.8.19", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -53,6 +53,8 @@ Bare `veto` in `is veto` is not `veto "message"` (that form is only a rule/unles
 | `ceil` | Round up | `ceil(value)` or `ceil value` |
 | `round` | Round nearest | `round(value)` or `round value` |
 
+`ceil`, `floor`, `round`, and `abs` also accept **quantity** operands (the unit is preserved; the function applies to the magnitude in the operand's bound unit). All other mathematical operators require a **number** operand.
+
 Note: Mathematical operators are prefix operators, not functions. Parentheses are optional.
 
 ### Type cast (`as`)

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.8.18"
+lemma-engine = "0.8.19"
 ```
 
 ### Minimal example

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -26,7 +26,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.18", path = ".." }
+lemma = { package = "lemma-engine", version = "=0.8.19", path = ".." }
 async-trait = "0.1"
 serde_json.workspace = true
 

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "icon": "lemma_128.png",

--- a/engine/packages/hex/lib/lemma.ex
+++ b/engine/packages/hex/lib/lemma.ex
@@ -186,17 +186,6 @@ defmodule Lemma do
   end
 
   @doc """
-  Loaded repositories (workspace and dependencies). Each map has string keys `"name"` and `"dependency"`.
-  """
-  @spec repositories(engine()) :: {:ok, [map()]} | {:error, term()}
-  def repositories(engine) do
-    case Lemma.Native.lemma_repositories(engine) do
-      {:ok, binary} -> {:ok, Jason.decode!(binary)}
-      err -> err
-    end
-  end
-
-  @doc """
   Formats Lemma source code. Does not require an engine instance.
 
   ## Example

--- a/engine/packages/hex/lib/lemma/native.ex
+++ b/engine/packages/hex/lib/lemma/native.ex
@@ -39,8 +39,6 @@ defmodule Lemma.Native do
 
   def lemma_format(_code), do: :erlang.nif_error(:nif_not_loaded)
 
-  def lemma_repositories(_resource), do: :erlang.nif_error(:nif_not_loaded)
-
   def lemma_generate_openapi(_resource, _explanations_enabled, _effective_opt),
     do: :erlang.nif_error(:nif_not_loaded)
 

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.8.18"
+  @version "0.8.19"
   @source_url "https://github.com/lemma/lemma"
 
   def project do

--- a/engine/packages/hex/native/lemma_hex/src/lib.rs
+++ b/engine/packages/hex/native/lemma_hex/src/lib.rs
@@ -447,37 +447,6 @@ fn lemma_execution_plan<'a>(
 }
 
 #[rustler::nif]
-fn lemma_repositories<'a>(
-    env: Env<'a>,
-    resource: ResourceArc<LemmaEngineResource>,
-) -> NifResult<Term<'a>> {
-    let engine = resource
-        .0
-        .lock()
-        .map_err(|_| rustler::Error::RaiseTerm(Box::new("Engine lock poisoned".to_string())))?;
-    let rows: Vec<_> = engine
-        .list()
-        .iter()
-        .map(|r| {
-            json!({
-                "name": r.repository.name,
-                "dependency": r.repository.dependency,
-            })
-        })
-        .collect();
-
-    let json = serde_json::to_vec(&rows).map_err(|e| {
-        rustler::Error::RaiseTerm(Box::new(format!("repositories JSON failed: {}", e)))
-    })?;
-    let mut owned = OwnedBinary::new(json.len()).ok_or_else(|| {
-        rustler::Error::RaiseTerm(Box::new("Binary allocation failed".to_string()))
-    })?;
-    owned.as_mut_slice().copy_from_slice(&json);
-    let binary = rustler::Binary::from_owned(owned, env);
-    Ok((rustler::Atom::from_str(env, "ok")?, binary).encode(env))
-}
-
-#[rustler::nif]
 fn lemma_format<'a>(env: Env<'a>, code: String) -> NifResult<Term<'a>> {
     match lemma::format_source(&code, SourceType::Volatile) {
         Ok(formatted) => Ok((rustler::Atom::from_str(env, "ok")?, formatted).encode(env)),

--- a/engine/packages/npm/lemma.d.ts
+++ b/engine/packages/npm/lemma.d.ts
@@ -308,9 +308,3 @@ export interface LemmaSpecJson {
   rules: unknown[];
   meta_fields: unknown[];
 }
-
-/** One entry of {@link Engine.repositories}. */
-export interface RepositoryEntry {
-  name: string | null;
-  dependency: string | null;
-}

--- a/engine/src/computation/mod.rs
+++ b/engine/src/computation/mod.rs
@@ -3,9 +3,12 @@ pub mod bigint;
 pub mod comparison;
 pub mod datetime;
 pub mod decimal_math;
+pub mod quantity_math;
 pub mod range;
 pub mod rational;
 pub mod units;
+
+pub use quantity_math::mathematical_computation_preserves_quantity_magnitude;
 
 pub use arithmetic::arithmetic_operation;
 pub use comparison::comparison_operation;

--- a/engine/src/computation/quantity_math.rs
+++ b/engine/src/computation/quantity_math.rs
@@ -1,0 +1,109 @@
+use crate::evaluation::operations::{OperationResult, VetoType};
+use crate::planning::semantics::{LiteralValue, MathematicalComputation, ValueKind};
+
+pub fn mathematical_computation_preserves_quantity_magnitude(op: &MathematicalComputation) -> bool {
+    matches!(
+        op,
+        MathematicalComputation::Abs
+            | MathematicalComputation::Ceil
+            | MathematicalComputation::Floor
+            | MathematicalComputation::Round
+    )
+}
+
+fn apply_decimal_magnitude_op(
+    op: &MathematicalComputation,
+    magnitude: rust_decimal::Decimal,
+) -> rust_decimal::Decimal {
+    match op {
+        MathematicalComputation::Abs => magnitude.abs(),
+        MathematicalComputation::Floor => magnitude.floor(),
+        MathematicalComputation::Ceil => magnitude.ceil(),
+        MathematicalComputation::Round => magnitude.round(),
+        _ => unreachable!("BUG: non-magnitude-preserving op passed to apply_decimal_magnitude_op"),
+    }
+}
+
+pub fn quantity_magnitude_math(
+    op: &MathematicalComputation,
+    value: &LiteralValue,
+) -> OperationResult {
+    debug_assert!(mathematical_computation_preserves_quantity_magnitude(op));
+
+    let ValueKind::Quantity(canonical_magnitude, signature) = &value.value else {
+        unreachable!("BUG: quantity_magnitude_math called with non-quantity value");
+    };
+
+    if signature.len() != 1 || signature[0].1 != 1 {
+        return OperationResult::Veto(VetoType::computation(format!(
+            "Cannot apply '{op}' to quantity with compound unit; convert with `as <unit>` first"
+        )));
+    }
+    let unit_name = signature[0].0.clone();
+
+    let unit_factor = value.lemma_type.quantity_unit_factor(&unit_name);
+    let magnitude_in_unit =
+        match crate::computation::rational::checked_div(canonical_magnitude, unit_factor) {
+            Ok(magnitude) => magnitude,
+            Err(failure) => {
+                return OperationResult::Veto(VetoType::computation(failure.to_string()));
+            }
+        };
+
+    let magnitude_decimal =
+        match crate::computation::rational::commit_rational_to_decimal(&magnitude_in_unit) {
+            Ok(decimal) => decimal,
+            Err(_) => {
+                return OperationResult::Veto(VetoType::computation(
+                    "Mathematical operation requires a decimal-representable input",
+                ));
+            }
+        };
+
+    let rounded_decimal = apply_decimal_magnitude_op(op, magnitude_decimal);
+
+    let rounded_rational = match crate::computation::rational::decimal_to_rational(rounded_decimal)
+    {
+        Ok(rational) => rational,
+        Err(failure) => {
+            return OperationResult::Veto(VetoType::computation(failure.to_string()));
+        }
+    };
+
+    let new_canonical =
+        match crate::computation::rational::checked_mul(&rounded_rational, unit_factor) {
+            Ok(canonical) => canonical,
+            Err(failure) => {
+                return OperationResult::Veto(VetoType::computation(failure.to_string()));
+            }
+        };
+
+    OperationResult::Value(LiteralValue::quantity_with_type(
+        new_canonical,
+        unit_name,
+        value.lemma_type.clone(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::computation::rational::rational_new;
+    use crate::planning::semantics::anonymous_quantity_type;
+    use std::sync::Arc;
+
+    #[test]
+    fn compound_signature_vetoes() {
+        let value = LiteralValue::quantity_with_signature(
+            rational_new(100, 1),
+            vec![("meter".to_string(), 1), ("second".to_string(), -1)],
+            Arc::new(anonymous_quantity_type()),
+        );
+        let result = quantity_magnitude_math(&MathematicalComputation::Ceil, &value);
+        assert!(
+            result.vetoed(),
+            "compound signature must veto, got {:?}",
+            result
+        );
+    }
+}

--- a/engine/src/computation/units.rs
+++ b/engine/src/computation/units.rs
@@ -8,11 +8,13 @@ use crate::evaluation::operations::OperationResult;
 use crate::parsing::ast::PrimitiveKind;
 use crate::planning::semantics::{
     calendar_unit_factor, primitive_number_arc, primitive_text_arc, LiteralValue,
-    SemanticCalendarUnit, SemanticConversionTarget, ValueKind,
+    SemanticCalendarUnit, SemanticConversionTarget, TypeSpecification, ValueKind,
 };
 use std::sync::Arc;
 
-/// Describes what type-resolution infrastructure is available at a `convert_unit` call site.
+/// Describes what type-resolution infrastructure is available at call sites that
+/// still resolve unit names from an expression-scope index (arithmetic naming,
+/// explanation equivalence across families).
 #[derive(Copy, Clone)]
 pub enum UnitResolutionContext<'a> {
     WithIndex(
@@ -25,11 +27,7 @@ pub enum UnitResolutionContext<'a> {
 }
 
 /// Apply a type cast (`as <target>`).
-pub fn convert_unit(
-    value: &LiteralValue,
-    target: &SemanticConversionTarget,
-    resolution_context: UnitResolutionContext<'_>,
-) -> OperationResult {
+pub fn convert_unit(value: &LiteralValue, target: &SemanticConversionTarget) -> OperationResult {
     match target {
         SemanticConversionTarget::Type(PrimitiveKind::Number) => cast_to_number(value),
         SemanticConversionTarget::Type(PrimitiveKind::Text) => OperationResult::Value(
@@ -56,14 +54,14 @@ pub fn convert_unit(
                 );
             }
         }
-        SemanticConversionTarget::Unit { unit_name } => {
-            cast_to_unit(value, unit_name, resolution_context)
-        }
+        SemanticConversionTarget::Unit {
+            unit_name,
+            owning_type,
+        } => cast_to_unit(value, unit_name, owning_type),
     }
 }
 
 fn same_primitive_kind(value: &LiteralValue, target: PrimitiveKind) -> bool {
-    use crate::planning::semantics::TypeSpecification;
     matches!(
         (target, &value.lemma_type.specifications),
         (PrimitiveKind::Number, TypeSpecification::Number { .. })
@@ -79,24 +77,24 @@ fn same_primitive_kind(value: &LiteralValue, target: PrimitiveKind) -> bool {
 fn cast_to_unit(
     value: &LiteralValue,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
     match &value.value {
         ValueKind::Number(magnitude) => {
-            cast_number_to_unit(magnitude.clone(), unit_name, resolution_context)
+            cast_number_to_unit(magnitude.clone(), unit_name, owning_type)
         }
         ValueKind::Quantity(magnitude, _) => {
-            cast_quantity_to_unit(magnitude.clone(), unit_name, resolution_context)
+            cast_quantity_to_unit(magnitude.clone(), unit_name, owning_type)
         }
         ValueKind::Range(left, right) => {
-            cast_range_span_to_unit(left, right, unit_name, resolution_context)
+            cast_range_span_to_unit(left, right, unit_name, owning_type)
         }
         ValueKind::Ratio(magnitude, from_unit) => cast_ratio_to_unit(
             value,
             magnitude.clone(),
             from_unit.as_deref(),
             unit_name,
-            resolution_context,
+            owning_type,
         ),
         other => unreachable!(
             "BUG: unit cast from {:?} should be rejected at planning",
@@ -108,25 +106,16 @@ fn cast_to_unit(
 fn cast_number_to_unit(
     magnitude: RationalInteger,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
-    let UnitResolutionContext::WithIndex(unit_index) = resolution_context else {
-        unreachable!("BUG: unit cast requires unit index at evaluation");
-    };
-    let target_type = unit_index.get(unit_name).unwrap_or_else(|| {
-        unreachable!(
-            "BUG: unit '{}' missing from expression unit index after planning",
-            unit_name
-        )
-    });
-    if target_type.is_ratio() {
+    if owning_type.is_ratio() {
         return OperationResult::Value(LiteralValue::ratio_with_type(
             magnitude,
             Some(unit_name.to_string()),
-            Arc::clone(target_type),
+            Arc::clone(owning_type),
         ));
     }
-    let factor = target_type.quantity_unit_factor(unit_name).clone();
+    let factor = owning_type.quantity_unit_factor(unit_name).clone();
     let canonical = match checked_mul(&magnitude, &factor) {
         Ok(v) => v,
         Err(failure) => {
@@ -138,28 +127,19 @@ fn cast_number_to_unit(
     OperationResult::Value(LiteralValue::quantity_with_type(
         canonical,
         unit_name.to_string(),
-        Arc::clone(target_type),
+        Arc::clone(owning_type),
     ))
 }
 
 fn cast_quantity_to_unit(
     magnitude: RationalInteger,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
-    let UnitResolutionContext::WithIndex(unit_index) = resolution_context else {
-        unreachable!("BUG: quantity unit cast requires unit index at evaluation");
-    };
-    let target_type = unit_index.get(unit_name).unwrap_or_else(|| {
-        unreachable!(
-            "BUG: unit '{}' missing from expression unit index after planning",
-            unit_name
-        )
-    });
     OperationResult::Value(LiteralValue::quantity_with_type(
         magnitude,
         unit_name.to_string(),
-        Arc::clone(target_type),
+        Arc::clone(owning_type),
     ))
 }
 
@@ -168,22 +148,13 @@ fn cast_ratio_to_unit(
     magnitude: RationalInteger,
     from_unit: Option<&str>,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
-    let UnitResolutionContext::WithIndex(unit_index) = resolution_context else {
-        unreachable!("BUG: ratio unit cast requires unit index at evaluation");
-    };
-    let target_type = unit_index.get(unit_name).unwrap_or_else(|| {
-        unreachable!(
-            "BUG: unit '{}' missing from expression unit index after planning",
-            unit_name
-        )
-    });
-    if value.lemma_type.same_quantity_family(target_type.as_ref()) {
+    if value.lemma_type.same_quantity_family(owning_type.as_ref()) {
         let from_factor = from_unit
             .map(|u| value.lemma_type.quantity_unit_factor(u).clone())
             .unwrap_or(rational_one());
-        let to_factor = target_type.quantity_unit_factor(unit_name).clone();
+        let to_factor = owning_type.quantity_unit_factor(unit_name).clone();
         let converted =
             match convert_quantity_magnitude_rational(magnitude, &from_factor, &to_factor) {
                 Ok(m) => m,
@@ -196,13 +167,13 @@ fn cast_ratio_to_unit(
         OperationResult::Value(LiteralValue::ratio_with_type(
             converted,
             Some(unit_name.to_string()),
-            Arc::clone(target_type),
+            Arc::clone(owning_type),
         ))
     } else {
         OperationResult::Value(LiteralValue::ratio_with_type(
             magnitude,
             Some(unit_name.to_string()),
-            Arc::clone(target_type),
+            Arc::clone(owning_type),
         ))
     }
 }
@@ -211,29 +182,21 @@ fn cast_range_span_to_unit(
     left: &LiteralValue,
     right: &LiteralValue,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
     if let (ValueKind::Date(left_date), ValueKind::Date(right_date)) = (&left.value, &right.value) {
         if calendar_unit_factor(unit_name).is_some() {
-            let UnitResolutionContext::WithIndex(unit_index) = resolution_context else {
-                unreachable!("BUG: calendar date span requires unit index after planning");
-            };
-            let calendar_type = Arc::clone(
-                unit_index
-                    .get(unit_name)
-                    .expect("BUG: calendar unit must be in index after planning"),
-            );
             return super::datetime::compute_date_calendar_difference(
                 left_date,
                 right_date,
                 &semantic_calendar_unit(unit_name),
-                calendar_type,
+                Arc::clone(owning_type),
             );
         }
         let OperationResult::Value(span) = super::range::compute_span(left, right) else {
             return super::range::compute_span(left, right);
         };
-        return convert_span_quantity_to_unit(&span, unit_name, resolution_context);
+        return convert_span_quantity_to_unit(&span, unit_name, owning_type);
     }
 
     let OperationResult::Value(span) = super::range::compute_span(left, right) else {
@@ -241,9 +204,7 @@ fn cast_range_span_to_unit(
     };
     let span = &span;
     match &span.value {
-        ValueKind::Quantity(_, _) => {
-            convert_span_quantity_to_unit(span, unit_name, resolution_context)
-        }
+        ValueKind::Quantity(_, _) => convert_span_quantity_to_unit(span, unit_name, owning_type),
         ValueKind::Ratio(_, _) => {
             let ValueKind::Ratio(magnitude, from_unit) = &span.value else {
                 unreachable!("BUG: ratio span expected");
@@ -253,11 +214,11 @@ fn cast_range_span_to_unit(
                 magnitude.clone(),
                 from_unit.as_deref(),
                 unit_name,
-                resolution_context,
+                owning_type,
             )
         }
         ValueKind::Number(magnitude) => {
-            cast_number_to_unit(magnitude.clone(), unit_name, resolution_context)
+            cast_number_to_unit(magnitude.clone(), unit_name, owning_type)
         }
         other => unreachable!("BUG: unexpected range span value kind for unit cast: {other:?}"),
     }
@@ -266,12 +227,12 @@ fn cast_range_span_to_unit(
 fn convert_span_quantity_to_unit(
     span: &LiteralValue,
     unit_name: &str,
-    resolution_context: UnitResolutionContext<'_>,
+    owning_type: &Arc<crate::planning::semantics::LemmaType>,
 ) -> OperationResult {
     let ValueKind::Quantity(magnitude, _) = &span.value else {
         unreachable!("BUG: span quantity expected");
     };
-    cast_quantity_to_unit(magnitude.clone(), unit_name, resolution_context)
+    cast_quantity_to_unit(magnitude.clone(), unit_name, owning_type)
 }
 
 fn semantic_calendar_unit(unit_name: &str) -> SemanticCalendarUnit {
@@ -341,5 +302,28 @@ fn cast_to_number(value: &LiteralValue) -> OperationResult {
             "BUG: cast to number from {:?} should be rejected at planning",
             value.lemma_type.name()
         ),
+    }
+}
+
+pub(crate) fn conversion_target_declares_unit(
+    target: &SemanticConversionTarget,
+) -> Option<(&str, &Arc<crate::planning::semantics::LemmaType>)> {
+    match target {
+        SemanticConversionTarget::Unit {
+            unit_name,
+            owning_type,
+        } => Some((unit_name.as_str(), owning_type)),
+        SemanticConversionTarget::Type(_) => None,
+    }
+}
+
+pub(crate) fn owning_type_declares_unit_name(
+    owning_type: &crate::planning::semantics::LemmaType,
+    unit_name: &str,
+) -> bool {
+    match &owning_type.specifications {
+        TypeSpecification::Quantity { units, .. } => units.get(unit_name).is_ok(),
+        TypeSpecification::Ratio { units, .. } => units.get(unit_name).is_ok(),
+        _ => false,
     }
 }

--- a/engine/src/evaluation/explanations.rs
+++ b/engine/src/evaluation/explanations.rs
@@ -188,14 +188,16 @@ fn conversion_rule_step_text(
         ValueKind::Range(left, right) => range_span_rule_step_text(left, right, result),
         ValueKind::Quantity(_, from_signature) if !value.lemma_type.is_calendar_like() => {
             match target {
-                SemanticConversionTarget::Unit { unit_name } => {
-                    quantity_unit_equivalence_step_text(
-                        from_signature,
-                        unit_name,
-                        &value.lemma_type,
-                        resolution_context,
-                    )
-                }
+                SemanticConversionTarget::Unit {
+                    unit_name,
+                    owning_type,
+                } => quantity_unit_equivalence_step_text(
+                    from_signature,
+                    unit_name,
+                    &value.lemma_type,
+                    owning_type.as_ref(),
+                    resolution_context,
+                ),
                 _ => None,
             }
         }
@@ -231,6 +233,7 @@ fn quantity_unit_equivalence_step_text(
     from_signature: &[(String, i32)],
     to_unit: &str,
     lemma_type: &LemmaType,
+    target_owning_type: &LemmaType,
     resolution_context: UnitResolutionContext<'_>,
 ) -> Option<String> {
     let from_unit = from_signature
@@ -259,11 +262,10 @@ fn quantity_unit_equivalence_step_text(
         return Some(format!("1 {from_unit} is {multiplier_display} {to_unit}"));
     }
 
+    let to_factor = target_owning_type.quantity_unit_factor(to_unit).clone();
     let UnitResolutionContext::WithIndex(unit_index) = resolution_context else {
         return None;
     };
-    let target_type = unit_index.get(to_unit)?;
-    let to_factor = target_type.quantity_unit_factor(to_unit).clone();
     let from_factor =
         crate::planning::semantics::signature_factor(from_signature, unit_index, None);
     let multiplier = checked_div(&from_factor, &to_factor).ok()?;
@@ -788,11 +790,15 @@ fn unit_equivalence_nodes(
                 .iter()
                 .find(|earlier| same_quantity_family(unit, earlier, unit_index))
             {
-                if let Some(owning) = unit_index.get(unit.as_str()) {
+                if let (Some(owning), Some(target_owning)) = (
+                    unit_index.get(unit.as_str()),
+                    unit_index.get(earlier.as_str()),
+                ) {
                     if let Some(text) = quantity_unit_equivalence_step_text(
                         &[(unit.clone(), 1)],
                         earlier,
                         owning,
+                        target_owning,
                         UnitResolutionContext::WithIndex(unit_index),
                     ) {
                         nodes.push(ExplanationNode::UnitEquivalence { text });
@@ -1399,8 +1405,9 @@ mod tests {
     use crate::parsing::ast::DateTimeValue;
     use crate::parsing::source::SourceType;
     use crate::planning::semantics::{
-        date_time_to_semantic, DataPath, LemmaType, LiteralValue, QuantityUnits, RulePath,
-        SemanticConversionTarget, TypeSpecification, ValueKind,
+        date_time_to_semantic, duration_decomposition, DataPath, LemmaType, LiteralValue,
+        QuantityTrait, QuantityUnits, RulePath, SemanticConversionTarget, TypeSpecification,
+        ValueKind,
     };
     use crate::Engine;
     use rust_decimal::Decimal;
@@ -1689,13 +1696,18 @@ rule total: subtotal + vat
             "kilogram".to_string(),
             Arc::clone(&lemma_type),
         );
-        let result =
-            LiteralValue::quantity_with_type(rational_new(2, 1), "gram".to_string(), lemma_type);
+        let gram_target = Arc::clone(&lemma_type);
+        let result = LiteralValue::quantity_with_type(
+            rational_new(2, 1),
+            "gram".to_string(),
+            Arc::clone(&lemma_type),
+        );
         let path = DataPath::local("mass".to_string());
         let steps = build_conversion_steps(
             &operand,
             &SemanticConversionTarget::Unit {
                 unit_name: "gram".to_string(),
+                owning_type: gram_target,
             },
             &result,
             Some(&path),
@@ -1741,6 +1753,20 @@ rule total: subtotal + vat
             value: ValueKind::Range(Box::new(left), Box::new(right)),
             lemma_type: Arc::new(LemmaType::primitive(TypeSpecification::date_range())),
         };
+        let mut duration_units = QuantityUnits::new();
+        duration_units.0.push(
+            QuantityUnit::from_decimal_factor("days".to_string(), Decimal::from(86_400), vec![])
+                .unwrap(),
+        );
+        let days_owning_type = Arc::new(LemmaType::primitive(TypeSpecification::Quantity {
+            minimum: None,
+            maximum: None,
+            decimals: None,
+            units: duration_units,
+            traits: vec![QuantityTrait::Duration],
+            decomposition: Some(duration_decomposition()),
+            help: String::new(),
+        }));
         let result = LiteralValue::quantity_with_type(
             rational_new(14, 1),
             "days".to_string(),
@@ -1751,6 +1777,7 @@ rule total: subtotal + vat
             &range,
             &SemanticConversionTarget::Unit {
                 unit_name: "days".to_string(),
+                owning_type: days_owning_type,
             },
             &result,
             Some(&path),
@@ -1785,6 +1812,7 @@ rule total: subtotal + vat
             "kilogram".to_string(),
             Arc::clone(&lemma_type),
         );
+        let kilogram_target = Arc::clone(&lemma_type);
         let result = LiteralValue::quantity_with_type(
             rational_new(2, 1),
             "kilogram".to_string(),
@@ -1794,6 +1822,7 @@ rule total: subtotal + vat
             &operand,
             &SemanticConversionTarget::Unit {
                 unit_name: "kilogram".to_string(),
+                owning_type: kilogram_target,
             },
             &result,
             None,

--- a/engine/src/evaluation/expression.rs
+++ b/engine/src/evaluation/expression.rs
@@ -3,6 +3,9 @@
 //! All runtime errors (division by zero, etc.) result in Veto instead of errors.
 
 use super::operations::{OperationResult, VetoType};
+use crate::computation::quantity_math::{
+    mathematical_computation_preserves_quantity_magnitude, quantity_magnitude_math,
+};
 use crate::planning::semantics::{LiteralValue, MathematicalComputation, ValueKind};
 
 pub(crate) fn evaluate_mathematical_operator(
@@ -11,6 +14,12 @@ pub(crate) fn evaluate_mathematical_operator(
 ) -> OperationResult {
     use crate::computation::decimal_math::{decimal_acos, decimal_asin, decimal_atan};
     use rust_decimal::MathematicalOps;
+
+    if matches!(&value.value, ValueKind::Quantity(_, _))
+        && mathematical_computation_preserves_quantity_magnitude(op)
+    {
+        return quantity_magnitude_math(op, value);
+    }
 
     match &value.value {
         ValueKind::Number(stored_rational) => {

--- a/engine/src/evaluation/mod.rs
+++ b/engine/src/evaluation/mod.rs
@@ -371,7 +371,7 @@ pub(crate) fn execute_instructions(
                     continue;
                 }
                 let source_val = unwrap_literal(source, "operand");
-                let result = convert_unit(&source_val, target, unit_ctx);
+                let result = convert_unit(&source_val, target);
                 context.write_register(*destination_register, result);
             }
             Instruction::Mathematical {

--- a/engine/src/evaluation/partial.rs
+++ b/engine/src/evaluation/partial.rs
@@ -70,11 +70,7 @@ pub(crate) fn try_resolve_value(
 
         ExpressionKind::UnitConversion(inner_expr, target) => {
             let inner_value = try_resolve_value(inner_expr, known_values, plan)?;
-            match convert_unit(
-                &inner_value,
-                target,
-                UnitResolutionContext::WithIndex(unit_index),
-            ) {
+            match convert_unit(&inner_value, target) {
                 OperationResult::Value(result) => Some(result),
                 OperationResult::Veto(_) => None,
             }

--- a/engine/src/evaluation/response.rs
+++ b/engine/src/evaluation/response.rs
@@ -1,5 +1,7 @@
+use crate::computation::rational::NumericFailure;
 use crate::evaluation::explanations::Explanation;
 use crate::evaluation::operations::{OperationResult, VetoType};
+use crate::evaluation::DECIMAL_VALUE_LIMIT_VETO_MESSAGE;
 use crate::parsing::ast::DateTimeValue;
 use crate::planning::semantics::{
     range_element_type_specification, DataPath, LemmaType, LiteralValue, RulePath,
@@ -152,58 +154,66 @@ impl RuleResult {
                 range: None,
                 explanation,
             },
-            OperationResult::Value(literal) => {
-                let mut result = Self {
-                    rule,
-                    veto_detail: None,
-                    vetoed: false,
-                    display: None,
-                    veto_reason: None,
-                    rule_type: rule_type_name,
-                    quantity: None,
-                    ratio: None,
-                    number: None,
-                    boolean: None,
-                    text: None,
-                    date: None,
-                    time: None,
-                    calendar: None,
-                    range: None,
-                    explanation,
-                };
-                match &literal.value {
-                    ValueKind::Range(from, to) => {
-                        let endpoint_type = element_type_from_range_rule(rule_type)
-                            .unwrap_or_else(|| rule_type.clone());
-                        result.range = Some(RangeResult {
-                            from: materialize_payload(
-                                from,
-                                &endpoint_materialization_type(from, &endpoint_type),
-                                expression_units,
-                            ),
-                            to: materialize_payload(
-                                to,
-                                &endpoint_materialization_type(to, &endpoint_type),
-                                expression_units,
-                            ),
-                        });
-                        result.display = Some(literal.to_string());
-                    }
-                    _ => {
-                        let payload = materialize_payload(&literal, rule_type, expression_units);
-                        result.quantity = payload.quantity;
-                        result.ratio = payload.ratio;
-                        result.number = payload.number;
-                        result.boolean = payload.boolean;
-                        result.text = payload.text;
-                        result.date = payload.date;
-                        result.time = payload.time;
-                        result.calendar = payload.calendar;
-                        result.display = Some(literal.to_string());
+            OperationResult::Value(literal) => match &literal.value {
+                ValueKind::Range(from, to) => {
+                    let endpoint_type = element_type_from_range_rule(rule_type)
+                        .unwrap_or_else(|| rule_type.clone());
+                    let from_type = endpoint_materialization_type(from, &endpoint_type);
+                    let to_type = endpoint_materialization_type(to, &endpoint_type);
+                    match (
+                        materialize_payload(from, &from_type, expression_units),
+                        materialize_payload(to, &to_type, expression_units),
+                    ) {
+                        (Ok(from_payload), Ok(to_payload)) => Self {
+                            rule,
+                            veto_detail: None,
+                            vetoed: false,
+                            display: Some(literal.to_string()),
+                            veto_reason: None,
+                            rule_type: rule_type_name,
+                            quantity: None,
+                            ratio: None,
+                            number: None,
+                            boolean: None,
+                            text: None,
+                            date: None,
+                            time: None,
+                            calendar: None,
+                            range: Some(RangeResult {
+                                from: from_payload,
+                                to: to_payload,
+                            }),
+                            explanation,
+                        },
+                        _ => {
+                            vetoed_rule_result_for_decimal_limit(rule, rule_type_name, explanation)
+                        }
                     }
                 }
-                result
-            }
+                _ => match materialize_payload(&literal, rule_type, expression_units) {
+                    Ok(payload) => Self {
+                        rule,
+                        veto_detail: None,
+                        vetoed: false,
+                        display: Some(literal.to_string()),
+                        veto_reason: None,
+                        rule_type: rule_type_name,
+                        quantity: payload.quantity,
+                        ratio: payload.ratio,
+                        number: payload.number,
+                        boolean: payload.boolean,
+                        text: payload.text,
+                        date: payload.date,
+                        time: payload.time,
+                        calendar: payload.calendar,
+                        range: None,
+                        explanation,
+                    },
+                    Err(_) => {
+                        vetoed_rule_result_for_decimal_limit(rule, rule_type_name, explanation)
+                    }
+                },
+            },
         }
     }
 
@@ -420,68 +430,89 @@ fn endpoint_materialization_type(
     }
 }
 
+fn vetoed_rule_result_for_decimal_limit(
+    rule: EvaluatedRule,
+    rule_type_name: String,
+    explanation: Option<Explanation>,
+) -> RuleResult {
+    let veto = VetoType::computation(DECIMAL_VALUE_LIMIT_VETO_MESSAGE);
+    RuleResult {
+        rule,
+        veto_detail: Some(veto.clone()),
+        vetoed: true,
+        display: None,
+        veto_reason: Some(veto.to_string()),
+        rule_type: rule_type_name,
+        quantity: None,
+        ratio: None,
+        number: None,
+        boolean: None,
+        text: None,
+        date: None,
+        time: None,
+        calendar: None,
+        range: None,
+        explanation,
+    }
+}
+
 fn materialize_payload(
     literal: &crate::planning::semantics::LiteralValue,
     result_type: &LemmaType,
     _expression_units: &std::collections::HashMap<String, Arc<LemmaType>>,
-) -> RuleResultPayload {
+) -> Result<RuleResultPayload, NumericFailure> {
     match &literal.value {
         ValueKind::Quantity(rational, sig) if literal.lemma_type.is_calendar_like() => {
             let unit =
                 crate::planning::semantics::semantic_calendar_unit_from_quantity_signature(sig);
-            RuleResultPayload {
+            Ok(RuleResultPayload {
                 calendar: Some(CalendarResult {
-                    value: rational_to_decimal_string(rational),
+                    value: literal
+                        .lemma_type
+                        .try_materialize_rational_as_decimal_string(rational)?,
                     unit: unit.to_string(),
                 }),
                 ..RuleResultPayload::default()
-            }
+            })
         }
-        ValueKind::Quantity(_, _) => RuleResultPayload {
-            quantity: Some(quantity_to_unit_map(literal, result_type)),
+        ValueKind::Quantity(_, _) => Ok(RuleResultPayload {
+            quantity: Some(quantity_to_unit_map(literal, result_type)?),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Ratio(_, _) => RuleResultPayload {
-            ratio: Some(ratio_to_unit_map(literal, result_type)),
+        }),
+        ValueKind::Ratio(_, _) => Ok(RuleResultPayload {
+            ratio: Some(ratio_to_unit_map(literal, result_type)?),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Number(rational) => RuleResultPayload {
-            number: Some(rational_to_decimal_string(rational)),
+        }),
+        ValueKind::Number(rational) => Ok(RuleResultPayload {
+            number: Some(result_type.try_materialize_rational_as_decimal_string(rational)?),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Boolean(b) => RuleResultPayload {
+        }),
+        ValueKind::Boolean(b) => Ok(RuleResultPayload {
             boolean: Some(*b),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Text(s) => RuleResultPayload {
+        }),
+        ValueKind::Text(s) => Ok(RuleResultPayload {
             text: Some(s.clone()),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Date(d) => RuleResultPayload {
+        }),
+        ValueKind::Date(d) => Ok(RuleResultPayload {
             date: Some(d.clone()),
             ..RuleResultPayload::default()
-        },
-        ValueKind::Time(t) => RuleResultPayload {
+        }),
+        ValueKind::Time(t) => Ok(RuleResultPayload {
             time: Some(t.clone()),
             ..RuleResultPayload::default()
-        },
+        }),
         ValueKind::Range(_, _) => {
             panic!("BUG: range payload must be built at RuleResult level, not RuleResultPayload")
         }
     }
 }
 
-fn rational_to_decimal_string(rational: &crate::computation::rational::RationalInteger) -> String {
-    crate::literals::rational_to_serialized_str(rational)
-        .expect("BUG: rule result magnitude must serialize to decimal string")
-}
-
 fn quantity_to_unit_map(
     literal: &crate::planning::semantics::LiteralValue,
     result_type: &LemmaType,
-) -> BTreeMap<String, String> {
-    use crate::computation::rational::checked_div;
-
+) -> Result<BTreeMap<String, String>, NumericFailure> {
     let unit_names = result_type
         .quantity_unit_names()
         .expect("BUG: rule result quantity must have declared units");
@@ -490,33 +521,26 @@ fn quantity_to_unit_map(
     };
     let mut map = BTreeMap::new();
     for unit_name in unit_names {
-        let to_factor = result_type.quantity_unit_factor(unit_name);
-        let converted = checked_div(magnitude, to_factor).unwrap_or_else(|failure| {
-            panic!(
-                "BUG: quantity unit conversion to '{}' failed at rule result materialization: {}",
-                unit_name, failure
-            )
-        });
-        map.insert(
-            unit_name.to_string(),
-            rational_to_decimal_string(&converted),
-        );
+        let materialized =
+            result_type.try_materialize_quantity_canonical_in_unit(magnitude, unit_name)?;
+        map.insert(unit_name.to_string(), materialized);
     }
-    map
+    Ok(map)
 }
 
 fn ratio_to_unit_map(
     literal: &crate::planning::semantics::LiteralValue,
     result_type: &LemmaType,
-) -> BTreeMap<String, String> {
-    use crate::computation::rational::checked_mul;
-
-    let units = match &result_type.specifications {
-        TypeSpecification::Ratio { units, .. } => units,
+) -> Result<BTreeMap<String, String>, NumericFailure> {
+    let materialization_type = match &result_type.specifications {
+        TypeSpecification::Ratio { .. } => result_type,
         TypeSpecification::RatioRange { .. } => {
             let element = range_element_type_specification(&result_type.specifications)
                 .expect("BUG: ratio range rule type must have ratio element specification");
-            let TypeSpecification::Ratio { units, .. } = element else {
+            let TypeSpecification::Ratio {
+                units, decimals, ..
+            } = element
+            else {
                 panic!("BUG: ratio range element spec must be Ratio");
             };
             return ratio_to_unit_map(
@@ -524,7 +548,7 @@ fn ratio_to_unit_map(
                 &LemmaType::primitive(TypeSpecification::Ratio {
                     minimum: None,
                     maximum: None,
-                    decimals: None,
+                    decimals,
                     units,
                     help: String::new(),
                 }),
@@ -537,6 +561,10 @@ fn ratio_to_unit_map(
             );
         }
     };
+    let units = match &materialization_type.specifications {
+        TypeSpecification::Ratio { units, .. } => units,
+        _ => unreachable!("BUG: ratio materialization type must be Ratio"),
+    };
     let ValueKind::Ratio(canonical, _) = &literal.value else {
         panic!("BUG: ratio_to_unit_map called with non-ratio value");
     };
@@ -548,15 +576,11 @@ fn ratio_to_unit_map(
     }
     let mut map = BTreeMap::new();
     for unit in units.iter() {
-        let display = checked_mul(canonical, &unit.value).unwrap_or_else(|failure| {
-            panic!(
-                "BUG: ratio unit conversion to '{}' failed at rule result materialization: {}",
-                unit.name, failure
-            )
-        });
-        map.insert(unit.name.clone(), rational_to_decimal_string(&display));
+        let materialized =
+            materialization_type.try_materialize_ratio_canonical_in_unit(canonical, &unit.name)?;
+        map.insert(unit.name.clone(), materialized);
     }
-    map
+    Ok(map)
 }
 
 impl Response {
@@ -796,7 +820,7 @@ mod tests {
             None,
         );
         let quantity = result.quantity.expect("quantity map");
-        assert_eq!(quantity.get("usd"), Some(&"10".to_string()));
+        assert_eq!(quantity.get("usd"), Some(&"10.00".to_string()));
         assert!(quantity.contains_key("eur"));
     }
 
@@ -819,9 +843,65 @@ mod tests {
             None,
         );
         let quantity = result.quantity.expect("quantity map");
-        assert_eq!(quantity.get("eur"), Some(&"10".to_string()));
-        assert!(quantity.contains_key("usd"));
-        assert!(quantity["usd"].starts_with("10.9"));
+        assert_eq!(quantity.get("eur"), Some(&"10.00".to_string()));
+        assert_eq!(quantity.get("usd"), Some(&"10.99".to_string()));
+    }
+
+    #[test]
+    fn quantity_materialization_respects_decimals_on_unit_conversion() {
+        let money = LemmaType::new(
+            "money".to_string(),
+            TypeSpecification::Quantity {
+                minimum: None,
+                maximum: None,
+                decimals: Some(2),
+                units: QuantityUnits::from(vec![
+                    QuantityUnit {
+                        name: "eur".to_string(),
+                        factor: crate::computation::rational::rational_one(),
+                        derived_quantity_factors: Vec::new(),
+                        decomposition: BaseQuantityVector::new(),
+                        minimum: None,
+                        maximum: None,
+                        default_magnitude: None,
+                    },
+                    QuantityUnit {
+                        name: "usd".to_string(),
+                        factor: crate::computation::rational::decimal_to_rational(Decimal::new(
+                            84, 2,
+                        ))
+                        .expect("usd factor"),
+                        derived_quantity_factors: Vec::new(),
+                        decomposition: BaseQuantityVector::new(),
+                        minimum: None,
+                        maximum: None,
+                        default_magnitude: None,
+                    },
+                ]),
+                traits: Vec::new(),
+                decomposition: Some(BaseQuantityVector::new()),
+                help: String::new(),
+            },
+            TypeExtends::Primitive,
+        );
+        let three_twelve_eur = LiteralValue {
+            value: ValueKind::Quantity(
+                crate::computation::rational::decimal_to_rational(Decimal::new(312, 2))
+                    .expect("3.12 eur canonical"),
+                vec![],
+            ),
+            lemma_type: Arc::new(money.clone()),
+        };
+        let result = RuleResult::from_operation_result(
+            dummy_evaluated_rule("delivery_cost", &money),
+            OperationResult::Value(three_twelve_eur),
+            &money,
+            &HashMap::new(),
+            None,
+        );
+        let quantity = result.quantity.expect("quantity map");
+        assert_eq!(quantity.get("eur"), Some(&"3.12".to_string()));
+        assert_eq!(quantity.get("usd"), Some(&"3.71".to_string()));
     }
 
     #[test]

--- a/engine/src/planning/execution_plan.rs
+++ b/engine/src/planning/execution_plan.rs
@@ -25,7 +25,7 @@ use crate::Error;
 use crate::ResourceLimits;
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// One spec's contribution to an [`ExecutionPlan`], together with its
@@ -1491,18 +1491,14 @@ pub(crate) fn validate_value_against_type(
         }
     }
 
-    fn format_rational(r: &RationalInteger, decimals: Option<u8>) -> String {
+    fn format_rational_for_validation_message(
+        expected_type: &crate::planning::semantics::LemmaType,
+        magnitude: &RationalInteger,
+    ) -> String {
         use crate::computation::rational::rational_to_display_str;
-        match commit_rational_to_decimal(r) {
-            Ok(decimal) => match decimals {
-                Some(dp) => {
-                    let rounded = decimal.round_dp(u32::from(dp));
-                    format!("{:.prec$}", rounded, prec = dp as usize)
-                }
-                None => decimal.normalize().to_string(),
-            },
-            Err(_) => rational_to_display_str(r),
-        }
+        expected_type
+            .try_materialize_rational_as_decimal_string(magnitude)
+            .unwrap_or_else(|_| rational_to_display_str(magnitude))
     }
 
     match (&expected_type.specifications, &value.value) {
@@ -1519,7 +1515,7 @@ pub(crate) fn validate_value_against_type(
                 if exceeds_decimal_places(n, *d) {
                     return Err(format!(
                         "{} exceeds decimals constraint {d}",
-                        format_rational(n, *decimals)
+                        format_rational_for_validation_message(expected_type, n)
                     ));
                 }
             }
@@ -1527,8 +1523,8 @@ pub(crate) fn validate_value_against_type(
                 if n < min {
                     return Err(format!(
                         "{} is below minimum {}",
-                        format_rational(n, *decimals),
-                        format_rational(min, *decimals)
+                        format_rational_for_validation_message(expected_type, n),
+                        format_rational_for_validation_message(expected_type, min)
                     ));
                 }
             }
@@ -1536,8 +1532,8 @@ pub(crate) fn validate_value_against_type(
                 if n > max {
                     return Err(format!(
                         "{} is above maximum {}",
-                        format_rational(n, *decimals),
-                        format_rational(max, *decimals)
+                        format_rational_for_validation_message(expected_type, n),
+                        format_rational_for_validation_message(expected_type, max)
                     ));
                 }
             }
@@ -1568,7 +1564,7 @@ pub(crate) fn validate_value_against_type(
                 if exceeds_decimal_places(&in_unit, *d) {
                     return Err(format!(
                         "{} {unit} exceeds decimals constraint {d}",
-                        format_rational(&in_unit, *decimals)
+                        format_rational_for_validation_message(expected_type, &in_unit)
                     ));
                 }
             }
@@ -1583,11 +1579,14 @@ pub(crate) fn validate_value_against_type(
                     let min_in_unit = checked_div(&canonical_min, factor).map_err(|failure| {
                         format!("cannot de-canonicalize minimum for validation: {failure}")
                     })?;
-                    let value_display =
-                        format!("{} {}", format_rational(&in_unit, *decimals), unit);
+                    let value_display = format!(
+                        "{} {}",
+                        format_rational_for_validation_message(expected_type, &in_unit),
+                        unit
+                    );
                     let bound_display = format!(
                         "{} {}",
-                        format_rational(&min_in_unit, *decimals),
+                        format_rational_for_validation_message(expected_type, &min_in_unit),
                         quantity_unit.name
                     );
                     return Err(format!("{value_display} is below minimum {bound_display}"));
@@ -1604,11 +1603,14 @@ pub(crate) fn validate_value_against_type(
                     let max_in_unit = checked_div(&canonical_max, factor).map_err(|failure| {
                         format!("cannot de-canonicalize maximum for validation: {failure}")
                     })?;
-                    let value_display =
-                        format!("{} {}", format_rational(&in_unit, *decimals), unit);
+                    let value_display = format!(
+                        "{} {}",
+                        format_rational_for_validation_message(expected_type, &in_unit),
+                        unit
+                    );
                     let bound_display = format!(
                         "{} {}",
-                        format_rational(&max_in_unit, *decimals),
+                        format_rational_for_validation_message(expected_type, &max_in_unit),
                         quantity_unit.name
                     );
                     return Err(format!("{value_display} is above maximum {bound_display}"));
@@ -1656,7 +1658,7 @@ pub(crate) fn validate_value_against_type(
                 if exceeds_decimal_places(r, *d) {
                     return Err(format!(
                         "{} exceeds decimals constraint {d}",
-                        format_rational(r, *decimals)
+                        format_rational_for_validation_message(expected_type, r)
                     ));
                 }
             }
@@ -1672,14 +1674,20 @@ pub(crate) fn validate_value_against_type(
                             );
                             format!(
                                 "{} {unit} is below minimum {} {unit}",
-                                format_rational(&value_per_unit, *decimals),
-                                format_rational(&bound_per_unit.clone(), *decimals),
+                                format_rational_for_validation_message(
+                                    expected_type,
+                                    &value_per_unit
+                                ),
+                                format_rational_for_validation_message(
+                                    expected_type,
+                                    &bound_per_unit.clone()
+                                ),
                             )
                         }
                         None => format!(
                             "{} is below minimum {}",
-                            format_rational(r, *decimals),
-                            format_rational(type_minimum, *decimals),
+                            format_rational_for_validation_message(expected_type, r),
+                            format_rational_for_validation_message(expected_type, type_minimum),
                         ),
                     };
                     return Err(message);
@@ -1697,14 +1705,20 @@ pub(crate) fn validate_value_against_type(
                             );
                             format!(
                                 "{} {unit} is above maximum {} {unit}",
-                                format_rational(&value_per_unit, *decimals),
-                                format_rational(&bound_per_unit.clone(), *decimals),
+                                format_rational_for_validation_message(
+                                    expected_type,
+                                    &value_per_unit
+                                ),
+                                format_rational_for_validation_message(
+                                    expected_type,
+                                    &bound_per_unit.clone()
+                                ),
                             )
                         }
                         None => format!(
                             "{} is above maximum {}",
-                            format_rational(r, *decimals),
-                            format_rational(type_maximum, *decimals),
+                            format_rational_for_validation_message(expected_type, r),
+                            format_rational_for_validation_message(expected_type, type_maximum),
                         ),
                     };
                     return Err(message);
@@ -1802,37 +1816,40 @@ pub(crate) fn validate_literal_data_against_types(plan: &ExecutionPlan) -> Vec<E
     errors
 }
 
-fn collect_unit_conversion_targets_from_instructions(
-    instructions: &Instructions,
-    units: &mut BTreeSet<String>,
-) {
-    for insn in &instructions.code {
-        if let Instruction::UnitConversion {
-            target: SemanticConversionTarget::Unit { unit_name },
-            ..
-        } = insn
-        {
-            units.insert(unit_name.clone());
+pub(crate) fn validate_unit_conversion_targets(plan: &ExecutionPlan) -> Result<(), Error> {
+    for rule in &plan.rules {
+        for instructions in [&rule.instructions, &rule.source_instructions] {
+            for insn in &instructions.code {
+                let Instruction::UnitConversion { target, .. } = insn else {
+                    continue;
+                };
+                let Some((unit_name, owning_type)) =
+                    crate::computation::units::conversion_target_declares_unit(target)
+                else {
+                    continue;
+                };
+                if crate::computation::units::owning_type_declares_unit_name(
+                    owning_type.as_ref(),
+                    unit_name,
+                ) {
+                    continue;
+                }
+                return Err(Error::validation(
+                    format!(
+                        "Unit conversion target '{unit_name}' is not declared on owning type '{}'",
+                        owning_type.name()
+                    ),
+                    None::<Source>,
+                    Some(plan.spec_name.clone()),
+                ));
+            }
         }
     }
+    Ok(())
 }
 
 pub(crate) fn validate_unit_index_references(plan: &ExecutionPlan) -> Result<(), Error> {
-    let mut required_units = BTreeSet::new();
-    for rule in &plan.rules {
-        collect_unit_conversion_targets_from_instructions(&rule.instructions, &mut required_units);
-    }
-    for unit_name in required_units {
-        if plan.resolved_types.unit_index.contains_key(&unit_name) {
-            continue;
-        }
-        return Err(Error::validation(
-            format!("Unknown unit '{unit_name}' in execution plan unit index."),
-            None::<Source>,
-            Some(plan.spec_name.clone()),
-        ));
-    }
-    Ok(())
+    validate_unit_conversion_targets(plan)
 }
 
 /// The serializable form of an [`ExecutionPlan`].
@@ -1923,7 +1940,7 @@ impl TryFrom<ExecutionPlanSerialized> for ExecutionPlan {
             .map(|rule| rule.instructions.register_count)
             .max()
             .unwrap_or(0);
-        Ok(Self {
+        let plan = Self {
             spec_name: serialized.spec_name,
             commentary: serialized.commentary,
             data: serialized.data,
@@ -1938,7 +1955,18 @@ impl TryFrom<ExecutionPlanSerialized> for ExecutionPlan {
             signature_index,
             effective: serialized.effective,
             sources: serialized.sources,
-        })
+        };
+        validate_unit_index_references(&plan).map_err(|error| {
+            crate::Error::request(
+                format!(
+                    "Serialized execution plan for spec '{}' is invalid: {}",
+                    plan.spec_name,
+                    error.message()
+                ),
+                None::<String>,
+            )
+        })?;
+        Ok(plan)
     }
 }
 

--- a/engine/src/planning/graph.rs
+++ b/engine/src/planning/graph.rs
@@ -2608,9 +2608,12 @@ impl<'a> GraphBuilder<'a> {
         right: &ast::Expression,
         ctx: &mut RuleExpressionConversion<'_>,
     ) -> Option<(Expression, Expression)> {
-        let converted_left = self.convert_expression_and_extract_dependencies(left, ctx)?;
-        let converted_right = self.convert_expression_and_extract_dependencies(right, ctx)?;
-        Some((converted_left, converted_right))
+        let converted_left = self.convert_expression_and_extract_dependencies(left, ctx);
+        let converted_right = self.convert_expression_and_extract_dependencies(right, ctx);
+        match (converted_left, converted_right) {
+            (Some(l), Some(r)) => Some((l, r)),
+            _ => None,
+        }
     }
 
     /// Converts an AST expression into a resolved expression and records any rule references.
@@ -3007,41 +3010,6 @@ fn find_types_by_spec<'b>(
         .map(|(_, _, t)| t)
 }
 
-fn find_type_by_name_in_scope(
-    resolved_types: &ResolvedTypesMap,
-    spec_arc: &Arc<LemmaSpec>,
-    name: &str,
-) -> Option<Arc<LemmaType>> {
-    if let Some(spec_types) = find_types_by_spec(resolved_types, spec_arc) {
-        if let Some(t) = spec_types
-            .resolved
-            .get(name)
-            .or_else(|| spec_types.unit_index.get(name))
-        {
-            return Some(Arc::clone(t));
-        }
-    }
-    for data in &spec_arc.data {
-        let ParsedDataValue::Import(spec_ref) = &data.value else {
-            continue;
-        };
-        let Some((_, _, imported_types)) = resolved_types
-            .iter()
-            .find(|(_, s, _)| s.name == spec_ref.name)
-        else {
-            continue;
-        };
-        if let Some(t) = imported_types
-            .resolved
-            .get(name)
-            .or_else(|| imported_types.unit_index.get(name))
-        {
-            return Some(Arc::clone(t));
-        }
-    }
-    None
-}
-
 /// Result of a decomposition-based type lookup in scope.
 ///
 /// Used by both `infer_expression_type` (to promote anonymous results to named types) and the
@@ -3051,78 +3019,59 @@ pub enum DecompositionMatch {
     /// No declared quantity type in scope has this decomposition.
     None,
     /// Exactly one declared quantity type in scope has this decomposition.
-    Unique(String),
-    /// Multiple declared quantity types in scope share this decomposition; the names
-    /// are sorted for stable diagnostic ordering.
+    Unique(Arc<LemmaType>),
+    /// Multiple quantity families in scope share this decomposition; family names are
+    /// sorted for stable diagnostic ordering.
     Multiple(Vec<String>),
 }
 
-/// Find the quantity type(s) in scope whose decomposition matches `decomposition` exactly.
+/// Find the quantity family (ies) in scope whose decomposition matches `decomposition` exactly.
 ///
-/// Replaces the special-case `find_duration_type_in_spec` and the inline decomposition
-/// match-loop. It walks every declared quantity type in `spec_arc` plus any quantity types
-/// reachable through imports, deduplicates by name, and reports whether exactly one matches.
+/// Uses the consumer spec's `unit_index` only. Units belong to families; binding aliases in
+/// `resolved` are ignored. Imports are already merged into `unit_index` during resolution.
 pub fn find_unique_quantity_type_by_decomposition(
     resolved_types: &ResolvedTypesMap,
     spec_arc: &Arc<LemmaSpec>,
     decomposition: &BaseQuantityVector,
 ) -> DecompositionMatch {
-    let mut seen: HashSet<String> = HashSet::new();
+    let mut seen: HashMap<String, Arc<LemmaType>> = HashMap::new();
 
-    let consider = |lemma_type: &LemmaType, seen: &mut HashSet<String>| {
+    let Some(spec_types) = find_types_by_spec(resolved_types, spec_arc) else {
+        return DecompositionMatch::None;
+    };
+
+    for arc in spec_types.unit_index.values() {
+        let lemma_type = arc.as_ref();
         if !matches!(
             lemma_type.specifications,
             TypeSpecification::Quantity { .. }
         ) {
-            return;
+            continue;
         }
         if lemma_type
             .quantity_type_decomposition()
-            .is_none_or(|d| d != decomposition)
+            .is_none_or(|decomposition_vector| decomposition_vector != decomposition)
         {
-            return;
-        }
-        seen.insert(lemma_type.name().to_string());
-    };
-
-    if let Some(spec_types) = find_types_by_spec(resolved_types, spec_arc) {
-        for lemma_type in spec_types.resolved.values() {
-            consider(lemma_type.as_ref(), &mut seen);
-        }
-        for lemma_type in spec_types.unit_index.values() {
-            consider(lemma_type.as_ref(), &mut seen);
-        }
-    }
-
-    for data in &spec_arc.data {
-        let ParsedDataValue::Import(spec_ref) = &data.value else {
             continue;
-        };
-        let Some((_, _, imported_types)) = resolved_types
-            .iter()
-            .find(|(_, s, _)| s.name == spec_ref.name)
-        else {
-            continue;
-        };
-        for lemma_type in imported_types.resolved.values() {
-            consider(lemma_type.as_ref(), &mut seen);
         }
-        for lemma_type in imported_types.unit_index.values() {
-            consider(lemma_type.as_ref(), &mut seen);
-        }
+        let quantity_family = lemma_type
+            .quantity_family_name()
+            .expect("BUG: unit_index quantity type must carry a family name");
+        seen.entry(quantity_family.to_string())
+            .or_insert_with(|| Arc::clone(arc));
     }
 
     match seen.len() {
         0 => DecompositionMatch::None,
         1 => DecompositionMatch::Unique(
-            seen.into_iter()
+            seen.into_values()
                 .next()
                 .expect("BUG: seen has exactly one element, len checked"),
         ),
         _ => {
-            let mut names: Vec<String> = seen.into_iter().collect();
-            names.sort();
-            DecompositionMatch::Multiple(names)
+            let mut family_names: Vec<String> = seen.into_keys().collect();
+            family_names.sort();
+            DecompositionMatch::Multiple(family_names)
         }
     }
 }
@@ -3153,9 +3102,9 @@ fn anonymous_rule_boundary_error(
         spec_arc,
         decomposition,
     ) {
-        DecompositionMatch::Multiple(names) => format!(
-            " Multiple types in scope share these dimensions: {}. Give the rule an explicit named type.",
-            names.join(", ")
+        DecompositionMatch::Multiple(family_names) => format!(
+            " Multiple quantity families in scope share these dimensions: {}. Give the rule an explicit named type.",
+            family_names.join(", ")
         ),
         _ => String::new(),
     };
@@ -3701,15 +3650,14 @@ fn infer_expression_type(
             if result.is_anonymous_quantity() {
                 if let Some(decomp) = result.quantity_type_decomposition() {
                     if !decomp.is_empty() {
-                        if let DecompositionMatch::Unique(name) =
+                        if let DecompositionMatch::Unique(lemma_type) =
                             find_unique_quantity_type_by_decomposition(
                                 resolved_types,
                                 spec_arc,
                                 decomp,
                             )
                         {
-                            result = find_type_by_name_in_scope(resolved_types, spec_arc, &name)
-                                .expect("BUG: Unique decomposition match must be findable by name");
+                            result = lemma_type;
                         }
                     }
                 }
@@ -3745,15 +3693,12 @@ fn infer_expression_type(
                 {
                     source_type
                 }
-                SemanticConversionTarget::Unit { unit_name } => {
-                    lookup_unit_type(resolved_types, spec_arc, unit_name)
-                        .unwrap_or_else(|| Arc::new(LemmaType::undetermined_type()))
-                }
+                SemanticConversionTarget::Unit { owning_type, .. } => Arc::clone(owning_type),
                 SemanticConversionTarget::Type(_) => Arc::new(LemmaType::undetermined_type()),
             }
         }
 
-        ExpressionKind::MathematicalComputation(_, operand) => {
+        ExpressionKind::MathematicalComputation(op, operand) => {
             let operand_type = infer_expression_type(
                 operand,
                 graph,
@@ -3766,6 +3711,11 @@ fn infer_expression_type(
             }
             if operand_type.is_undetermined() {
                 return Arc::new(LemmaType::undetermined_type());
+            }
+            if crate::computation::mathematical_computation_preserves_quantity_magnitude(op)
+                && operand_type.is_quantity()
+            {
+                return operand_type;
             }
             primitive_number_arc().clone()
         }
@@ -4403,20 +4353,9 @@ fn check_arithmetic_types(
                 }
             }
             ArithmeticComputation::Multiply => {
-                if left_type.same_quantity_family(right_type) {
-                    Err(vec![engine_error_at_graph(
-                        graph,
-                        source,
-                        format!(
-                            "Cannot multiply two '{}' quantity values of the same type. \
-                             Convert operands first: 'value as number'.",
-                            left_type.name()
-                        ),
-                    )])
-                } else {
-                    // Cross-family Quantity * Quantity → anonymous intermediate. Allowed.
-                    Ok(())
-                }
+                // Quantity * Quantity (same or cross family) → anonymous intermediate when
+                // dimensions combine; promotion resolves a unique named type when possible.
+                Ok(())
             }
             ArithmeticComputation::Divide => {
                 // Quantity / Quantity (any family) → scalar Number or anonymous intermediate. Allowed.
@@ -4712,9 +4651,15 @@ fn check_unit_conversion_types(
                 )])
             }
         }
-        SemanticConversionTarget::Unit { unit_name } => {
+        SemanticConversionTarget::Unit {
+            unit_name,
+            owning_type,
+        } => {
             if source_type.is_number() {
-                if unit_index.contains_key(unit_name) {
+                if crate::computation::units::owning_type_declares_unit_name(
+                    owning_type.as_ref(),
+                    unit_name,
+                ) {
                     return Ok(());
                 }
                 return Err(vec![engine_error_at_graph(
@@ -4724,16 +4669,9 @@ fn check_unit_conversion_types(
                 )]);
             }
             if source_type.is_quantity() {
-                let Some(target_type) = lookup_unit_type(resolved_types, spec_arc, unit_name)
-                else {
-                    return Err(vec![engine_error_at_graph(
-                        graph,
-                        source_loc,
-                        format!("Unknown unit '{unit_name}' in spec '{}'.", spec_arc.name),
-                    )]);
-                };
-                if source_type.same_quantity_family(&target_type)
-                    || source_type.compatible_with_anonymous_quantity(&target_type)
+                let target_type = owning_type.as_ref();
+                if source_type.same_quantity_family(target_type)
+                    || source_type.compatible_with_anonymous_quantity(target_type)
                     || target_type.compatible_with_anonymous_quantity(source_type)
                 {
                     return Ok(());
@@ -4771,7 +4709,10 @@ fn check_unit_conversion_types(
                 )]);
             }
             if source_type.is_calendar_like() {
-                if unit_index.contains_key(unit_name) {
+                if crate::computation::units::owning_type_declares_unit_name(
+                    owning_type.as_ref(),
+                    unit_name,
+                ) {
                     return Ok(());
                 }
                 return Err(vec![engine_error_at_graph(
@@ -4900,24 +4841,29 @@ fn check_unit_conversion_types(
 }
 fn check_mathematical_operand(
     graph: &Graph,
+    op: &semantics::MathematicalComputation,
     operand_type: &LemmaType,
     source: &Source,
 ) -> Result<(), Vec<Error>> {
     if operand_type.vetoed() {
         return Ok(());
     }
-    if !operand_type.is_number() {
-        Err(vec![engine_error_at_graph(
-            graph,
-            source,
-            format!(
-                "Mathematical function requires number operand, got {}",
-                operand_type
-            ),
-        )])
-    } else {
-        Ok(())
+    if operand_type.is_number() {
+        return Ok(());
     }
+    if operand_type.is_quantity()
+        && crate::computation::mathematical_computation_preserves_quantity_magnitude(op)
+    {
+        return Ok(());
+    }
+    let message = if operand_type.is_quantity() {
+        format!(
+            "Mathematical function '{op}' cannot be applied to {operand_type}; use 'as number' first"
+        )
+    } else {
+        format!("Mathematical function '{op}' requires number operand, got {operand_type}")
+    };
+    Err(vec![engine_error_at_graph(graph, source, message)])
 }
 
 /// Check that all rule references in the graph point to existing rules.
@@ -5163,7 +5109,7 @@ fn check_expression(
             let right_outcome = if is_multiplicative {
                 if let ExpressionKind::UnitConversion(
                     inner_source,
-                    SemanticConversionTarget::Unit { unit_name },
+                    conversion_target @ SemanticConversionTarget::Unit { unit_name, .. },
                 ) = &right.kind
                 {
                     // Always recurse into the inner source to catch errors in sub-expressions.
@@ -5207,9 +5153,7 @@ fn check_expression(
                                     graph,
                                     inner_source,
                                     &inner_type,
-                                    &SemanticConversionTarget::Unit {
-                                        unit_name: unit_name.clone(),
-                                    },
+                                    conversion_target,
                                     resolved_types,
                                     expr_source,
                                     spec_arc,
@@ -5260,9 +5204,7 @@ fn check_expression(
                                         graph,
                                         inner_source,
                                         &inner_type,
-                                        &SemanticConversionTarget::Unit {
-                                            unit_name: unit_name.clone(),
-                                        },
+                                        conversion_target,
                                         resolved_types,
                                         expr_source,
                                         spec_arc,
@@ -5372,7 +5314,7 @@ fn check_expression(
             );
         }
 
-        ExpressionKind::MathematicalComputation(_, operand) => {
+        ExpressionKind::MathematicalComputation(op, operand) => {
             collect(
                 check_expression(operand, graph, inferred_types, resolved_types, spec_arc),
                 &mut errors,
@@ -5385,7 +5327,7 @@ fn check_expression(
                 .as_ref()
                 .expect("BUG: expression missing source in check_expression");
             collect(
-                check_mathematical_operand(graph, &operand_type, expr_source),
+                check_mathematical_operand(graph, op, &operand_type, expr_source),
                 &mut errors,
             );
         }
@@ -5920,29 +5862,90 @@ fn arc_unwrap(arc: Arc<LemmaType>) -> LemmaType {
     Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone())
 }
 
+fn unit_index_arc_declares_unit(lemma_type: &LemmaType, unit_name: &str) -> bool {
+    match &lemma_type.specifications {
+        TypeSpecification::Quantity { units, .. } => units.get(unit_name).is_ok(),
+        TypeSpecification::Ratio { units, .. } => units.get(unit_name).is_ok(),
+        _ => false,
+    }
+}
+
 fn sync_unit_index_from_resolved(
     resolved: &HashMap<String, Arc<LemmaType>>,
     unit_index: HashMap<String, Arc<LemmaType>>,
 ) -> HashMap<String, Arc<LemmaType>> {
-    unit_index
+    let synced = unit_index
         .into_iter()
-        .map(|(unit_name, pre_decomp_type)| {
-            let post = pre_decomp_type
+        .filter_map(|(unit_name, pre_decomp_type)| {
+            let lookup_name = pre_decomp_type
                 .name
                 .as_deref()
-                .or_else(|| pre_decomp_type.quantity_family_name())
-                .and_then(|type_name| {
-                    resolved.get(type_name).or_else(|| {
+                .or_else(|| pre_decomp_type.quantity_family_name());
+            let post = if pre_decomp_type.is_quantity() {
+                let type_name = lookup_name.expect(
+                    "BUG: quantity arc in unit_index must carry name or family for sync",
+                );
+                if let Some(synced) = resolved
+                    .get(type_name)
+                    .or_else(|| {
                         pre_decomp_type
                             .quantity_family_name()
                             .and_then(|family| resolved.get(family))
                     })
-                })
-                .map(Arc::clone)
-                .unwrap_or(pre_decomp_type);
-            (unit_name, post)
+                {
+                    Arc::clone(synced)
+                } else if pre_decomp_type.quantity_type_decomposition().is_some() {
+                    pre_decomp_type
+                } else {
+                    panic!(
+                        "BUG: quantity unit_index unit '{}' type '{}' must exist in resolved or carry decomposition after import merge",
+                        unit_name, type_name
+                    )
+                }
+            } else {
+                lookup_name
+                    .and_then(|type_name| {
+                        resolved.get(type_name).or_else(|| {
+                            pre_decomp_type
+                                .quantity_family_name()
+                                .and_then(|family| resolved.get(family))
+                        })
+                    })
+                    .map(Arc::clone)
+                    .unwrap_or(pre_decomp_type)
+            };
+            if unit_index_arc_declares_unit(post.as_ref(), &unit_name) {
+                Some((unit_name, post))
+            } else {
+                None
+            }
         })
-        .collect()
+        .collect();
+    merge_family_root_quantity_units_into_index(resolved, synced)
+}
+
+/// Ensure every unit declared on a family-root quantity type in `resolved` has an index entry.
+fn merge_family_root_quantity_units_into_index(
+    resolved: &HashMap<String, Arc<LemmaType>>,
+    mut unit_index: HashMap<String, Arc<LemmaType>>,
+) -> HashMap<String, Arc<LemmaType>> {
+    for (type_name, lemma_type) in resolved {
+        let TypeSpecification::Quantity { units, .. } = &lemma_type.specifications else {
+            continue;
+        };
+        let is_family_root = lemma_type
+            .quantity_family_name()
+            .is_some_and(|family| family == type_name.as_str());
+        if !is_family_root {
+            continue;
+        }
+        for unit in units.iter() {
+            unit_index
+                .entry(unit.name.clone())
+                .or_insert_with(|| Arc::clone(lemma_type));
+        }
+    }
+    unit_index
 }
 
 /// `uses`-merged quantity rows in `unit_index` can still have empty `decomposition` until synced from
@@ -6120,9 +6123,18 @@ pub(crate) fn build_signature_index(
         let TypeSpecification::Quantity { units, .. } = &lemma_type.specifications else {
             continue;
         };
-        let Ok(unit) = units.get(unit_name) else {
-            continue;
-        };
+        let unit = units.get(unit_name).map_err(|_| {
+            Error::validation(
+                format!(
+                    "In spec '{}': unit_index entry '{}' is not declared on quantity type '{}'",
+                    spec_name,
+                    unit_name,
+                    lemma_type.name()
+                ),
+                None::<Source>,
+                None::<String>,
+            )
+        })?;
         if unit.derived_quantity_factors.is_empty() {
             continue;
         }
@@ -7027,6 +7039,112 @@ mod tests {
     }
 
     #[test]
+    fn chained_add_reports_all_missing_references() {
+        let minimal = r#"spec s
+data a: 1
+rule bad: a + missing_one + missing_two
+"#;
+        let specs = crate::parse(
+            minimal,
+            crate::parsing::source::SourceType::Volatile,
+            &crate::ResourceLimits::default(),
+        )
+        .expect("minimal fixture parses")
+        .into_flattened_specs();
+        let s = specs.iter().find(|d| d.name == "s").expect("spec s");
+        let result = build_graph(s, &specs);
+        let errors = result.expect_err("chained + with two missing refs must fail planning");
+        let not_found: Vec<_> = errors
+            .iter()
+            .filter(|e| e.to_string().contains("not found"))
+            .collect();
+        assert_eq!(
+            not_found.len(),
+            2,
+            "expected two missing-reference errors, got: {}",
+            errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        assert!(
+            not_found
+                .iter()
+                .any(|e| e.to_string().contains("missing_one")),
+            "expected error for missing_one"
+        );
+        assert!(
+            not_found
+                .iter()
+                .any(|e| e.to_string().contains("missing_two")),
+            "expected error for missing_two"
+        );
+        for error in &not_found {
+            let source = error
+                .location()
+                .expect("missing-reference error must carry source span");
+            assert_ne!(
+                source.span.start, source.span.end,
+                "error span must not be empty"
+            );
+        }
+
+        let user_shaped = r#"spec s
+data base_cost: 1
+data starch_levy: 2
+data quality_extra: 3
+rule landed_cost_per_kg:
+  base_cost + starch_levy + quality_extra + transport_extra_per_kg + amortization_per_kg
+"#;
+        let specs = crate::parse(
+            user_shaped,
+            crate::parsing::source::SourceType::Volatile,
+            &crate::ResourceLimits::default(),
+        )
+        .expect("user-shaped fixture parses")
+        .into_flattened_specs();
+        let s = specs.iter().find(|d| d.name == "s").expect("spec s");
+        let result = build_graph(s, &specs);
+        let errors = result.expect_err("landed_cost_per_kg with two typos must fail planning");
+        let not_found: Vec<_> = errors
+            .iter()
+            .filter(|e| e.to_string().contains("not found"))
+            .collect();
+        assert_eq!(
+            not_found.len(),
+            2,
+            "expected two missing-reference errors, got: {}",
+            errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        assert!(
+            not_found
+                .iter()
+                .any(|e| e.to_string().contains("transport_extra_per_kg")),
+            "expected error for transport_extra_per_kg"
+        );
+        assert!(
+            not_found
+                .iter()
+                .any(|e| e.to_string().contains("amortization_per_kg")),
+            "expected error for amortization_per_kg"
+        );
+        for error in &not_found {
+            let source = error
+                .location()
+                .expect("missing-reference error must carry source span");
+            assert_ne!(
+                source.span.start, source.span.end,
+                "error span must not be empty"
+            );
+        }
+    }
+
+    #[test]
     fn test_missing_spec_reference() {
         let mut spec = create_test_spec("test");
 
@@ -7443,8 +7561,8 @@ pub struct ResolvedSpecTypes {
     /// Raw defaults retained after materialization for cross-spec parent lookup during later specs.
     pub(crate) source_defaults: HashMap<String, RawDefault>,
 
-    /// Unit index: unit_name -> resolved type.
-    /// Built during resolution — if unit appears in multiple types, resolution fails.
+    /// Unit index: unit_name -> family-root quantity type for that unit's family.
+    /// Binding aliases never appear; cross-family duplicate unit names fail at resolution.
     pub unit_index: HashMap<String, Arc<LemmaType>>,
 }
 
@@ -7821,12 +7939,19 @@ impl<'a> TypeResolver<'a> {
 
         let mut validated_in_unit_index: HashSet<String> = HashSet::new();
         for lemma_type in resolved_types.unit_index.values() {
-            let Some(type_name) = lemma_type.name.as_deref() else {
+            let Some(quantity_family) = lemma_type.quantity_family_name() else {
                 continue;
             };
-            if !lemma_type.is_quantity() || !validated_in_unit_index.insert(type_name.to_string()) {
+            if !lemma_type.is_quantity()
+                || !validated_in_unit_index.insert(quantity_family.to_string())
+            {
                 continue;
             }
+            let type_name = lemma_type
+                .name
+                .as_deref()
+                .filter(|name| *name == quantity_family)
+                .unwrap_or(quantity_family);
             let source = type_sources
                 .get(type_name)
                 .cloned()
@@ -8241,12 +8366,16 @@ impl<'a> TypeResolver<'a> {
                 .get(type_name.as_str())
                 .expect("BUG: type was resolved but not in registry");
             let merge_result = if type_arc.is_quantity() {
-                Self::add_quantity_units_to_index(
-                    spec,
-                    &mut unit_index_tmp,
-                    type_arc,
-                    data_type_def,
-                )
+                if matches!(data_type_def.parent, ParentType::Qualified { .. }) {
+                    Ok(())
+                } else {
+                    Self::add_quantity_units_to_index(
+                        spec,
+                        &mut unit_index_tmp,
+                        type_arc,
+                        data_type_def,
+                    )
+                }
             } else if type_arc.is_ratio() {
                 Self::add_ratio_units_to_index(spec, &mut unit_index_tmp, type_arc, data_type_def)
             } else {
@@ -8264,7 +8393,10 @@ impl<'a> TypeResolver<'a> {
             let (_, imported_spec) =
                 match self.resolve_spec_for_import(spec, spec_ref, &data_row.source_location, at) {
                     Ok(import_pair) => import_pair,
-                    Err(_) => continue,
+                    Err(error) => {
+                        errors.push(error);
+                        continue;
+                    }
                 };
             let Some(imported_resolved) = already_resolved
                 .iter()
@@ -8285,12 +8417,26 @@ impl<'a> TypeResolver<'a> {
                 if matches!(def.parent, ParentType::Qualified { .. }) {
                     continue;
                 }
-                let Some(type_arc) = imported_resolved.resolved.get(imported_type_name.as_str())
-                else {
-                    continue;
-                };
+                let type_arc = imported_resolved
+                    .resolved
+                    .get(imported_type_name.as_str())
+                    .unwrap_or_else(|| {
+                        unreachable!(
+                            "BUG: imported type '{}' must exist in resolved spec '{}'",
+                            imported_type_name, imported_spec.name
+                        )
+                    });
                 let merge_result = if type_arc.is_quantity() {
-                    Self::add_quantity_units_to_index(spec, &mut unit_index_tmp, type_arc, def)
+                    let consumer_owns_type_locally = data_defs
+                        .get(imported_type_name.as_str())
+                        .is_some_and(|local_def| {
+                            !matches!(local_def.parent, ParentType::Qualified { .. })
+                        });
+                    if consumer_owns_type_locally {
+                        Ok(())
+                    } else {
+                        Self::add_quantity_units_to_index(spec, &mut unit_index_tmp, type_arc, def)
+                    }
                 } else if type_arc.is_ratio() {
                     Self::add_ratio_units_to_index(spec, &mut unit_index_tmp, type_arc, def)
                 } else {
@@ -8363,22 +8509,17 @@ impl<'a> TypeResolver<'a> {
         defined_by: &DataTypeDef,
     ) -> Result<(), Error> {
         let resolved_ref = resolved_type.as_ref();
+        if matches!(defined_by.parent, ParentType::Qualified { .. }) {
+            unreachable!("BUG: qualified import alias rows must not register units");
+        }
+        let quantity_family = resolved_ref
+            .quantity_family_name()
+            .expect("BUG: add_quantity_units_to_index requires quantity type with family");
         let units = Self::extract_units_from_type(&resolved_ref.specifications);
         for unit in units {
             if let Some((existing_type, existing_def)) = unit_index.get(&unit) {
-                let same_type = existing_def.as_ref() == Some(defined_by);
-
-                if same_type {
-                    return Err(Error::validation_with_context(
-                        format!(
-                            "Unit '{}' is defined more than once in type '{}'",
-                            unit, defined_by.name
-                        ),
-                        Some(defined_by.source.clone()),
-                        None::<String>,
-                        Some(Arc::clone(spec)),
-                        None,
-                    ));
+                if existing_def.as_ref() == Some(defined_by) {
+                    continue;
                 }
 
                 let existing_name: String = existing_def
@@ -8396,6 +8537,8 @@ impl<'a> TypeResolver<'a> {
                     .map(|p| p == defined_by.name.as_str())
                     .unwrap_or(false);
 
+                // Defining-type extension chains only (family-root rows); binding aliases never
+                // reach this function.
                 if existing_type.is_quantity()
                     && (current_extends_existing || existing_extends_current)
                 {
@@ -8406,8 +8549,38 @@ impl<'a> TypeResolver<'a> {
                     continue;
                 }
 
-                if existing_type.same_quantity_family(resolved_ref) {
-                    continue;
+                if existing_type.is_quantity() && existing_type.same_quantity_family(resolved_ref) {
+                    if let (
+                        TypeSpecification::Quantity {
+                            units: existing_units,
+                            ..
+                        },
+                        TypeSpecification::Quantity {
+                            units: new_units, ..
+                        },
+                    ) = (&existing_type.specifications, &resolved_ref.specifications)
+                    {
+                        let same_factor = existing_units
+                            .iter()
+                            .find(|u| u.name == unit)
+                            .zip(new_units.iter().find(|u| u.name == unit))
+                            .is_some_and(|(existing_unit, new_unit)| {
+                                existing_unit.factor == new_unit.factor
+                            });
+                        if same_factor {
+                            continue;
+                        }
+                        return Err(Error::validation_with_context(
+                            format!(
+                                "Unit '{}' in quantity family '{}' is defined with conflicting factors",
+                                unit, quantity_family
+                            ),
+                            Some(defined_by.source.clone()),
+                            None::<String>,
+                            Some(Arc::clone(spec)),
+                            None,
+                        ));
+                    }
                 }
 
                 return Err(Error::validation_with_context(
@@ -9016,44 +9189,391 @@ data invalid: choice -> option "a""#,
     }
 
     #[test]
-    fn test_quantity_extension_overwrites_parent_units() {
+    fn extension_unit_factor_override_errors() {
         let (resolver, spec_arc) = resolver_single_spec(
             r#"spec test
 data money: quantity
-  -> unit eur 1.00
-  -> unit usd 0.84
-
+  -> unit eur 1
 data money2: money
-  -> unit eur 1.20
-  -> unit usd 1.21
-  -> unit gbp 1.30"#,
+  -> unit eur 1.10"#,
+        );
+
+        let result = resolver.resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new());
+        assert!(
+            result.is_err(),
+            "extension child must not override inherited unit factor"
+        );
+        let error_msg = result
+            .unwrap_err()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            error_msg.contains("eur"),
+            "error must name unit eur, got: {error_msg}"
+        );
+        assert!(
+            error_msg.contains("inherited") || error_msg.contains("cannot change"),
+            "error must reject inherited unit redefinition, got: {error_msg}"
+        );
+    }
+
+    #[test]
+    fn inherited_unit_idempotent_redeclare_ok() {
+        let (resolver, spec_arc) = resolver_single_spec(
+            r#"spec test
+data money: quantity
+  -> unit eur 1
+data money2: money
+  -> unit eur 1"#,
         );
 
         let resolved = resolver
             .resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new())
-            .unwrap();
-        let money2 = resolved.resolved.get("money2").unwrap();
+            .expect("idempotent inherited unit redeclare must resolve");
+        let money2 = resolved.resolved.get("money2").expect("money2");
         match &money2.specifications {
             TypeSpecification::Quantity { units, .. } => {
-                assert_eq!(units.len(), 3);
-                let eur = units.iter().find(|u| u.name == "eur").unwrap();
-                let usd = units.iter().find(|u| u.name == "usd").unwrap();
-                let gbp = units.iter().find(|u| u.name == "gbp").unwrap();
+                let eur = units.iter().find(|u| u.name == "eur").expect("eur");
                 assert_eq!(
                     crate::computation::rational::commit_rational_to_decimal(&eur.factor).unwrap(),
-                    Decimal::from_str_exact("1.20").unwrap()
-                );
-                assert_eq!(
-                    crate::computation::rational::commit_rational_to_decimal(&usd.factor).unwrap(),
-                    Decimal::from_str_exact("1.21").unwrap()
-                );
-                assert_eq!(
-                    crate::computation::rational::commit_rational_to_decimal(&gbp.factor).unwrap(),
-                    Decimal::from_str_exact("1.30").unwrap()
+                    Decimal::ONE,
+                    "eur factor must remain 1"
                 );
             }
-            other => panic!("Expected Quantity type specifications, got {:?}", other),
+            other => panic!("expected Quantity, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn extension_additive_unit_registers_in_unit_index() {
+        let (resolver, spec_arc) = resolver_single_spec(
+            r#"spec test
+data money: quantity
+  -> unit eur 1
+data money2: money
+  -> unit usd 1.24"#,
+        );
+
+        let resolved = resolver
+            .resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new())
+            .expect("additive extension unit must resolve");
+        let money2 = resolved
+            .resolved
+            .get("money2")
+            .expect("money2 resolved")
+            .clone();
+        assert!(
+            resolved.unit_index.contains_key("eur"),
+            "eur must be in unit_index"
+        );
+        assert!(
+            resolved.unit_index.contains_key("usd"),
+            "usd must be in unit_index"
+        );
+        let eur_owner = resolved.unit_index.get("eur").expect("eur owner");
+        let usd_owner = resolved.unit_index.get("usd").expect("usd owner");
+        assert_eq!(
+            eur_owner.name.as_deref(),
+            Some("money2"),
+            "most-derived type must own inherited eur"
+        );
+        assert_eq!(
+            usd_owner.name.as_deref(),
+            Some("money2"),
+            "most-derived type must own new usd"
+        );
+        assert_eq!(eur_owner.as_ref(), money2.as_ref());
+        assert_eq!(usd_owner.as_ref(), money2.as_ref());
+    }
+
+    #[test]
+    fn find_unique_reports_multiple_families_with_same_decomposition() {
+        let code = r#"spec units
+data money: quantity
+  -> unit eur 1
+  -> unit usd 0.86
+data mass: quantity
+  -> unit kg 1
+data price_eur_per_kg: quantity
+  -> unit eur_per_kg eur/kg
+data price_usd_per_kg: quantity
+  -> unit usd_per_kg usd/kg
+"#;
+        let (resolver, spec_arcs) = resolver_for_code(code);
+        let units_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "units")
+            .cloned()
+            .expect("units spec");
+        let (context, _) = test_context_and_effective(&spec_arcs);
+        let repository = context.workspace();
+        let resolved = resolver
+            .resolve_and_validate(&units_arc, &EffectiveDate::Origin, &ResolvedTypesMap::new())
+            .expect("units resolves");
+        let eur_decomp = resolved
+            .unit_index
+            .get("eur_per_kg")
+            .expect("eur_per_kg")
+            .quantity_type_decomposition()
+            .expect("eur_per_kg decomposition")
+            .clone();
+        let map = vec![(repository, units_arc.clone(), resolved)];
+
+        let unique = find_unique_quantity_type_by_decomposition(&map, &units_arc, &eur_decomp);
+        match unique {
+            DecompositionMatch::Multiple(families) => {
+                assert_eq!(families.len(), 2);
+                assert!(families.contains(&"price_eur_per_kg".to_string()));
+                assert!(families.contains(&"price_usd_per_kg".to_string()));
+            }
+            other => panic!("expected Multiple families, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unit_index_maps_family_root_not_binding_alias() {
+        let code = r#"spec units
+data money: quantity
+  -> unit eur 1
+data mass: quantity
+  -> unit kg 1
+data price_per_weight: quantity
+  -> unit eur_per_kg eur/kg
+
+spec consumer
+uses u: units
+data starch_levy_per_kg: u.price_per_weight
+  -> default 0.1 eur_per_kg
+data amortization_per_kg: u.price_per_weight
+  -> default 0.2 eur_per_kg
+"#;
+        let (resolver, spec_arcs) = resolver_for_code(code);
+        let units_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "units")
+            .cloned()
+            .expect("units spec");
+        let consumer_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "consumer")
+            .cloned()
+            .expect("consumer spec");
+        let (context, _) = test_context_and_effective(&spec_arcs);
+        let repository = context.workspace();
+
+        let mut already_resolved = ResolvedTypesMap::new();
+        let units_types = resolver
+            .resolve_and_validate(&units_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("units spec resolves");
+        let units_price_per_weight = units_types
+            .resolved
+            .get("price_per_weight")
+            .expect("units defines price_per_weight")
+            .clone();
+        already_resolved.push((Arc::clone(&repository), units_arc, units_types));
+
+        let consumer_types = resolver
+            .resolve_and_validate(&consumer_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("consumer spec resolves");
+
+        let eur_per_kg_owner = consumer_types
+            .unit_index
+            .get("eur_per_kg")
+            .expect("eur_per_kg in unit_index");
+        assert_eq!(
+            eur_per_kg_owner.name.as_deref(),
+            Some("price_per_weight"),
+            "unit must belong to family root, not binding alias row name"
+        );
+        assert_eq!(
+            eur_per_kg_owner.quantity_family_name(),
+            Some("price_per_weight")
+        );
+        assert_eq!(eur_per_kg_owner.as_ref(), units_price_per_weight.as_ref());
+
+        let starch_alias = consumer_types
+            .resolved
+            .get("starch_levy_per_kg")
+            .expect("alias row in resolved");
+        assert!(
+            !Arc::ptr_eq(eur_per_kg_owner, starch_alias),
+            "unit_index must not store binding alias arc"
+        );
+    }
+
+    #[test]
+    fn import_merge_skips_locally_owned_family_root() {
+        let code = r#"spec std_units
+data mass: quantity
+  -> unit kilogram 1
+  -> unit kilograms 1
+  -> unit gram 0.001
+
+spec s
+uses u: std_units
+data mass: quantity
+  -> unit kg 1
+  -> unit tonne 1000
+rule smoke: true
+"#;
+        let (resolver, spec_arcs) = resolver_for_code(code);
+        let std_units_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "std_units")
+            .cloned()
+            .expect("std_units spec");
+        let consumer_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "s")
+            .cloned()
+            .expect("consumer spec");
+        let (context, _) = test_context_and_effective(&spec_arcs);
+        let repository = context.workspace();
+
+        let mut already_resolved = ResolvedTypesMap::new();
+        let std_units_types = resolver
+            .resolve_and_validate(&std_units_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("std_units resolves");
+        already_resolved.push((Arc::clone(&repository), std_units_arc, std_units_types));
+
+        let consumer_types = resolver
+            .resolve_and_validate(&consumer_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("consumer resolves");
+
+        let local_mass = consumer_types
+            .resolved
+            .get("mass")
+            .expect("consumer defines mass")
+            .clone();
+
+        assert!(
+            consumer_types.unit_index.contains_key("kg"),
+            "local kg must be indexed"
+        );
+        assert!(
+            consumer_types.unit_index.contains_key("tonne"),
+            "local tonne must be indexed"
+        );
+        assert!(
+            !consumer_types.unit_index.contains_key("kilogram"),
+            "import kilogram must not leak after local shadow"
+        );
+        assert!(
+            !consumer_types.unit_index.contains_key("kilograms"),
+            "import kilograms must not leak after local shadow"
+        );
+        assert!(
+            !consumer_types.unit_index.contains_key("gram"),
+            "import gram must not leak after local shadow"
+        );
+
+        let kg_owner = consumer_types.unit_index.get("kg").expect("kg owner");
+        let tonne_owner = consumer_types.unit_index.get("tonne").expect("tonne owner");
+        assert_eq!(kg_owner.as_ref(), local_mass.as_ref());
+        assert_eq!(tonne_owner.as_ref(), local_mass.as_ref());
+    }
+
+    #[test]
+    fn same_family_same_unit_same_factor_is_idempotent() {
+        let code = r#"spec units_a
+data duration: quantity
+  -> unit hour 1
+
+spec consumer
+uses a: units_a
+uses b: units_a
+rule smoke: true
+"#;
+        let (resolver, spec_arcs) = resolver_for_code(code);
+        let units_a_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "units_a")
+            .cloned()
+            .expect("units_a spec");
+        let consumer_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "consumer")
+            .cloned()
+            .expect("consumer spec");
+        let (context, _) = test_context_and_effective(&spec_arcs);
+        let repository = context.workspace();
+
+        let mut already_resolved = ResolvedTypesMap::new();
+        let units_a_types = resolver
+            .resolve_and_validate(&units_a_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("units_a resolves");
+        already_resolved.push((Arc::clone(&repository), units_a_arc, units_a_types));
+
+        let consumer_types = resolver
+            .resolve_and_validate(&consumer_arc, &EffectiveDate::Origin, &already_resolved)
+            .expect("double import of same duration must be idempotent");
+
+        assert!(
+            consumer_types.unit_index.contains_key("hour"),
+            "hour must be indexed once"
+        );
+    }
+
+    #[test]
+    fn same_family_same_unit_different_factor_errors() {
+        let code = r#"spec units_a
+data duration: quantity
+  -> unit hour 1
+
+spec units_b
+data duration: quantity
+  -> unit hour 60
+
+spec consumer
+uses a: units_a
+uses b: units_b
+rule smoke: true
+"#;
+        let (resolver, spec_arcs) = resolver_for_code(code);
+        let units_a_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "units_a")
+            .cloned()
+            .expect("units_a spec");
+        let units_b_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "units_b")
+            .cloned()
+            .expect("units_b spec");
+        let consumer_arc = spec_arcs
+            .iter()
+            .find(|spec| spec.name == "consumer")
+            .cloned()
+            .expect("consumer spec");
+        let (context, _) = test_context_and_effective(&spec_arcs);
+        let repository = context.workspace();
+
+        let mut already_resolved = ResolvedTypesMap::new();
+        for units_arc in [units_a_arc, units_b_arc] {
+            let units_types = resolver
+                .resolve_and_validate(&units_arc, &EffectiveDate::Origin, &already_resolved)
+                .expect("units spec resolves");
+            already_resolved.push((Arc::clone(&repository), units_arc, units_types));
+        }
+
+        let result =
+            resolver.resolve_and_validate(&consumer_arc, &EffectiveDate::Origin, &already_resolved);
+        assert!(
+            result.is_err(),
+            "conflicting hour factors in same family must error"
+        );
+        let error_msg = result
+            .unwrap_err()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            error_msg.contains("hour") && error_msg.contains("conflicting factors"),
+            "expected conflicting factor error for hour, got: {error_msg}"
+        );
     }
 
     #[test]
@@ -9273,31 +9793,57 @@ data my_money: money
     }
 
     #[test]
-    fn test_value_copy_quantity_binding_overwrites_unit_factor() {
+    fn binding_unit_factor_override_errors() {
         let (resolver, spec_arc) = resolver_single_spec(
             r#"spec test
 data source_quantity: quantity
   -> unit usd 1.00
-
 data z: source_quantity
   -> unit usd 0.84"#,
         );
 
-        let resolved = resolver
-            .resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new())
-            .unwrap();
-        let z = resolved.resolved.get("z").unwrap();
-        match &z.specifications {
-            TypeSpecification::Quantity { units, .. } => {
-                assert_eq!(units.len(), 1);
-                let usd = units.iter().find(|u| u.name == "usd").unwrap();
-                assert_eq!(
-                    crate::computation::rational::commit_rational_to_decimal(&usd.factor).unwrap(),
-                    Decimal::from_str_exact("0.84").unwrap()
-                );
-            }
-            other => panic!("Expected Quantity type specifications, got {:?}", other),
-        }
+        let result = resolver.resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new());
+        assert!(
+            result.is_err(),
+            "binding row must not override inherited unit factor"
+        );
+        let error_msg = result
+            .unwrap_err()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            error_msg.contains("usd"),
+            "error must name unit usd, got: {error_msg}"
+        );
+    }
+
+    #[test]
+    fn ratio_extension_unit_factor_override_errors() {
+        let (resolver, spec_arc) = resolver_single_spec(
+            r#"spec test
+data parent: ratio
+  -> unit basis 1
+data child: parent
+  -> unit basis 100"#,
+        );
+
+        let result = resolver.resolve_and_validate(&spec_arc, &EffectiveDate::Origin, &Vec::new());
+        assert!(
+            result.is_err(),
+            "ratio extension must not override inherited unit factor"
+        );
+        let error_msg = result
+            .unwrap_err()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            error_msg.contains("basis"),
+            "error must name unit basis, got: {error_msg}"
+        );
     }
 
     #[test]
@@ -10508,5 +11054,176 @@ mod validation_tests {
             "got: {}",
             errors[0]
         );
+    }
+}
+
+#[cfg(test)]
+mod decomposition_promotion_tests {
+    use super::*;
+    use crate::engine::Context;
+    use crate::parse;
+    use crate::ResourceLimits;
+    use std::sync::Arc;
+
+    fn insert_parsed_repos(ctx: &mut Context, code: &str) -> Vec<Arc<LemmaSpec>> {
+        let result = parse(
+            code,
+            crate::parsing::source::SourceType::Volatile,
+            &ResourceLimits::default(),
+        )
+        .expect("parse");
+        let mut spec_arcs = Vec::new();
+        for (repo_arc, specs) in &result.repositories {
+            for spec in specs {
+                let arc = Arc::new(spec.clone());
+                ctx.insert_spec(Arc::clone(repo_arc), Arc::clone(&arc))
+                    .expect("insert spec");
+                spec_arcs.push(arc);
+            }
+        }
+        spec_arcs
+    }
+
+    fn repo_by_name(ctx: &Context, name: &str) -> Arc<LemmaRepository> {
+        ctx.repositories()
+            .keys()
+            .find(|r| r.name.as_deref() == Some(name))
+            .cloned()
+            .expect("repository must exist after insert")
+    }
+
+    fn resolve_specs_in_order(
+        resolver: &TypeResolver<'_>,
+        repo: &Arc<LemmaRepository>,
+        spec_arcs: &[Arc<LemmaSpec>],
+        local_types: &mut ResolvedTypesMap,
+    ) {
+        for spec_arc in spec_arcs {
+            let types = resolver
+                .resolve_and_validate(spec_arc, &EffectiveDate::Origin, local_types)
+                .unwrap_or_else(|e| panic!("resolve {} failed: {:?}", spec_arc.name, e));
+            local_types.push((Arc::clone(repo), Arc::clone(spec_arc), types));
+        }
+    }
+
+    fn worker_torque_fixture() -> (
+        ResolvedTypesMap,
+        Arc<LemmaSpec>,
+        BaseQuantityVector,
+        Arc<LemmaType>,
+    ) {
+        let mut ctx = Context::new();
+        insert_parsed_repos(&mut ctx, crate::stdlib::UNITS_LEMMA);
+        let alpha_code = r#"repo alpha
+spec units
+data force: quantity
+  -> unit newton 1
+data length: quantity
+  -> unit metre 1
+data torque: quantity
+  -> unit nm newton*metre
+
+spec worker
+uses u: alpha units
+data f: 3 newton
+data d: 4 metre
+rule t: f * d
+"#;
+        let alpha_specs = insert_parsed_repos(&mut ctx, alpha_code);
+        let alpha_repo = repo_by_name(&ctx, "alpha");
+        let worker_arc = alpha_specs
+            .iter()
+            .find(|s| s.name == "worker")
+            .expect("worker spec")
+            .clone();
+        let units_arc = alpha_specs
+            .iter()
+            .find(|s| s.name == "units")
+            .expect("alpha units spec")
+            .clone();
+        let lemma_repo = repo_by_name(&ctx, crate::engine::EMBEDDED_STDLIB_REPOSITORY);
+        let lemma_units = ctx
+            .spec_set(&lemma_repo, "units")
+            .expect("lemma repo")
+            .get_exact(None)
+            .expect("lemma units spec")
+            .clone();
+
+        let mut resolver = TypeResolver::new(&ctx);
+        for spec in &alpha_specs {
+            resolver
+                .register_all(&alpha_repo, spec)
+                .into_iter()
+                .for_each(|e| panic!("register alpha: {e:?}"));
+        }
+        resolver
+            .register_all(&lemma_repo, &lemma_units)
+            .into_iter()
+            .for_each(|e| panic!("register lemma units: {e:?}"));
+
+        let mut local_types = ResolvedTypesMap::new();
+        resolve_specs_in_order(
+            &resolver,
+            &lemma_repo,
+            std::slice::from_ref(&lemma_units),
+            &mut local_types,
+        );
+        resolve_specs_in_order(
+            &resolver,
+            &alpha_repo,
+            std::slice::from_ref(&units_arc),
+            &mut local_types,
+        );
+        resolve_specs_in_order(
+            &resolver,
+            &alpha_repo,
+            std::slice::from_ref(&worker_arc),
+            &mut local_types,
+        );
+
+        let alpha_torque = local_types
+            .iter()
+            .find(|(_, s, _)| Arc::ptr_eq(s, &units_arc))
+            .and_then(|(_, _, t)| t.resolved.get("torque"))
+            .expect("alpha torque type")
+            .clone();
+        let decomp = alpha_torque
+            .quantity_type_decomposition()
+            .expect("torque decomposition")
+            .clone();
+
+        (local_types, worker_arc, decomp, alpha_torque)
+    }
+
+    #[test]
+    fn unique_decomposition_carries_matching_arc() {
+        let (map, worker_spec, decomp, alpha_torque) = worker_torque_fixture();
+        let unique = find_unique_quantity_type_by_decomposition(&map, &worker_spec, &decomp);
+        match unique {
+            DecompositionMatch::Unique(arc) => {
+                assert_eq!(*arc, *alpha_torque);
+                assert_eq!(arc.name.as_deref(), Some("torque"));
+            }
+            other => panic!("expected Unique(Arc) torque match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_unique_ignores_polluted_resolved_map() {
+        let (mut map, worker_spec, decomp, alpha_torque) = worker_torque_fixture();
+        map.iter_mut()
+            .find(|(_, s, _)| Arc::ptr_eq(s, &worker_spec))
+            .expect("worker must be in resolved map")
+            .2
+            .resolved = HashMap::new();
+
+        let unique = find_unique_quantity_type_by_decomposition(&map, &worker_spec, &decomp);
+        match unique {
+            DecompositionMatch::Unique(arc) => {
+                assert_eq!(*arc, *alpha_torque);
+                assert_eq!(arc.name.as_deref(), Some("torque"));
+            }
+            other => panic!("expected Unique(alpha torque) via unit_index, got {other:?}"),
+        }
     }
 }

--- a/engine/src/planning/mod.rs
+++ b/engine/src/planning/mod.rs
@@ -247,12 +247,18 @@ fn plan_spec(
                     limits,
                 ) {
                     Ok(execution_plan) => {
-                        let value_errors =
-                            execution_plan::validate_literal_data_against_types(&execution_plan);
-                        if value_errors.is_empty() {
+                        let mut plan_errors =
+                            execution_plan::validate_unit_index_references(&execution_plan)
+                                .err()
+                                .into_iter()
+                                .collect::<Vec<_>>();
+                        plan_errors.extend(execution_plan::validate_literal_data_against_types(
+                            &execution_plan,
+                        ));
+                        if plan_errors.is_empty() {
                             spec_result.plans.push(execution_plan);
                         } else {
-                            spec_result.errors.extend(value_errors);
+                            spec_result.errors.extend(plan_errors);
                         }
                     }
                     Err(plan_errors) => {

--- a/engine/src/planning/semantics.rs
+++ b/engine/src/planning/semantics.rs
@@ -1424,10 +1424,17 @@ impl TypeSpecification {
                             );
                         }
                     };
-                    if let Some(u) = units.0.iter_mut().find(|u| u.name == unit_name) {
-                        u.factor = crate::computation::rational::decimal_to_rational(value)
+                    if let Some(existing) = units.0.iter().find(|u| u.name == unit_name) {
+                        let new_factor = crate::computation::rational::decimal_to_rational(value)
                             .map_err(|failure| failure.to_string())?;
-                        u.derived_quantity_factors = derived_quantity_factors;
+                        if existing.factor != new_factor
+                            || existing.derived_quantity_factors != derived_quantity_factors
+                        {
+                            return Err(format!(
+                                "Unit '{unit_name}' is already defined in this type's inherited units; \
+                                 cannot change factor or decomposition. Add a new unit name instead."
+                            ));
+                        }
                     } else {
                         units.0.push(QuantityUnit::from_decimal_factor(
                             unit_name,
@@ -1631,8 +1638,13 @@ impl TypeSpecification {
                                 failure
                             )
                         })?;
-                    if let Some(u) = units.0.iter_mut().find(|u| u.name == unit_name) {
-                        u.value = value;
+                    if let Some(existing) = units.0.iter().find(|u| u.name == unit_name) {
+                        if existing.value != value {
+                            return Err(format!(
+                                "Unit '{unit_name}' is already defined in this type's inherited units; \
+                                 cannot change factor. Add a new unit name instead."
+                            ));
+                        }
                     } else {
                         units.0.push(RatioUnit {
                             name: unit_name,
@@ -1714,8 +1726,13 @@ impl TypeSpecification {
                                 "ratio unit value is not exactly representable as a rational: {e}"
                             )
                         })?;
-                    if let Some(u) = units.0.iter_mut().find(|u| u.name == unit_name) {
-                        u.value = value;
+                    if let Some(existing) = units.0.iter().find(|u| u.name == unit_name) {
+                        if existing.value != value {
+                            return Err(format!(
+                                "Unit '{unit_name}' is already defined in this type's inherited units; \
+                                 cannot change factor. Add a new unit name instead."
+                            ));
+                        }
                     } else {
                         units.0.push(RatioUnit {
                             name: unit_name,
@@ -1979,10 +1996,17 @@ impl TypeSpecification {
                             );
                         }
                     };
-                    if let Some(u) = units.0.iter_mut().find(|u| u.name == unit_name) {
-                        u.factor = crate::computation::rational::decimal_to_rational(value)
+                    if let Some(existing) = units.0.iter().find(|u| u.name == unit_name) {
+                        let new_factor = crate::computation::rational::decimal_to_rational(value)
                             .map_err(|failure| failure.to_string())?;
-                        u.derived_quantity_factors = derived_quantity_factors;
+                        if existing.factor != new_factor
+                            || existing.derived_quantity_factors != derived_quantity_factors
+                        {
+                            return Err(format!(
+                                "Unit '{unit_name}' is already defined in this type's inherited units; \
+                                 cannot change factor or decomposition. Add a new unit name instead."
+                            ));
+                        }
                     } else {
                         units.0.push(QuantityUnit::from_decimal_factor(
                             unit_name,
@@ -2229,15 +2253,57 @@ pub fn semantic_calendar_unit_from_quantity_signature(
     semantic_calendar_unit_from_unit_name(unit_name)
 }
 
+mod arc_lemma_type {
+    use super::LemmaType;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::sync::Arc;
+
+    pub fn serialize<S>(value: &Arc<LemmaType>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.as_ref().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<LemmaType>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        LemmaType::deserialize(deserializer).map(Arc::new)
+    }
+}
+
 /// Target type for `as` casts (semantic; used by evaluation/computation).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SemanticConversionTarget {
     Type(PrimitiveKind),
     /// `number as eur` — construct, convert, relabel, or range-span into `unit_name`.
     Unit {
         unit_name: String,
+        /// Quantity/ratio type resolved in the spec where the conversion was written.
+        #[serde(with = "arc_lemma_type")]
+        owning_type: Arc<LemmaType>,
     },
+}
+
+impl std::hash::Hash for SemanticConversionTarget {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Type(kind) => {
+                0u8.hash(state);
+                kind.hash(state);
+            }
+            Self::Unit {
+                unit_name,
+                owning_type,
+            } => {
+                1u8.hash(state);
+                unit_name.hash(state);
+                owning_type.hash(state);
+            }
+        }
+    }
 }
 
 impl SemanticConversionTarget {
@@ -2254,7 +2320,7 @@ impl fmt::Display for SemanticConversionTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SemanticConversionTarget::Type(kind) => write!(f, "{:?}", kind),
-            SemanticConversionTarget::Unit { unit_name } => write!(f, "{unit_name}"),
+            SemanticConversionTarget::Unit { unit_name, .. } => write!(f, "{unit_name}"),
         }
     }
 }
@@ -3373,6 +3439,64 @@ impl LemmaType {
         }
     }
 
+    /// Commit a rational magnitude to a decimal string for API materialization.
+    ///
+    /// Applies this type's `decimal_places` when set. Returns [`NumericFailure`] when the
+    /// magnitude cannot commit to `rust_decimal` (callers map this to a decimal-limit Veto).
+    pub fn try_materialize_rational_as_decimal_string(
+        &self,
+        magnitude: &crate::computation::rational::RationalInteger,
+    ) -> Result<String, crate::computation::rational::NumericFailure> {
+        use crate::computation::rational::commit_rational_to_decimal;
+        let decimal = commit_rational_to_decimal(magnitude)?;
+        Ok(format_committed_decimal_for_api(
+            decimal,
+            self.decimal_places(),
+        ))
+    }
+
+    /// Commit a canonical quantity magnitude in the named declared unit for API materialization.
+    pub fn try_materialize_quantity_canonical_in_unit(
+        &self,
+        canonical_magnitude: &crate::computation::rational::RationalInteger,
+        unit_name: &str,
+    ) -> Result<String, crate::computation::rational::NumericFailure> {
+        use crate::computation::rational::checked_div;
+        let unit_factor = self.quantity_unit_factor(unit_name);
+        let magnitude_in_unit = checked_div(canonical_magnitude, unit_factor)?;
+        self.try_materialize_rational_as_decimal_string(&magnitude_in_unit)
+    }
+
+    /// Commit a canonical ratio magnitude in the named declared unit for API materialization.
+    pub fn try_materialize_ratio_canonical_in_unit(
+        &self,
+        canonical_magnitude: &crate::computation::rational::RationalInteger,
+        unit_name: &str,
+    ) -> Result<String, crate::computation::rational::NumericFailure> {
+        use crate::computation::rational::checked_mul;
+        let units = match &self.specifications {
+            TypeSpecification::Ratio { units, .. } => units,
+            _ => unreachable!(
+                "BUG: try_materialize_ratio_canonical_in_unit called on non-ratio type {}",
+                self.name()
+            ),
+        };
+        let ratio_unit = units
+            .iter()
+            .find(|unit| unit.name == unit_name)
+            .unwrap_or_else(|| {
+                let valid: Vec<&str> = units.iter().map(|unit| unit.name.as_str()).collect();
+                unreachable!(
+                    "BUG: unknown ratio unit '{}' for type {} (valid: {}); planning must reject invalid units",
+                    unit_name,
+                    self.name(),
+                    valid.join(", ")
+                )
+            });
+        let magnitude_in_unit = checked_mul(canonical_magnitude, &ratio_unit.value)?;
+        self.try_materialize_rational_as_decimal_string(&magnitude_in_unit)
+    }
+
     /// Get an example value string for this type, suitable for UI help text
     pub fn example_value(&self) -> &'static str {
         match &self.specifications {
@@ -4293,12 +4417,15 @@ pub fn conversion_target_to_semantic(
         ConversionTarget::Type(kind) => Ok(SemanticConversionTarget::Type(*kind)),
         ConversionTarget::Unit { unit_name } => {
             let unit_name = crate::parsing::ast::ascii_lowercase_logical_name(unit_name.clone());
-            if let Some(index) = unit_index {
-                if index.get(&unit_name).is_none() {
-                    return Err(format!("Unknown unit '{unit_name}'."));
-                }
-            }
-            Ok(SemanticConversionTarget::Unit { unit_name })
+            let index = unit_index.ok_or_else(|| format!("Unknown unit '{unit_name}'."))?;
+            let owning_type = index
+                .get(&unit_name)
+                .ok_or_else(|| format!("Unknown unit '{unit_name}'."))?
+                .clone();
+            Ok(SemanticConversionTarget::Unit {
+                unit_name,
+                owning_type,
+            })
         }
     }
 }
@@ -4464,16 +4591,47 @@ fn decimal_places_in_display_value(decimal: &rust_decimal::Decimal) -> u32 {
     decimal.fract().normalize().scale()
 }
 
-fn format_decimal_for_quantity_display(
+fn format_committed_decimal_for_api(
     decimal: rust_decimal::Decimal,
-    decimals: Option<u8>,
+    decimal_places: Option<u8>,
 ) -> String {
-    match decimals {
-        Some(dp) => {
-            let rounded = decimal.round_dp(u32::from(dp));
-            format!("{:.prec$}", rounded, prec = dp as usize)
+    match decimal_places {
+        Some(decimal_places) => {
+            let rounded = decimal.round_dp(u32::from(decimal_places));
+            format!("{:.prec$}", rounded, prec = decimal_places as usize)
+        }
+        None => {
+            let normalized = decimal.normalize();
+            if normalized.fract().is_zero() {
+                normalized.trunc().to_string()
+            } else {
+                normalized.to_string()
+            }
+        }
+    }
+}
+
+fn format_committed_decimal_for_human_display(
+    decimal: rust_decimal::Decimal,
+    decimal_places: Option<u8>,
+) -> String {
+    match decimal_places {
+        Some(decimal_places) => {
+            let rounded = decimal.round_dp(u32::from(decimal_places));
+            format!("{:.prec$}", rounded, prec = decimal_places as usize)
         }
         None => decimal.normalize().to_string(),
+    }
+}
+
+fn format_rational_for_human_display(
+    magnitude: &crate::computation::rational::RationalInteger,
+    decimal_places: Option<u8>,
+) -> String {
+    use crate::computation::rational::{commit_rational_to_decimal, rational_to_display_str};
+    match commit_rational_to_decimal(magnitude) {
+        Ok(decimal) => format_committed_decimal_for_human_display(decimal, decimal_places),
+        Err(_) => rational_to_display_str(magnitude),
     }
 }
 
@@ -4482,9 +4640,7 @@ fn format_quantity_canonical_for_display(
     lemma_type: &LemmaType,
     signature: &[(String, i32)],
 ) -> String {
-    use crate::computation::rational::{
-        checked_div, commit_rational_to_decimal, rational_to_display_str,
-    };
+    use crate::computation::rational::{checked_div, commit_rational_to_decimal};
     use rust_decimal::Decimal;
 
     let decimals = lemma_type.decimal_places();
@@ -4495,10 +4651,7 @@ fn format_quantity_canonical_for_display(
                 if let Some(unit) = units.iter().find(|u| u.name == *sig_unit) {
                     let in_unit = checked_div(canonical, &unit.factor)
                         .expect("BUG: de-canonicalization for quantity display must not fail");
-                    let formatted = match commit_rational_to_decimal(&in_unit) {
-                        Ok(decimal) => format_decimal_for_quantity_display(decimal, decimals),
-                        Err(_) => rational_to_display_str(&in_unit),
-                    };
+                    let formatted = format_rational_for_human_display(&in_unit, decimals);
                     return format!("{} {}", formatted, unit.name);
                 }
             }
@@ -4515,10 +4668,7 @@ fn format_quantity_canonical_for_display(
             for unit in units.iter() {
                 let in_unit = checked_div(canonical, &unit.factor)
                     .expect("BUG: de-canonicalization for quantity display must not fail");
-                let formatted = match commit_rational_to_decimal(&in_unit) {
-                    Ok(decimal) => format_decimal_for_quantity_display(decimal, decimals),
-                    Err(_) => rational_to_display_str(&in_unit),
-                };
+                let formatted = format_rational_for_human_display(&in_unit, decimals);
                 let abs_magnitude = match commit_rational_to_decimal(&in_unit) {
                     Ok(decimal) => decimal.abs(),
                     Err(_) => Decimal::MAX,
@@ -4562,10 +4712,7 @@ fn format_quantity_canonical_for_display(
         [(name, 1)] => name.clone(),
         _ => format_signature_operator_style(signature),
     };
-    let formatted = match commit_rational_to_decimal(canonical) {
-        Ok(decimal) => format_decimal_for_quantity_display(decimal, decimals),
-        Err(_) => rational_to_display_str(canonical),
-    };
+    let formatted = format_rational_for_human_display(canonical, decimals);
     if unit_label.is_empty() {
         formatted
     } else {
@@ -5611,5 +5758,90 @@ mod tests {
     fn value_kind_matches_spec_rejects_number_for_quantity() {
         let n = ValueKind::Number(rational_new(10, 1));
         assert!(!value_kind_matches_spec(&n, &quantity_type_with_kilogram()));
+    }
+
+    #[test]
+    fn apply_constraint_rejects_inherited_unit_factor_change() {
+        let mut specs = TypeSpecification::quantity();
+        specs = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &unit_factor_arg("eur", 1),
+                &mut None,
+            )
+            .expect("seed eur");
+        let err = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &[
+                    CommandArg::Label("eur".to_string()),
+                    CommandArg::UnitExpr(crate::parsing::ast::UnitArg::Factor(Decimal::new(11, 1))),
+                ],
+                &mut None,
+            )
+            .expect_err("must not change inherited unit factor");
+        assert!(err.contains("eur"), "error must name unit, got: {err}");
+        assert!(
+            err.contains("inherited") || err.contains("cannot change"),
+            "error must reject factor change, got: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_constraint_allows_additive_unit_on_inherited_spec() {
+        let mut specs = TypeSpecification::quantity();
+        specs = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &unit_factor_arg("eur", 1),
+                &mut None,
+            )
+            .expect("seed eur");
+        specs = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &unit_factor_arg("usd", 1),
+                &mut None,
+            )
+            .expect("add usd");
+        match &specs {
+            TypeSpecification::Quantity { units, .. } => assert_eq!(units.len(), 2),
+            other => panic!("expected Quantity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_constraint_idempotent_inherited_unit_redeclare() {
+        let mut specs = TypeSpecification::quantity();
+        specs = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &unit_factor_arg("eur", 1),
+                &mut None,
+            )
+            .expect("seed eur");
+        specs = specs
+            .apply_constraint(
+                "money",
+                TypeConstraintCommand::Unit,
+                &unit_factor_arg("eur", 1),
+                &mut None,
+            )
+            .expect("idempotent eur");
+        match &specs {
+            TypeSpecification::Quantity { units, .. } => {
+                assert_eq!(units.len(), 1);
+                assert_eq!(
+                    units.iter().find(|u| u.name == "eur").expect("eur").factor,
+                    crate::computation::rational::rational_one()
+                );
+            }
+            other => panic!("expected Quantity, got {other:?}"),
+        }
     }
 }

--- a/engine/src/registry.rs
+++ b/engine/src/registry.rs
@@ -468,6 +468,9 @@ fn collect_repository_qualifiers_from_spec_ref(
     let Some(qualifier) = spec_ref.repository.as_ref() else {
         return;
     };
+    if !qualifier.is_registry() {
+        return;
+    }
     if ctx.find_repository(&qualifier.name).is_some() {
         return;
     }
@@ -520,7 +523,7 @@ fn find_missing_repositories(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::Engine;
+    use crate::engine::{Context, Engine};
     use crate::literals::DateGranularity;
 
     /// A test Registry that returns predefined bundles keyed by name.
@@ -608,6 +611,48 @@ data price: 100"#;
         let names: Vec<String> = store.iter().map(|a| a.name.clone()).collect();
         assert!(names.iter().any(|n| n == "example"));
         assert!(names.iter().any(|n| n == "units"));
+    }
+
+    /// Mirrors `lemma fetch --all`: bare `Context::new()` without embedded stdlib.
+    #[tokio::test]
+    async fn resolve_does_not_fetch_non_at_qualified_repositories() {
+        let local_source = r#"spec burn_baby_burn
+uses lemma units
+rule x: 1 hour"#;
+        let local_specs = crate::parse(
+            local_source,
+            crate::parsing::source::SourceType::Volatile,
+            &ResourceLimits::default(),
+        )
+        .unwrap()
+        .into_flattened_specs();
+        let mut store = Context::new();
+        let local_repository = store.workspace();
+        for spec in local_specs {
+            store
+                .insert_spec(Arc::clone(&local_repository), Arc::new(spec))
+                .unwrap();
+        }
+        let mut sources: HashMap<crate::parsing::source::SourceType, String> = HashMap::new();
+        sources.insert(
+            crate::parsing::source::SourceType::Volatile,
+            local_source.to_string(),
+        );
+
+        let registry = TestRegistry::new();
+        let result = resolve_registry_references(
+            &mut store,
+            &mut sources,
+            &registry,
+            &ResourceLimits::default(),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "non-@ repository qualifiers must not be sent to the registry, got: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]

--- a/engine/src/wasm.rs
+++ b/engine/src/wasm.rs
@@ -257,23 +257,6 @@ impl WasmEngine {
             Err(e) => Err(error_to_js(&e)),
         }
     }
-
-    /// Loaded repositories (workspace and dependencies): `{ name, dependency }`.
-    #[wasm_bindgen(js_name = repositories)]
-    pub fn repositories(&self) -> Result<JsValue, JsValue> {
-        let rows: Vec<serde_json::Value> = self
-            .engine
-            .list()
-            .iter()
-            .map(|r| {
-                serde_json::json!({
-                    "name": r.repository.name,
-                    "dependency": r.repository.dependency,
-                })
-            })
-            .collect();
-        serialize_engine_json(&rows)
-    }
 }
 
 #[derive(Serialize)]

--- a/engine/tests/cross_spec_unit_index.rs
+++ b/engine/tests/cross_spec_unit_index.rs
@@ -1,0 +1,199 @@
+//! Cross-spec plans must execute dependency unit conversions without widening
+//! the consumer spec's expression-scope unit index.
+
+use lemma::{DateTimeValue, Engine, ExecutionPlan, SourceType};
+use std::collections::HashMap;
+
+const UNITS_SPEC: &str = r#"
+spec units
+uses lemma units
+data money: quantity
+  -> unit eur 1
+  -> decimals 2
+"#;
+
+const WAREHOUSING_SPEC: &str = r#"
+spec warehousing
+uses units
+uses si: lemma units
+
+data units_per_pallet: number
+  -> minimum 1
+  -> default 1
+
+data storage_duration: si.duration
+  -> minimum 0 weeks
+  -> default 10 days
+
+data interbranch_transport_per_pallet: units.money
+  -> minimum 0 eur
+  -> default 0 eur
+
+data inbound_handling_per_pallet: units.money
+  -> minimum 0 eur
+  -> default 0 eur
+
+data storage_per_pallet_per_week: units.money
+  -> minimum 0 eur
+  -> default 10 eur
+
+data labeling_per_pallet: units.money
+  -> minimum 0 eur
+  -> default 0 eur
+
+data outbound_handling_per_pallet: units.money
+  -> minimum 0 eur
+  -> default 0 eur
+
+rule storage_cost_per_pallet:
+  storage_per_pallet_per_week
+  * ceil storage_duration as weeks as Number
+
+rule total_logistics_per_pallet:
+  interbranch_transport_per_pallet
+  + inbound_handling_per_pallet
+  + storage_cost_per_pallet
+  + labeling_per_pallet
+  + outbound_handling_per_pallet
+
+rule total_logistics_per_ce:
+  total_logistics_per_pallet / units_per_pallet
+"#;
+
+const QUOTATION_SPEC: &str = r#"
+spec quotation
+uses wh: warehousing
+rule total: wh.total_logistics_per_ce
+"#;
+
+const QUOTATION_BAD_SPEC: &str = r#"
+spec quotation_bad
+uses wh: warehousing
+rule bad: 5 minutes
+"#;
+
+fn load_specs(engine: &mut Engine) {
+    engine
+        .load(UNITS_SPEC, SourceType::Volatile)
+        .expect("units spec must load");
+    engine
+        .load(WAREHOUSING_SPEC, SourceType::Volatile)
+        .expect("warehousing spec must load");
+}
+
+#[test]
+fn warehousing_plans_alone() {
+    let mut engine = Engine::new();
+    load_specs(&mut engine);
+    let now = DateTimeValue::now();
+    engine
+        .get_plan(None, "warehousing", Some(&now))
+        .expect("warehousing must plan alone");
+    let response = engine
+        .run(None, "warehousing", Some(&now), HashMap::new(), false, None)
+        .expect("warehousing must evaluate");
+    let display = response
+        .results
+        .get("storage_cost_per_pallet")
+        .expect("storage_cost_per_pallet must be present")
+        .display
+        .clone()
+        .expect("storage_cost_per_pallet must have display");
+    assert_eq!(
+        display, "20.00 eur",
+        "10 eur/week * ceil(10 days as weeks) must be 20.00 eur, got: {display}"
+    );
+}
+
+#[test]
+fn quotation_plans_without_consumer_stdlib_units() {
+    let mut engine = Engine::new();
+    load_specs(&mut engine);
+    engine
+        .load(QUOTATION_SPEC, SourceType::Volatile)
+        .expect("quotation must plan without uses lemma units");
+    let now = DateTimeValue::now();
+    let plan = engine
+        .get_plan(None, "quotation", Some(&now))
+        .expect("quotation must plan without Unknown unit minutes/weeks in unit index");
+
+    let expression_units = &plan.resolved_types.unit_index;
+    assert!(
+        !expression_units.contains_key("weeks"),
+        "consumer expression scope must not contain weeks: {:?}",
+        expression_units.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !expression_units.contains_key("minutes"),
+        "consumer expression scope must not contain minutes: {:?}",
+        expression_units.keys().collect::<Vec<_>>()
+    );
+    let mut keys: Vec<_> = expression_units.keys().cloned().collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        ["percent", "permille"],
+        "consumer expression scope must only have builtin ratio units, not dependency units"
+    );
+}
+
+#[test]
+fn quotation_evaluates_cross_spec_duration_conversion() {
+    let mut engine = Engine::new();
+    load_specs(&mut engine);
+    engine
+        .load(QUOTATION_SPEC, SourceType::Volatile)
+        .expect("quotation must load");
+    let now = DateTimeValue::now();
+    let plan = engine
+        .get_plan(None, "quotation", Some(&now))
+        .expect("quotation must plan");
+    assert!(
+        !plan.resolved_types.unit_index.contains_key("weeks"),
+        "consumer unit_index must not contain weeks before serialize"
+    );
+
+    let mut json: serde_json::Value =
+        serde_json::to_value(lemma::ExecutionPlanSerialized::from(plan)).unwrap();
+    let unit_index = json["unit_index"]
+        .as_object_mut()
+        .expect("serialized plan must have unit_index");
+    unit_index.remove("weeks");
+    unit_index.remove("minutes");
+
+    let serialized: lemma::ExecutionPlanSerialized = serde_json::from_value(json).unwrap();
+    let reconstructed = ExecutionPlan::try_from(serialized)
+        .expect("inlined weeks conversion must validate via owning_type, not consumer unit_index");
+    let response = engine
+        .run_plan(&reconstructed, Some(&now), HashMap::new(), false, None)
+        .expect("serialized quotation plan must evaluate");
+    let display = response
+        .results
+        .get("total")
+        .expect("rule total must be present")
+        .display
+        .clone()
+        .expect("total must have display");
+    assert_eq!(
+        display, "20.00 eur",
+        "10 eur/week * ceil(10 days as weeks) / 1 CE must be 20.00 eur, got: {display}"
+    );
+}
+
+#[test]
+fn quotation_rejects_minutes_in_local_rule() {
+    let mut engine = Engine::new();
+    load_specs(&mut engine);
+    let err = engine
+        .load(QUOTATION_BAD_SPEC, SourceType::Volatile)
+        .expect_err("5 minutes in consumer must fail at load");
+    let minutes_err = err
+        .errors
+        .iter()
+        .find(|error| error.message().contains("minutes"))
+        .expect("load must report minutes out of scope");
+    assert_eq!(
+        minutes_err.message(),
+        "Unit 'minutes' is not in scope for this spec"
+    );
+}

--- a/engine/tests/data_binding_type_validation.rs
+++ b/engine/tests/data_binding_type_validation.rs
@@ -421,28 +421,7 @@ rule r: msg
 }
 
 #[test]
-fn quantity_overwrites_inherited_unit_factors() {
-    use lemma::TypeSpecification;
-    use rust_decimal::Decimal;
-    use std::str::FromStr;
-
-    fn decimal_lit(s: &str) -> Decimal {
-        Decimal::from_str(s).unwrap()
-    }
-
-    fn qty_factor(spec: &TypeSpecification, name: &str) -> Decimal {
-        match spec {
-            TypeSpecification::Quantity { units, .. } => {
-                let u = units
-                    .iter()
-                    .find(|u| u.name == name)
-                    .unwrap_or_else(|| panic!("unit {name} missing"));
-                u.factor_decimal()
-            }
-            other => panic!("expected Quantity, got {other:?}"),
-        }
-    }
-
+fn import_binding_unit_factor_override_errors() {
     let mut engine = Engine::new();
     engine
         .load(
@@ -451,40 +430,34 @@ spec finance
 data money: quantity
   -> unit eur 1.00
   -> unit usd 0.91
-  -> decimals 2
 "#,
             lemma::SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from(
                 "finance.lemma",
             ))),
         )
-        .unwrap();
-    engine
-        .load(
-            r#"
+        .expect("finance spec must load");
+
+    let result = engine.load(
+        r#"
 spec pricing
 uses fin: finance
 data currency: fin.money
-  -> unit eur 1
   -> unit usd 0.84
-  -> decimals 2
 rule r: currency
 "#,
-            lemma::SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from(
-                "pricing.lemma",
-            ))),
-        )
-        .unwrap();
-
-    let now = DateTimeValue::now();
-    let schema = engine.schema(None, "pricing", Some(&now)).expect("schema");
-    let entry = schema.data.get("currency").expect("currency");
-    let specs = &entry.lemma_type.specifications;
-    assert_eq!(qty_factor(specs, "usd"), decimal_lit("0.84"));
-    assert_eq!(qty_factor(specs, "eur"), decimal_lit("1"));
-    match specs {
-        TypeSpecification::Quantity { decimals, .. } => assert_eq!(*decimals, Some(2)),
-        other => panic!("expected Quantity, got {other:?}"),
-    }
+        lemma::SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from(
+            "pricing.lemma",
+        ))),
+    );
+    assert!(
+        result.is_err(),
+        "import binding must not override inherited unit factor"
+    );
+    let error_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        error_msg.contains("usd"),
+        "error must name unit usd, got: {error_msg}"
+    );
 }
 
 #[test]

--- a/engine/tests/decomposition_binding_alias_collision.rs
+++ b/engine/tests/decomposition_binding_alias_collision.rs
@@ -1,0 +1,64 @@
+//! Binding aliases sharing a quantity family must not block decomposition promotion.
+
+use lemma::Engine;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn source() -> lemma::SourceType {
+    lemma::SourceType::Path(Arc::new(PathBuf::from(
+        "decomposition_binding_alias_collision.lemma",
+    )))
+}
+
+fn assert_loads(code: &str) {
+    let mut engine = Engine::new();
+    engine
+        .load(code, source())
+        .expect("spec must load and plan");
+}
+
+fn eval_display(code: &str, spec_name: &str, rule_name: &str) -> String {
+    let mut engine = Engine::new();
+    engine.load(code, source()).expect("spec must load");
+    let response = engine
+        .run(None, spec_name, None, HashMap::new(), true, None)
+        .expect("spec must evaluate");
+    response
+        .results
+        .get(rule_name)
+        .unwrap_or_else(|| panic!("rule '{rule_name}' missing"))
+        .display
+        .clone()
+        .expect("display")
+}
+
+const PURCHASE_COST_SPEC: &str = r#"spec units
+uses lemma units
+data money: quantity
+  -> unit eur 1
+data mass: quantity
+  -> unit kg 1
+data price_per_weight: quantity
+  -> unit eur_per_kg eur/kg
+
+spec purchase_cost
+uses u: units
+data total_eur: 100 eur
+data weight: 10 kg
+data starch_levy_per_kg: u.price_per_weight
+  -> default 0.1 eur_per_kg
+data amortization_per_kg: u.price_per_weight
+  -> default 0.2 eur_per_kg
+rule base_cost_per_kg: total_eur / weight
+"#;
+
+#[test]
+fn division_promotes_despite_binding_aliases() {
+    assert_loads(PURCHASE_COST_SPEC);
+    let display = eval_display(PURCHASE_COST_SPEC, "purchase_cost", "base_cost_per_kg");
+    assert!(
+        display.contains("10") && display.to_lowercase().contains("eur_per_kg"),
+        "expected 10 eur_per_kg, got: {display}"
+    );
+}

--- a/engine/tests/decomposition_promotion_collision.rs
+++ b/engine/tests/decomposition_promotion_collision.rs
@@ -1,0 +1,58 @@
+//! Decomposition promotion with cross-repo `units` basename collision (bugs.md §1–§3).
+
+use lemma::Engine;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn source() -> lemma::SourceType {
+    lemma::SourceType::Path(Arc::new(PathBuf::from(
+        "decomposition_promotion_collision.lemma",
+    )))
+}
+
+fn assert_loads(code: &str) {
+    let mut engine = Engine::new();
+    engine
+        .load(code, source())
+        .expect("spec must load and plan");
+}
+
+fn eval_display(code: &str, repository: Option<&str>, spec_name: &str, rule_name: &str) -> String {
+    let mut engine = Engine::new();
+    engine.load(code, source()).expect("spec must load");
+    let response = engine
+        .run(repository, spec_name, None, HashMap::new(), true, None)
+        .expect("spec must evaluate");
+    response
+        .results
+        .get(rule_name)
+        .unwrap_or_else(|| panic!("rule '{rule_name}' missing"))
+        .display
+        .clone()
+        .expect("display")
+}
+
+const AREA_CALC_SPEC: &str = r#"repo alpha
+spec units
+data length: quantity
+  -> unit widget 1
+data area: quantity
+  -> unit sqwidget widget*widget
+
+spec worker
+uses myunits: alpha units
+data l: 3 widget
+data w: 4 widget
+rule area_calc: l * w
+"#;
+
+#[test]
+fn area_calc_promotes_to_sqwidget() {
+    assert_loads(AREA_CALC_SPEC);
+    let display = eval_display(AREA_CALC_SPEC, Some("alpha"), "worker", "area_calc");
+    assert!(
+        display.contains("12") && display.to_lowercase().contains("sqwidget"),
+        "expected 12 sqwidget, got: {display}"
+    );
+}

--- a/engine/tests/delivery_decimals_materialization.rs
+++ b/engine/tests/delivery_decimals_materialization.rs
@@ -1,0 +1,62 @@
+use lemma::{DateTimeValue, Engine, SourceType};
+use std::collections::HashMap;
+
+#[test]
+fn delivery_cost_materializes_converted_unit_with_schema_decimals() {
+    let code = r#"
+spec delivery 2026-01-01
+
+data distance: quantity
+  -> unit meter 1
+  -> unit kilometer 1000
+
+data money: quantity
+  -> decimals 2
+  -> unit eur 1.00
+  -> unit usd 0.84
+
+data rate: quantity
+  -> unit eur_per_km eur/kilometer
+
+rule delivery_cost: 0.26 eur_per_km * distance
+"#;
+
+    let mut engine = Engine::new();
+    engine.load(code, SourceType::Volatile).unwrap();
+
+    let effective = DateTimeValue {
+        year: 2026,
+        month: 1,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: 0,
+        timezone: None,
+        granularity: lemma::DateGranularity::Full,
+    };
+
+    let response = engine
+        .run(
+            None,
+            "delivery",
+            Some(&effective),
+            HashMap::from([("distance".to_string(), "12 kilometer".to_string())]),
+            false,
+            None,
+        )
+        .expect("run");
+
+    let delivery_cost = response
+        .results
+        .get("delivery_cost")
+        .expect("delivery_cost rule");
+
+    assert!(!delivery_cost.vetoed);
+    let quantity = delivery_cost
+        .quantity
+        .as_ref()
+        .expect("quantity map on delivery_cost");
+    assert_eq!(quantity.get("eur"), Some(&"3.12".to_string()));
+    assert_eq!(quantity.get("usd"), Some(&"3.71".to_string()));
+}

--- a/engine/tests/error_messages.rs
+++ b/engine/tests/error_messages.rs
@@ -693,7 +693,7 @@ rule r: sqrt true
 "#,
     );
     assert!(
-        joined.contains("Mathematical function requires number operand"),
+        joined.contains("Mathematical function 'sqrt' requires number operand, got boolean"),
         "expected math-function operand error: {joined}"
     );
     assert_lowercase_type_in_errors(&joined, &["boolean"], &["Boolean"]);

--- a/engine/tests/quantity_math_ops.rs
+++ b/engine/tests/quantity_math_ops.rs
@@ -1,0 +1,148 @@
+//! Magnitude-preserving math (`ceil`, `floor`, `round`, `abs`) on quantity operands.
+
+use lemma::{Engine, SourceType};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn source() -> SourceType {
+    SourceType::Path(Arc::new(PathBuf::from("quantity_math_ops.lemma")))
+}
+
+fn load_ok(code: &str) {
+    let mut engine = Engine::new();
+    engine
+        .load(code, source())
+        .unwrap_or_else(|errors| panic!("spec must load: {errors:?}"));
+}
+
+fn load_err(code: &str) -> String {
+    let mut engine = Engine::new();
+    match engine.load(code, source()) {
+        Ok(()) => panic!("expected planning error"),
+        Err(errors) => errors
+            .iter()
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>()
+            .join("; "),
+    }
+}
+
+fn eval_display(code: &str, spec: &str, rule: &str, data: HashMap<String, String>) -> String {
+    let mut engine = Engine::new();
+    engine.load(code, source()).expect("spec must load");
+    let response = engine
+        .run(None, spec, None, data, false, None)
+        .expect("spec must evaluate");
+    response
+        .results
+        .get(rule)
+        .unwrap_or_else(|| panic!("rule '{rule}' missing"))
+        .display
+        .clone()
+        .expect("rule must have display value")
+}
+
+#[test]
+fn ceil_duration_as_weeks() {
+    let code = r#"spec duration_math
+uses lemma units
+data storage_duration: 10 days
+rule weeks_billed: ceil (storage_duration as weeks)"#;
+    load_ok(code);
+    let displayed = eval_display(code, "duration_math", "weeks_billed", HashMap::new());
+    assert!(
+        displayed.contains('2') && displayed.to_lowercase().contains("week"),
+        "10 days as weeks ceiled must be 2 weeks, got: {displayed}"
+    );
+}
+
+#[test]
+fn warehousing_storage_cost_with_ceil_weeks() {
+    let code = r#"spec warehousing
+uses lemma units
+data money: quantity -> unit eur 1
+data rate: quantity -> unit eur_per_week eur/week
+data storage_per_pallet_per_week: 10 eur_per_week
+data storage_duration: 10 days
+rule storage_cost_per_pallet:
+  storage_per_pallet_per_week * ceil (storage_duration as weeks)"#;
+    load_ok(code);
+    let displayed = eval_display(
+        code,
+        "warehousing",
+        "storage_cost_per_pallet",
+        HashMap::new(),
+    );
+    assert!(
+        displayed.contains("20") && displayed.to_lowercase().contains("eur"),
+        "10 eur/week * ceil(10 days as weeks) must be 20 eur, got: {displayed}"
+    );
+}
+
+#[test]
+fn floor_round_abs_on_quantity() {
+    let code = r#"spec mass_math
+uses lemma units
+data mass: quantity -> unit kilogram 1
+data weight: 2.6 kilogram
+rule floored: floor weight
+rule rounded: round weight
+rule absolute: abs (0 kilogram - weight)"#;
+    load_ok(code);
+    assert_eq!(
+        eval_display(code, "mass_math", "floored", HashMap::new()),
+        "2 kilogram"
+    );
+    assert_eq!(
+        eval_display(code, "mass_math", "rounded", HashMap::new()),
+        "3 kilogram"
+    );
+    assert_eq!(
+        eval_display(code, "mass_math", "absolute", HashMap::new()),
+        "2.6 kilogram"
+    );
+}
+
+#[test]
+fn sqrt_on_quantity_rejected_at_plan() {
+    let code = r#"spec bad_math
+uses lemma units
+data storage_duration: 10 days
+rule bad: sqrt (storage_duration as weeks)"#;
+    let error = load_err(code);
+    assert!(
+        error.to_lowercase().contains("sqrt") && error.to_lowercase().contains("number"),
+        "sqrt on quantity must fail at plan time, got: {error}"
+    );
+}
+
+#[test]
+fn ceil_anonymous_compound_at_rule_boundary_rejected_at_plan() {
+    let code = r#"spec compound_ceil
+uses lemma units
+data length: quantity -> unit meter 1
+data dist: 100 meter
+data time: 20 seconds
+rule bad:
+  ceil (dist / time)"#;
+    let error = load_err(code);
+    assert!(
+        error.to_lowercase().contains("anonymous"),
+        "ceil on dist/time at rule boundary must fail at plan time, got: {error}"
+    );
+}
+
+#[test]
+fn ceil_negative_duration_as_weeks() {
+    let code = r#"spec negative_duration
+uses lemma units
+data storage_duration: -10 days
+rule weeks_billed: ceil (storage_duration as weeks)"#;
+    load_ok(code);
+    let displayed = eval_display(code, "negative_duration", "weeks_billed", HashMap::new());
+    assert!(
+        displayed.contains("-1") && displayed.to_lowercase().contains("week"),
+        "-10 days as weeks ceiled must be -1 weeks, got: {displayed}"
+    );
+}

--- a/engine/tests/quantity_unit_conversion.rs
+++ b/engine/tests/quantity_unit_conversion.rs
@@ -1252,9 +1252,10 @@ rule quotient: ten / zero
     );
 }
 
-/// Regression: stale deserialized `unit_index` must return Error, not panic at eval.
+/// Regression: stripping expression-scope unit_index from a serialized plan must
+/// not invalidate unit conversions that carry their owning type at plan time.
 #[test]
-fn eval_stale_unit_index_returns_error_not_internal_panic() {
+fn eval_stripped_plan_unit_index_still_plans_and_runs() {
     let code = r#"
 spec t
 uses lemma units
@@ -1275,22 +1276,118 @@ rule r: x as minutes
         .as_object_mut()
         .expect("unit_index object");
     assert!(
-        unit_index.contains_key("minutes") || unit_index.contains_key("minute"),
-        "plan must contain minutes/minute in unit_index before tampering; keys: {:?}",
+        unit_index.contains_key("minutes"),
+        "x as minutes must register minutes in unit_index before tampering; keys: {:?}",
         unit_index.keys().collect::<Vec<_>>()
     );
     unit_index.remove("minutes");
-    unit_index.remove("minute");
 
     let serialized: lemma::ExecutionPlanSerialized = serde_json::from_value(json).unwrap();
-    let tampered_plan: ExecutionPlan = ExecutionPlan::try_from(serialized).unwrap();
+    let reconstructed = ExecutionPlan::try_from(serialized)
+        .expect("carried owning_type must not need plan unit_index");
+    let response = engine
+        .run_plan(&reconstructed, Some(&now), HashMap::new(), false, None)
+        .expect("evaluation must succeed with carried conversion types");
+    let display = response
+        .results
+        .get("r")
+        .expect("rule r must be present")
+        .display
+        .clone()
+        .expect("rule r must have display");
+    assert_eq!(display, "5 minutes");
+}
 
-    let result = engine.run_plan(&tampered_plan, Some(&now), HashMap::new(), true, None);
-    assert!(
-        result.is_err(),
-        "stale unit_index must surface as Error, not Ok: {:?}",
-        result.ok()
+/// Regression: tampered unit conversion target rejected at TryFrom, not at eval.
+#[test]
+fn eval_tampered_unit_conversion_target_rejected_at_try_from() {
+    let code = r#"
+spec t
+uses lemma units
+data duration: units.duration
+data x: number -> default 5
+rule r: x as minutes
+"#;
+
+    let mut engine = Engine::new();
+    engine.load(code, lemma::SourceType::Volatile).unwrap();
+    let now = DateTimeValue::now();
+
+    let plan = engine.get_plan(None, "t", Some(&now)).unwrap();
+
+    let mut json: serde_json::Value =
+        serde_json::to_value(lemma::ExecutionPlanSerialized::from(plan)).unwrap();
+    let code_array = json["rules"][0]["instructions"]["code"]
+        .as_array_mut()
+        .expect("instruction code array");
+    let conversion = code_array
+        .iter_mut()
+        .find(|insn| insn.get("unit_conversion").is_some())
+        .expect("plan must contain a unit_conversion instruction");
+    let target = conversion
+        .get_mut("unit_conversion")
+        .expect("unit_conversion object")
+        .get_mut("target")
+        .expect("conversion target");
+    let unit = target
+        .get_mut("unit")
+        .expect("unit conversion target must be unit variant");
+    unit["unit_name"] = serde_json::Value::String("tampered_unit".to_string());
+
+    let serialized: lemma::ExecutionPlanSerialized = serde_json::from_value(json).unwrap();
+    let result = ExecutionPlan::try_from(serialized);
+    let err = result.expect_err("tampered conversion target must fail TryFrom");
+    assert_eq!(
+        err.message(),
+        "Serialized execution plan for spec 't' is invalid: Unit conversion target 'tampered_unit' is not declared on owning type 'duration'"
     );
+}
+
+#[test]
+fn shadowed_duration_rejects_minutes_alias_at_load() {
+    let code = r#"
+spec s
+uses lemma units
+data duration: quantity
+  -> unit minute 60
+rule r: 5 as minutes
+"#;
+
+    let mut engine = Engine::new();
+    let err = engine
+        .load(code, lemma::SourceType::Volatile)
+        .expect_err("shadowed duration must reject minutes alias at load");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("minutes"),
+        "expected unknown minutes at load, got: {msg}"
+    );
+}
+
+#[test]
+fn stdlib_duration_minutes_loads_and_runs() {
+    let code = r#"
+spec t
+uses lemma units
+data duration: units.duration
+data x: number -> default 5
+rule r: x as minutes
+"#;
+
+    let mut engine = Engine::new();
+    engine.load(code, lemma::SourceType::Volatile).unwrap();
+    let now = DateTimeValue::now();
+    let response = engine
+        .run(None, "t", Some(&now), HashMap::new(), true, None)
+        .expect("stdlib duration with minutes must run");
+    let display = response
+        .results
+        .get("r")
+        .expect("rule r")
+        .display
+        .as_deref()
+        .expect("display");
+    assert_eq!(display, "5 minutes");
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/engine/tests/unified_ratio_units.rs
+++ b/engine/tests/unified_ratio_units.rs
@@ -407,7 +407,7 @@ rule out: margin
     expect_load_error(
         code,
         "redefine_percent.lemma",
-        &["margin", "custom", "percent"],
+        &["percent", "cannot change factor", "inherited"],
     );
 }
 

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.8.18", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.8.19", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
## [0.8.19] - 2026-06-11

0.8.19 fixes registry resolution, a few quantity planning/materialization bugs and removes a redundant SDK method.

### Added

- **Quantity ceil/floor/round/abs**: preserve operand unit.

### Fixed

- **Registry resolve skips non-`@` repository qualifiers**: workspace-local repository references no longer trigger registry fetches.
- **Decomposition promotion**: binding aliases no longer collide across quantity families.
- **Materialization**: converted quantities honor type `decimals`; decimal overflow vetoes the rule.
- **Inherited units**: conflicting inherited unit definitions rejected at planning.
- **Unit-index validation**: structural plan checks run at planning and deserialize, not first `run`.

### Removed

- **`Engine.repositories()` / `Lemma.repositories/1`**: returned only `{ name, dependency }` per loaded repository — the same fields already on `list()[].repository`. Use `list()` for loaded-repo discovery.
