### PR TITLE
docs: add Cursor Cloud dev env instructions (Nix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+Lemma is a Rust workspace (CLI + engine + LSP, plus an Elixir Hex package and a WASM/npm package).
+
+- **Language & contribution rules:** see `documentation/AGENTS.md` (mandatory rules) and `README.md`.
+- **Full CI gate / release tooling:** see `xtask/README.md` (`cargo precommit`, `cargo verify`).
+
+## Cursor Cloud specific instructions
+
+The dev environment is provided by the committed Nix flake (`flake.nix`). Nix is installed single-user at `~/.nix-profile`; flakes are enabled. Enter the dev shell from the repo root and run tools inside it:
+
+    nix develop --command bash -c '<cmd>'
+
+The shell provides Rust 1.92 (pinned by `rust-toolchain.toml`), `cargo-nextest`, `cargo-deny`, `wasm-pack`, Node 24, and Elixir 1.18 — everything needed for the workspace and the Hex/npm sub-packages. No database or external services are required (the engine is stateless).
+
+- Tests: `cargo nextest run --workspace` (never plain `cargo test`).
+- Lint: `cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check`.
+- Run the CLI: `cargo run -p lemma -- run coffee_order --prefix documentation/examples product=latte size=large number_of_cups=2 has_loyalty_card=true age=70`.
+- Run the HTTP server (port 8012): `cargo run -p lemma -- server --prefix documentation/examples --port 8012`, then `POST /<spec>` with JSON data.
+
+This same Nix dev shell also supplies the Elixir/Node toolchain used by the sibling `lemmabase.com` repo, which has no flake of its own.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a root `AGENTS.md` documenting how to set up and run the Lemma Rust workspace in the Cursor Cloud environment using the committed Nix flake. No source code changes.

The dev environment is fully provided by `flake.nix` (`nix develop`): Rust 1.92, `cargo-nextest`, `cargo-deny`, `wasm-pack`, Node 24, Elixir 1.18. No database/services required.

## Validation (run inside `nix develop`)
- `cargo build --workspace` — builds clean
- `cargo nextest run --workspace` — 2174 passed, 2 skipped
- `cargo clippy --workspace --all-targets` — clean
- CLI: `lemma run coffee_order ...` → correct evaluation table
- HTTP server: `POST /coffee_order` on port 8012 → JSON results

[lemma coffee_order evaluation](https://cursor.com/agents/bc-59e84016-f277-4176-a2e5-3720027d111e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flemmabase_register_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e84016-f277-4176-a2e5-3720027d111e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e84016-f277-4176-a2e5-3720027d111e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

