### PR TITLE
Release 0.9.3: transactional updates, quality recommendations, MCP evaluate guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `lemma-v{version}` (for example `lemma-v0.8.20`); releases before the rename used `cli-v{version}`. Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest release tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
+## [0.9.3] - 2026-08-05
+
+0.9.3 makes engine mutations transactional, adds structural quality Recommendations, and expands the MCP authoring/evaluate loop (`update_spec`, evaluate guide, richer admin tools).
+
+### Added
+
+- **Transactional `Engine::update`**: replace a temporal spec slice with new source in one atomic apply (rollback on failure). Exposed on WASM/TS as `update(...)`.
+- **MCP admin mutators**: `update_spec`, `remove_spec`, `clear`, and `fetch` (with `--admin`).
+- **Structural quality**: `Engine::quality()` returns advisory `Recommendation` values (missing commentary/effective date/`-> help`, open text without options, open inputs without suggest, veto-as-rejection cascades). MCP `check` appends them on success; LSP publishes them as Hint diagnostics.
+- **Evaluate guide**: MCP `guide` with no topic (and `lemma://guide`) returns the CS evaluate guide. Authoring uses `topic: "full"` / `lemma://guide/full`. New section topics: `method`, `natural_language`.
+
+### Changed
+
+- **`load` / `remove` / `update`**: share one transactional apply path; failed batches leave the engine unchanged.
+- **MCP `source`**: available in read-only mode (no longer requires `--admin`).
+- **Authoring guide**: refreshed fragments (rules method, anti-patterns, veto, data, composition) and `llms.txt`.
+
 ## [0.9.2] - 2026-08-03
 
 0.9.2 strengthens the MCP authoring loop, relocates published docs next to the CLI, and exposes a single serializable `EngineError` wire type from the Rust engine.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.3"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508004a5500f2e1f68af048f70feea2de86d35ab115d85716530860822aef397"
+checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1555,18 +1555,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.3"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8b30cafa78358ae6cd1494a7d6410b89530e28bf567f862c869c667e900d9f"
+checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.3"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5526bd381d230af94908d07e6835a33fd82a465e12f5f1e9c81f5c2aa23b3c21"
+checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1578,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1604,7 +1604,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lemma"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-lsp"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "lemma-engine",
  "lemma-openapi",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_jni"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "jni",
  "lemma-engine",
@@ -2372,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.3"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af3eb523cce0df0af3c30d624b829b2dabd233172b5bc2615fcd03ceae8f746"
+checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
@@ -2401,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Ben Rogmans <ben@lemmabase.com>"]
 description = "A pure, declarative language for business rules."

--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ lemma server --prefix ./policies --watch
 AI assistants interact with Lemma specs via the Model Context Protocol:
 
 ```bash
-lemma mcp             # read-only (evaluate, list, show, check, guide)
-lemma mcp --admin     # also enable add_spec and source
+lemma mcp             # read-only (evaluate, list, show, source, check, guide)
+lemma mcp --admin     # also enable add_spec and other mutators
 ```
 
 Authoring loop: `guide` → `check` (diagnostics) → `evaluate`. Resources expose `lemma://guide` and curated examples.
@@ -325,7 +325,7 @@ See [engine/packages/npm/README.md](engine/packages/npm/README.md).
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
 </dependency>
 ```
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,9 +16,9 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.2", path = "../engine" }
-lemma-lsp = { version = "=0.9.2", path = "../engine/lsp" }
-lemma-openapi = { version = "=0.9.2", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.9.3", path = "../engine" }
+lemma-lsp = { version = "=0.9.3", path = "../engine/lsp" }
+lemma-openapi = { version = "=0.9.3", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/cli/documentation/evaluate_guide.txt
+++ b/cli/documentation/evaluate_guide.txt
@@ -1,0 +1,43 @@
+**Evaluating loaded specs**
+
+Default guide for answering with loaded specs. Do not load `guide` topic `full` unless authoring new Lemma. Do not write or redesign specs here.
+
+A reply can close many fields; a question should open only one topic.
+
+**User-facing language**
+
+Talk like a consultant in their domain. Do not say bindings, facts, schema, missing_data, suggest, or other tooling words to the user. Those are for tools only. In chat: questions, the details you recorded, and the answer.
+
+Never ask the user what the policy means (“does X count as Y?”, “should that count as… — is that right?”). Ask about their situation. Bind clear entailments from their answers using help/schema; do not quiz them on the mapping.
+
+Never dispose your interpretation as the truth (“that counts as…”, “that’s fine”, “is sturdy”). When a judgment call cannot be answered from their situation plus help/schema, be careful and use *should* — then continue (final verify table is where they correct recorded details).
+
+**Setup**
+
+1. **`list`** — learn available specs. Never invent spec names.
+2. **`show`** the chosen spec once. Do not call show again between asks. Never turn show into a questionnaire.
+3. **`evaluate`** one target `rule`. Read `missing_data` (name, type, help, suggest). `missing_data` is inputs still needed — not a queue order and not a script.
+
+**After every user turn (primary loop)**
+
+Instructions to you — do not say “bind” to the user.
+
+4. Bind every `missing_data` field that utterance decides, including clear entailments across fields. Supply bindings and re-evaluate.
+5. Do not ask again about a topic the user already settled with a broader claim. Synonym probes of the same claim are forbidden.
+6. **Ambiguous polarity** → do not bind; re-ask that one input clearly.
+7. **Broad / over-answer** that covers a topic → bind all fields that claim settles; do not keep grilling that topic.
+8. **Blanket yes to everything** → bind only what the yes clearly covers. Confirm unusual leftovers separately (minority `suggest`, or where true is not the compliant case). Never silent-fill from `-> suggest` alone; suggest is a prior for phrasing cluster questions, not an invented answer.
+
+**When inputs remain (fallback)**
+
+9. Ask **one** natural question aimed at the next undecided *topic* (or the single blocking input). Prefer what a consultant would ask. At most one unanswered question in flight. Help may inform meaning; ask normally.
+10. If the missing list is huge, you may evaluate the next undecided intermediate gate to learn which topic to ask — still without dumping the schema.
+
+**When the rule answers (verify before done)**
+
+11. Do not treat the first complete evaluation as final. Present a short table the user can check:
+    - **Details** — each input in readable wording (help label or plain language), with the value you used.
+    - **Answer** — the outcome for their question and any other derived answers you relied on.
+12. Close with a statement, not a question — e.g. tell the user to say if anything requires adjustment. If they correct something, update the data, re-evaluate, and verify again. Only then treat the outcome as final.
+
+Repeat the intake loop until the rule answers, then verify, then stop.

--- a/cli/documentation/examples/02_library_fees.lemma
+++ b/cli/documentation/examples/02_library_fees.lemma
@@ -6,6 +6,8 @@ Shows conditional logic with unless clauses.
 Easy to understand: books returned late incur fees.
 """
 
+uses lemma units
+
 data money: measure
   -> decimals 2
   -> unit eur 1.00
@@ -18,8 +20,10 @@ data book_kind: text
 
 data book_type:        book_kind
 data is_first_offense: boolean
-data days_overdue: number
-  -> minimum 0
+data due_date:         date
+data return_date:      date
+
+rule days_overdue: (due_date...return_date) as day as number
 
 rule daily_fee: 0 eur
   unless book_type is "regular"     then 0.25 eur

--- a/cli/documentation/guide/00_intro.txt
+++ b/cli/documentation/guide/00_intro.txt
@@ -3,9 +3,7 @@
 > Lemma: declarative business rule language. Translate natural-language policy to readable, deterministic `.lemma` specs. Inputs derived from rules — declare `data` with constraints. No runtime value invention.
 
 Goal: produce Lemma source for human reading and system evaluation. Prefer named pipeline rules. No clever one-liners. Split unrelated policies to separate specs.
-Use `lemma show` to inspect static interface (types, constraints, normalized rules). Run-data needs come from rule `missing_data` on `run` (not `show`).
-Explanations opt-in (`explain: true` / `lemma run -x`). Wire shape: `engine/schemas/api.v1.json` (`RuleResult.explanation` is `RuleNode`; nested nodes under `ExplanationNode`).
 
-**NO INLINE COMMENTS.** Lemma has no `#`, `//`, or `--` comment syntax. `#` starts parse error. No trailing remarks on `data` or `rule` lines.
+Authoring method, discovery loop, and output contract: see **Method**. Explanations opt-in (`explain: true` / `lemma run -x`).
 
-**Only doc in source:** commentary block `"""..."""`. Must be **very next tokens** after `spec` line (before `uses`, `data`, etc.). Nowhere else.
+**NO INLINE COMMENTS.** Lemma has no `#`, `//`, or `--` comment syntax. See **Syntax** for opening order and commentary placement.

--- a/cli/documentation/guide/05_method.txt
+++ b/cli/documentation/guide/05_method.txt
@@ -1,0 +1,51 @@
+**Method: write as a policy consultant, not a transcriber**
+
+Syntax alone can encode the wrong policy. Never invent numbers, dates, or outcomes the source does not decide — ask those gaps before writing. No retroactive questions after authoring. No follow-up ideas after deliver.
+
+**Process**
+
+1. **Gather** — Collect sources (prose, statute, ticket, answers, field names). Inventory. Do not write Lemma yet.
+2. **Interpret** — Restate as questions the system must answer. Name actors, triggers, windows. One coherent policy → one `spec` (you decide).
+3. **Interrogate** — Ask only when the **source leaves a policy outcome undecided**. Phrase questions in plain language a non-Lemma author understands. Do not invent. Do not Author until answers or explicit acceptance.
+4. **Scope** — One `spec` per coherent policy; split / `uses` only when the source clearly mixes unrelated domains; `@…` catalogs; temporal date only when the author confirms a start date — never guess.
+5. **Model** — Public `data` API and named `rule` pipeline (you choose field shape — do not ask the author). Domain-principle `unless` defaults (see **Rules**). Denial = `false`/`no`; unanswerable = veto (see **Veto**). Prefer raw inputs over precomputed numbers. Encode rule gates the source states; omit advisory how-to that is not a gate. Name booleans for the fact you mean; prefer the natural predicate with `-> suggest` for the usual case (`data item_damaged: boolean -> suggest false`). Do not invent awkward opposites (`item_undamaged`) or negated names (`not_*`, `no_*`, `has_no_*`).
+6. **Author** — After questions resolved. Commentary after `spec`, `meta` for provenance; no inline comments (see **Syntax**). Spec is the only documentation.
+7. **Verify** — `check`, `show`, `evaluate` at boundaries (half-open ranges). Result text must match conditions. Then `add_spec` / `update_spec` to load.
+8. **Deliver** — Always paste the full Lemma source in chat so the user can verify what was saved or loaded (use `source` if you need the loaded text). Confirm loaded. Close with a statement, not a question — e.g. tell them to say if anything requires adjustment. No pitch for more work. Stop.
+
+**What to ask (and what not to)**
+
+Ask when the source does not decide a **policy outcome**, e.g. a threshold boundary ("above €50" vs "€50 or more"), or whether rules start on a specific date.
+
+Do **not** ask:
+
+- Modeling shape (`data` field count, option vs boolean, one input vs two)
+- Spec packaging (one vs split) when the source is one coherent policy
+- Whether advisory prose (tips, how-to steps, "contact support") is "in scope" — encode gates; omit advice
+- Edge cases the source never mentions
+
+Plain language: "Is this policy effective from a specific date, or have these rules always been in effect?" — not "Effective date — pin a date on the spec, or leave undated?"
+
+**Output contract (mandatory)**
+
+- **Before Author** — Ask the few real gaps (if any). Wait. Do not invent.
+- **At Deliver** — Full Lemma source in chat for user verify + loaded confirmation + assumptions the author confirmed. No new policy questions. No pitch for more work. Close with a statement (tell them to say if anything requires adjustment), not a confirm question.
+
+**Principles**
+
+- Spec is the only documentation: `-> help`, commentary, `meta` (see **Syntax**).
+- `data` names are a public API. Prefer `-> option` for closed text sets.
+- Decomposition is output quality: named intermediates, not mega-rules.
+
+**Worked example**
+
+Source: *"Standard shipping is €4.95. Free shipping when the order is €50 or more."*
+
+Ask before writing (real gaps only):
+
+1. At exactly €50 — free shipping or €4.95?
+2. Is this shipping policy effective from a specific date, or have these rules always been in effect?
+
+WRONG to ask: one `shipping` spec or split; how many `data` fields for destination; express vs economy when the source never mentions them; whether packing tips are hard rules.
+
+After answers: Model / Author / Verify / `add_spec`. Fee rule uses domain-principle default (usual fee, free when threshold met). If author says free at €50 or more → `order_total >= 50 eur`. Paste source, deliver and stop.

--- a/cli/documentation/guide/10_syntax.txt
+++ b/cli/documentation/guide/10_syntax.txt
@@ -8,4 +8,9 @@ data ...
 rule ...
 ```
 
-Commentary after `uses` or `data` is invalid, parse fails. No `#`, `//`, `--` comment syntax. Use descriptive names. Put user explanations outside code fences — never inside ` ```lemma ` blocks.
+Commentary after `uses` or `data` is invalid. No `#`, `//`, `--` comments. Use descriptive names. Put user explanations outside code fences — never inside ` ```lemma ` blocks.
+
+**Gotchas (parse errors)**
+
+- No `or` operator. Disjunction via `unless` chains or separate boolean rules.
+- Constraints (`-> help`, `-> option`, `-> minimum`, etc.) apply to `data` only. Rules have no constraints.

--- a/cli/documentation/guide/20_composition.txt
+++ b/cli/documentation/guide/20_composition.txt
@@ -4,7 +4,7 @@ Default: one file, one implicit repo. No `repo` blocks unless multi-namespace wo
 
 **Spec** = namespace for `data` and `rules`. **Rule** = named computed value. Reference rules by name; engine resolves if name is data or rule. One file can have multiple specs.
 Hierarchical names: `spec employee/contract`. Effective date for temporal changes: `spec pricing 2026-01-01`.
-Sole documentation: commentary `"""..."""` immediately after `spec <name> [<effective>]` (before `uses`, `data`, or `rule`).
+Commentary placement: see **Syntax**.
 
 **Example A — minimal single-spec file**
 
@@ -12,7 +12,6 @@ Sole documentation: commentary `"""..."""` immediately after `spec <name> [<effe
 spec pricing 2026-01-01
 """
 Pricing rules for bulk and member discounts.
-Commentary must follow the spec line; it cannot go anywhere else.
 """
 
 data qty:        number

--- a/cli/documentation/guide/25_natural_language.txt
+++ b/cli/documentation/guide/25_natural_language.txt
@@ -4,7 +4,8 @@ Request: *"Library charges €0.25/day for regular books, €0.50 for reference,
 
 Map logic:
 - Book types → `data book_type` with `-> option` constraints
-- Overdue days, first offense → `data` input slots
+- Due and return dates → `data` input slots; overdue days derived by a rule
+- First offense → `data` input slot
 - Per-day rates → `rule daily_fee` with unless branches
 - Grace period → `rule is_in_grace_period`
 - Fee pipeline → `rule total_fee`, `rule final_fee`
@@ -14,6 +15,7 @@ Map logic:
 
 ```lemma
 spec library_fees
+uses lemma units
 
 data money: measure
   -> decimals 2
@@ -27,8 +29,10 @@ data book_kind: text
 
 data book_type:        book_kind
 data is_first_offense: boolean
-data days_overdue: number
-  -> minimum 0
+data due_date:         date
+data return_date:      date
+
+rule days_overdue: (due_date...return_date) as day as number
 
 rule daily_fee: 0 eur
   unless book_type is "regular"     then 0.25 eur

--- a/cli/documentation/guide/30_data.txt
+++ b/cli/documentation/guide/30_data.txt
@@ -1,6 +1,8 @@
 **Data: constraint definitions, not placeholders**
 
-`data` declares variables. Constraints define validity. Type-only `data` (no value) is input slot. `lemma show` lists static reachable data. Evaluator needs come from rule `missing_data` on `run` (not `show`). Use real domain values. Never `"TODO"` or dummy placeholders.
+`data` declares variables. Constraints define validity. Type-only `data` (no value) is an input slot. Use real domain values. Never `"TODO"` or dummy placeholders.
+
+For which inputs a rule still needs at runtime, call MCP `guide` with no topic (evaluate guide): `list` → `show` once → `evaluate` → ask one `missing_data` field → repeat. Load `guide` topic `full` only when authoring new specs. `show` is the static catalog — not a required-input checklist. `-> help` is the literal CS ask string; do not replace the question with a different one.
 
 **Example D — typed data (coffee order)**
 
@@ -73,7 +75,7 @@ data money: measure -> unit eur 1.00
 data wallet: money -> minimum 0 eur
 ```
 
-With help text:
+With help text (literal CS ask string):
 ```lemma
 spec payroll
 
@@ -81,6 +83,15 @@ data pay_period: text
   -> option "month"
   -> option "week"
   -> help "How often you are paid."
+```
+
+Boolean with usual-case suggest:
+```lemma
+spec returns
+
+data item_damaged: boolean
+  -> suggest false
+  -> help "Item damaged?"
 ```
 
 Constraints chain: `-> minimum`, `-> maximum`, `-> option`, `-> unit`, `-> decimals`, `-> suggest`, `-> help`, etc. Details in Reference.

--- a/cli/documentation/guide/50_rules.txt
+++ b/cli/documentation/guide/50_rules.txt
@@ -1,8 +1,26 @@
 **Rules and unless: last matching clause wins**
 
-Write default expression, then: `unless <condition> then <result>`. Evaluated in source order. If multiple match, **bottommost wins**. Order general first, specific overrides last.
+Default expression, then `unless <condition> then <result>`. Source order; **bottommost match wins**. General first, specific last. Snake_case names; boolean predicates (`is_eligible`, `can_ship`). Named pipeline rules — no opaque mega-expressions.
 
-Use **snake_case** rule names. Boolean rules as predicates: `is_eligible`, `can_ship`. Decompose logic into pipeline of named rules. No opaque single expressions.
+**Domain-principle default**
+
+Default is not "prefer yes/no." It is the answer **in principle for this rule's domain**. Experts must read top-to-bottom as: "In principle X; unless Y, then Z."
+
+1. Name the question (`can_ship` → "Can we ship this order?").
+2. Before special cases, what is true in principle? That is the default — from *this* rule's domain, not optimism or "start true and subtract failures."
+3. What positive facts change the answer? Those are `unless` conditions — not `… is false then flip`.
+4. Write `rule name: <principle> unless <positive conditions> then <exception>`.
+
+Examples by domain: shipping often earned (`no` unless grant); discount often `0%`; fees use the policy's usual fee — not "free unless expensive."
+
+Forbidden: double denial (`yes` / `unless … is false then no`); fail-each-check cascades; invented `*_compliant` default-yes helpers.
+
+```lemma-skip
+rule can_ship: no
+  unless in_stock
+    and address_complete
+    then yes
+```
 
 **Example F — overlapping unless (last wins)**
 
@@ -18,123 +36,47 @@ rule discount: 0%
   unless is_vip          then 25%
 ```
 
-VIP customer ordering 75 items gets **25%** (not 20%). Both `qty >= 50` and `is_vip` match; bottommost wins.
+VIP ordering 75 items gets **25%** (not 20%): both `qty >= 50` and `is_vip` match; bottommost wins.
 
 **Example G — progressive unless chain**
 
 ```lemma
 spec rules_and_unless
 
-data is_premium:   yes
-data base_price:   number -> minimum 0
-data customer_age: number -> minimum 0 -> maximum 120
-data qty:          number -> minimum 0
+data is_premium: yes
+data base_price: number -> minimum 0
+data qty:        number -> minimum 0
 
-rule total_before_discount:
-  base_price * qty
+rule total_before_discount: base_price * qty
 
-rule discount_percentage:
-  0%
+rule discount_percentage: 0%
   unless qty >= 10 then 10%
   unless qty >= 20 then 15%
-  unless is_premium   then 20%
+  unless is_premium then 20%
 
-rule discount_amount:
-  total_before_discount * discount_percentage
+rule discount_amount:      total_before_discount * discount_percentage
+rule total_after_discount: total_before_discount - discount_amount
 
-rule total_after_discount:
-  total_before_discount - discount_amount
-
-rule shipping_cost:
-  15
+rule shipping_cost: 15
   unless total_after_discount >= 100 then 10
   unless total_after_discount >= 200 then 0
 
-rule final_total:
-  total_after_discount + shipping_cost
+rule final_total: total_after_discount + shipping_cost
 ```
 
-Tiered discounts, derived rules referencing prior rules, unless on computed values.
-
-**Example H — decomposed shipping pipeline**
+**Example H — short pipeline sketch**
 
 ```lemma
-spec shipping_policy
+spec shipping_fees
 uses lemma units
 
-data destination_country: text
-  -> option "NL"
-  -> option "BE"
-  -> option "DE"
-  -> option "FR"
-  -> suggest "NL"
+data item_weight: units.mass
+data order_total: number -> minimum 0
 
-data customer_tier: text
-  -> option "standard"
-  -> option "silver"
-  -> option "gold"
-  -> option "platinum"
-  -> suggest "gold"
-
-data destination_region: text
-data is_expedited:       boolean
-data is_hazardous:       boolean
-data is_po_box:          boolean
-data item_weight:        units.mass
-data order_total:        number -> minimum 0
-
-rule base_shipping_rate: 35
-  unless destination_country is "NL" then 22
-  unless destination_country is "BE" then 25
-  unless destination_country is "DE" then 28
-  unless destination_country is "FR" then 30
-
+rule base_rate: 22
 rule weight_surcharge: 0
-  unless item_weight > 5 kilogram  then 7.5
-  unless item_weight > 20 kilogram
-    then veto "Item too heavy for standard shipping"
+  unless item_weight > 5 kilogram then 7.5
 
-rule po_box_fee: 0
-  unless is_po_box then 5
-
-rule expedited_fee: 0
-  unless is_expedited                           then 25
-  unless is_expedited and item_weight > 10 kilogram then 45
-
-rule hazardous_fee: 0
-  unless is_hazardous then 50
-  unless is_hazardous and destination_country is not "NL"
-    then veto "Cannot ship hazardous materials internationally"
-
-rule customer_discount: 0%
-  unless customer_tier is "silver"   then 10%
-  unless customer_tier is "gold"     then 20%
-  unless customer_tier is "platinum" then 30%
-
-rule free_shipping_eligible:
-  order_total >= 100 and destination_country is "NL"
-
-rule shipping_before_discount:
-  base_shipping_rate + weight_surcharge + po_box_fee
-  + expedited_fee + hazardous_fee
-
-rule shipping_discount_amount:
-  shipping_before_discount * customer_discount
-
-rule final_shipping:
-  shipping_before_discount - shipping_discount_amount
-  unless free_shipping_eligible then 0
-
-rule ships_to_location: true
-  unless is_po_box and is_hazardous
-    then veto "Cannot ship hazardous materials to PO boxes"
-  unless destination_region is "Svalbard"
-    then veto "Shipping not available to Svalbard"
-
-rule Summary: "Standard shipping"
-  unless free_shipping_eligible
-    then "Free shipping (order over €100)"
-  unless is_expedited then "Expedited shipping"
+rule final_shipping: base_rate + weight_surcharge
+  unless order_total >= 100 then 0
 ```
-
-Each fee is distinct rule. `item_weight` uses `units.mass`. Veto clauses placed last in `weight_surcharge` and `ships_to_location`. Eligibility separated from amount rules.

--- a/cli/documentation/guide/60_veto.txt
+++ b/cli/documentation/guide/60_veto.txt
@@ -9,6 +9,10 @@ Veto is like Rust's `Err` — rule has **no value** and propagates to dependents
 | Normal business "no" | `false` or `no` |
 | Test veto without propagating | `x is veto` (returns boolean) |
 
+**Litmus test:** Can the question be answered? If yes, even when the answer is negative, use `true`/`false`. If the question itself is unanswerable for this input, use veto. "Is the customer eligible?" is always answerable (`true` or `false`). "What is the price of this coffee?" when the product is not on the menu is unanswerable (veto).
+
+A vetoed rule is not `false`. `x is false` does not match a vetoed `x`. To test whether a rule vetoed, use `x is veto`.
+
 Place veto unless clauses **last** to override other branches.
 
 **Example I — enumeration with default veto**
@@ -107,6 +111,5 @@ If `validated_score` vetoes but `use_default` is true, `result` is 50. Unless br
 3. **Outputs**: every answerable question is a `rule`.
 4. **Factor**: intermediate calculations as named rules.
 5. **Unless**: default first, general to specific, vetoes last.
-6. **No inline comments**: no `#`, `//`. Commentary `"""..."""` only as first block after `spec`.
-7. **Validate**: verify reachable data with `show`, missing inputs via `run`, and correct override order.
-8. **Advanced**: use `uses lemma units`, ranges, compound units when needed.
+6. **Validate**: `check`, then `show`, then `evaluate` (MCP `guide` with no topic for `missing_data` intake; topic `full` only when authoring).
+7. **Advanced**: `uses lemma units`, ranges, compound units when needed.

--- a/cli/documentation/guide/70_anti_patterns.txt
+++ b/cli/documentation/guide/70_anti_patterns.txt
@@ -2,63 +2,11 @@
 
 Inline comments (WRONG — `#` fails to parse):
 ```lemma-skip
-data customer_age: number -> minimum 0 -> maximum 120  # input slot
-data tax_rate: 21%  # fixed policy constant
-rule discount: 0%  # default: no discount
-  unless qty >= 10 then 10%  # bulk rate
+data customer_age: number -> minimum 0  # input
+rule discount: 0%  # default
 ```
 
-Commentary after `uses` (WRONG — fails to parse):
-```lemma-skip
-spec wholesale_nuts_pricing
-uses lemma units
-"""
-B2B pricing calculation for a wholesale nuts supplier.
-Handles product base pricing, organic premiums, and freight shipping.
-"""
-
-data base_price: number
-```
-
-Commentary after `data` (WRONG — fails to parse):
-```lemma-skip
-spec pricing
-
-data qty: number
-"""
-This is not valid commentary placement.
-"""
-
-rule discount: 0%
-```
-
-Commentary before `uses` (RIGHT):
-```lemma
-spec wholesale_nuts_pricing
-"""
-B2B pricing for a wholesale nuts supplier.
-Handles base pricing, organic premiums, volume discounts, and freight.
-"""
-
-uses lemma units
-
-data base_price: number
-```
-
-Commentary immediately after spec (RIGHT — no `uses`):
-```lemma
-spec pricing
-"""
-Customer age is an input; tax_rate is a fixed policy constant.
-"""
-
-data customer_age: number -> minimum 0 -> maximum 120
-data tax_rate: 21%
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
-```
+Commentary after `uses` (WRONG). RIGHT: commentary immediately after `spec` (see **Syntax**).
 
 Mega-rule (WRONG):
 ```lemma-skip
@@ -83,70 +31,44 @@ rule shipping_cost:        15 unless total_after_discount >= 100 then 10
 rule final_total:          total_after_discount + shipping_cost
 ```
 
-Hardcoded input (WRONG):
-```lemma-skip
-rule discount: 10 * 0.1
-```
+Hardcoded input (WRONG): `rule discount: 10 * 0.1`
+RIGHT: `data qty: number` then `rule discount: qty * 0.1`
 
-Input as data (RIGHT):
-```lemma
-spec bulk_discount
-
-data qty: number -> minimum 0
-rule discount: qty * 0.1
-```
-
-Wrong unless order (WRONG — VIP gets 20%, not 25%):
+Wrong unless order (WRONG — VIP gets 20% not 25%):
 ```lemma-skip
 rule discount: 0%
-  unless is_vip          then 25%
-  unless qty >= 50  then 20%
+  unless is_vip then 25%
+  unless qty >= 50 then 20%
 ```
+RIGHT: specific override last (`qty` tiers first, `is_vip` last).
 
-Correct order (RIGHT):
-```lemma
-spec tiered_discount
+Placeholder (WRONG): `data customer_name: "TODO"`
+RIGHT: `data customer_name: text`
 
-data qty: number
-data is_vip:   boolean
+Error vs Veto: `5 and "text"` = planning Error. `unless age > 120 then veto "…"` = runtime Veto.
 
-rule discount: 0%
-  unless qty >= 50  then 20%
-  unless is_vip          then 25%
-```
-
-Placeholder (WRONG):
+Veto-as-rejection (WRONG — denial is answerable; see **Veto**):
 ```lemma-skip
-data customer_name: "TODO"
+rule is_eligible: true
+  unless age < 18 then veto "Must be 18+"
+  unless has_id is false then veto "ID required"
 ```
+RIGHT: boolean rules composed with `and` (`is_old_enough and has_valid_id`).
 
-Type-only input (RIGHT):
-```lemma
-spec customer_record
+Unnecessary `repo` (WRONG). RIGHT: single-file `spec` without `repo`.
 
-data customer_name: text
-```
+No `or` (WRONG): `rule is_eligible: is_adult or has_guardian` — see **Syntax**; use `unless` or separate booleans.
 
-Error vs Veto: `5 and "text"` is planning Error (invalid Lemma). `unless age > 120 then veto "Invalid age"` is runtime Veto (valid spec, domain no-value). Do not confuse.
+Constraints on rules (WRONG): `rule discount: 10% -> help "…"` — `->` is data-only (see **Syntax**).
 
-Unnecessary repo (WRONG):
+Domain-blind polarity / double denial (WRONG):
 ```lemma-skip
-repo default
-
-spec pricing
-
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
+rule can_ship: yes
+  unless in_stock is false then no
+  unless address_complete is false then no
 ```
-
-Single-file spec (RIGHT):
-```lemma
-spec pricing
-
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
+RIGHT: domain principle + positive grant (see **Rules**):
+```lemma-skip
+rule can_ship: no
+  unless in_stock and address_complete then yes
 ```

--- a/cli/documentation/guide/80_footer.txt
+++ b/cli/documentation/guide/80_footer.txt
@@ -1,36 +1,8 @@
-## Docs
+## See also
 
-- [Learn guide](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/readme.md): specs, data, rules, unless, veto
-- [Reference](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/readme.md): operators, types, units, ranges, `uses`
-- [Veto](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/types_and_units.md#veto): propagation, `is veto`
-- [Composing specs](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/composing_specs.md): `uses`, temporal versions, pins
-- [CLI](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/cli.md): `run`, `show`, `format`
-- [Registry](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/registry.md): LemmaBase `@user/repo` imports
-- [LemmaBase search](https://lemmabase.com/search?q=): registry search
-- [Examples (docs)](https://github.com/lemma/lemma/tree/main/cli/documentation/examples): `.lemma` files
-- [Examples (tests)](https://github.com/lemma/lemma/tree/main/cli/tests/integrations/examples): progressives
+- [Learn guide](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/readme.md)
+- [Reference](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/readme.md)
+- [LemmaBase search](https://lemmabase.com/search?q=)
+- [Examples](https://github.com/lemma/lemma/tree/main/cli/documentation/examples)
 
-## Examples by pattern
-
-- [Coffee order](https://github.com/lemma/lemma/blob/main/cli/documentation/examples/01_coffee_order.lemma): constraints, unless, veto enum
-- [Library fees](https://github.com/lemma/lemma/blob/main/cli/documentation/examples/02_library_fees.lemma): unless chains, bool vs veto
-- [Rules and unless](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/02_rules_and_unless.lemma): progressive unless
-- [Spec references](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/03_spec_references.lemma): compound units, `uses lemma units`
-- [Unit conversions](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/04_unit_conversions.lemma): duration, `as` conversion
-- [Spec composition](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/11_spec_composition.lemma): hierarchy
-- [Registry references](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/12_registry_references.lemma): registry import
-- [Shipping policy](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/07_shipping_policy.lemma): decomposed rules
-
-## Numeric precision (summary)
-
-Exact rationals (ℚ) for `+`, `−`, `×`, `÷`, comparisons, conversions. `^`, `sqrt`, trig, `log` use ~28-significant-digit Decimal. `floor`/`ceil`/`round` on measures use Decimal.
-
-**Boundary number contract:** WASM, HTTP JSON, Elixir NIF accept integers as numbers, reject float/decimal numbers. Pass decimals as strings. Example: `{ "quantity": 42, "rate": "0.075" }`. On Maven (JDK 21+), pass `BigDecimal` or decimal strings via `RunRequest.data(...)`; output is `BigDecimal`.
-
-## Optional
-
-- [LemmaBase](https://lemmabase.com): registry
-- [Numeric precision](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/precision.md): exact rational arithmetic, boundary contract
-- [JavaScript / TypeScript (WASM)](https://github.com/lemma/lemma/blob/main/cli/documentation/tools/javascript.md): browser and Node
-- [Maven (Java / Kotlin)](https://github.com/lemma/lemma/blob/main/cli/documentation/tools/maven.md): Central JNI package
-- [README](https://github.com/lemma/lemma/blob/main/README.md): install, quick start
+Decimals at JSON boundaries: pass as strings. Detail: [Numeric precision](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/precision.md).

--- a/cli/documentation/learn/types_and_units.md
+++ b/cli/documentation/learn/types_and_units.md
@@ -244,6 +244,10 @@ Also: `in future`, `future N day`, `in past|future calendar year|month|week`, `n
 
 Use Veto when a Rule cannot produce a meaningful value: the domain says "no answer here." Use Veto for impossible situations, not for negative business results. A Rule that evaluates to `false` or `0` is still a valid result.
 
+**Litmus test:** Can the question be answered? If yes, even when the answer is negative, use `true`/`false`. If the question itself is unanswerable for this input, use veto. "Is the customer eligible?" is always answerable (`true` or `false`). "What is the price of this coffee?" when the product is not on the menu is unanswerable (veto).
+
+A vetoed Rule is not `false`. `x is false` does not match a vetoed `x`. To test whether a Rule vetoed, use `x is veto`.
+
 Common cases:
 
 - Data validation: input is out of acceptable range.

--- a/cli/documentation/llms.txt
+++ b/cli/documentation/llms.txt
@@ -3,12 +3,65 @@
 > Lemma: declarative business rule language. Translate natural-language policy to readable, deterministic `.lemma` specs. Inputs derived from rules — declare `data` with constraints. No runtime value invention.
 
 Goal: produce Lemma source for human reading and system evaluation. Prefer named pipeline rules. No clever one-liners. Split unrelated policies to separate specs.
-Use `lemma show` to inspect static interface (types, constraints, normalized rules). Run-data needs come from rule `missing_data` on `run` (not `show`).
-Explanations opt-in (`explain: true` / `lemma run -x`). Wire shape: `engine/schemas/api.v1.json` (`RuleResult.explanation` is `RuleNode`; nested nodes under `ExplanationNode`).
 
-**NO INLINE COMMENTS.** Lemma has no `#`, `//`, or `--` comment syntax. `#` starts parse error. No trailing remarks on `data` or `rule` lines.
+Authoring method, discovery loop, and output contract: see **Method**. Explanations opt-in (`explain: true` / `lemma run -x`).
 
-**Only doc in source:** commentary block `"""..."""`. Must be **very next tokens** after `spec` line (before `uses`, `data`, etc.). Nowhere else.
+**NO INLINE COMMENTS.** Lemma has no `#`, `//`, or `--` comment syntax. See **Syntax** for opening order and commentary placement.
+
+
+---
+
+**Method: write as a policy consultant, not a transcriber**
+
+Syntax alone can encode the wrong policy. Never invent numbers, dates, or outcomes the source does not decide — ask those gaps before writing. No retroactive questions after authoring. No follow-up ideas after deliver.
+
+**Process**
+
+1. **Gather** — Collect sources (prose, statute, ticket, answers, field names). Inventory. Do not write Lemma yet.
+2. **Interpret** — Restate as questions the system must answer. Name actors, triggers, windows. One coherent policy → one `spec` (you decide).
+3. **Interrogate** — Ask only when the **source leaves a policy outcome undecided**. Phrase questions in plain language a non-Lemma author understands. Do not invent. Do not Author until answers or explicit acceptance.
+4. **Scope** — One `spec` per coherent policy; split / `uses` only when the source clearly mixes unrelated domains; `@…` catalogs; temporal date only when the author confirms a start date — never guess.
+5. **Model** — Public `data` API and named `rule` pipeline (you choose field shape — do not ask the author). Domain-principle `unless` defaults (see **Rules**). Denial = `false`/`no`; unanswerable = veto (see **Veto**). Prefer raw inputs over precomputed numbers. Encode rule gates the source states; omit advisory how-to that is not a gate. Name booleans for the fact you mean; prefer the natural predicate with `-> suggest` for the usual case (`data item_damaged: boolean -> suggest false`). Do not invent awkward opposites (`item_undamaged`) or negated names (`not_*`, `no_*`, `has_no_*`).
+6. **Author** — After questions resolved. Commentary after `spec`, `meta` for provenance; no inline comments (see **Syntax**). Spec is the only documentation.
+7. **Verify** — `check`, `show`, `evaluate` at boundaries (half-open ranges). Result text must match conditions. Then `add_spec` / `update_spec` to load.
+8. **Deliver** — Always paste the full Lemma source in chat so the user can verify what was saved or loaded (use `source` if you need the loaded text). Confirm loaded. Close with a statement, not a question — e.g. tell them to say if anything requires adjustment. No pitch for more work. Stop.
+
+**What to ask (and what not to)**
+
+Ask when the source does not decide a **policy outcome**, e.g. a threshold boundary ("above €50" vs "€50 or more"), or whether rules start on a specific date.
+
+Do **not** ask:
+
+- Modeling shape (`data` field count, option vs boolean, one input vs two)
+- Spec packaging (one vs split) when the source is one coherent policy
+- Whether advisory prose (tips, how-to steps, "contact support") is "in scope" — encode gates; omit advice
+- Edge cases the source never mentions
+
+Plain language: "Is this policy effective from a specific date, or have these rules always been in effect?" — not "Effective date — pin a date on the spec, or leave undated?"
+
+**Output contract (mandatory)**
+
+- **Before Author** — Ask the few real gaps (if any). Wait. Do not invent.
+- **At Deliver** — Full Lemma source in chat for user verify + loaded confirmation + assumptions the author confirmed. No new policy questions. No pitch for more work. Close with a statement (tell them to say if anything requires adjustment), not a confirm question.
+
+**Principles**
+
+- Spec is the only documentation: `-> help`, commentary, `meta` (see **Syntax**).
+- `data` names are a public API. Prefer `-> option` for closed text sets.
+- Decomposition is output quality: named intermediates, not mega-rules.
+
+**Worked example**
+
+Source: *"Standard shipping is €4.95. Free shipping when the order is €50 or more."*
+
+Ask before writing (real gaps only):
+
+1. At exactly €50 — free shipping or €4.95?
+2. Is this shipping policy effective from a specific date, or have these rules always been in effect?
+
+WRONG to ask: one `shipping` spec or split; how many `data` fields for destination; express vs economy when the source never mentions them; whether packing tips are hard rules.
+
+After answers: Model / Author / Verify / `add_spec`. Fee rule uses domain-principle default (usual fee, free when threshold met). If author says free at €50 or more → `order_total >= 50 eur`. Paste source, deliver and stop.
 
 
 ---
@@ -23,7 +76,12 @@ data ...
 rule ...
 ```
 
-Commentary after `uses` or `data` is invalid, parse fails. No `#`, `//`, `--` comment syntax. Use descriptive names. Put user explanations outside code fences — never inside ` ```lemma ` blocks.
+Commentary after `uses` or `data` is invalid. No `#`, `//`, `--` comments. Use descriptive names. Put user explanations outside code fences — never inside ` ```lemma ` blocks.
+
+**Gotchas (parse errors)**
+
+- No `or` operator. Disjunction via `unless` chains or separate boolean rules.
+- Constraints (`-> help`, `-> option`, `-> minimum`, etc.) apply to `data` only. Rules have no constraints.
 
 
 ---
@@ -34,7 +92,7 @@ Default: one file, one implicit repo. No `repo` blocks unless multi-namespace wo
 
 **Spec** = namespace for `data` and `rules`. **Rule** = named computed value. Reference rules by name; engine resolves if name is data or rule. One file can have multiple specs.
 Hierarchical names: `spec employee/contract`. Effective date for temporal changes: `spec pricing 2026-01-01`.
-Sole documentation: commentary `"""..."""` immediately after `spec <name> [<effective>]` (before `uses`, `data`, or `rule`).
+Commentary placement: see **Syntax**.
 
 **Example A — minimal single-spec file**
 
@@ -42,7 +100,6 @@ Sole documentation: commentary `"""..."""` immediately after `spec <name> [<effe
 spec pricing 2026-01-01
 """
 Pricing rules for bulk and member discounts.
-Commentary must follow the spec line; it cannot go anywhere else.
 """
 
 data qty:        number
@@ -146,7 +203,8 @@ Request: *"Library charges €0.25/day for regular books, €0.50 for reference,
 
 Map logic:
 - Book types → `data book_type` with `-> option` constraints
-- Overdue days, first offense → `data` input slots
+- Due and return dates → `data` input slots; overdue days derived by a rule
+- First offense → `data` input slot
 - Per-day rates → `rule daily_fee` with unless branches
 - Grace period → `rule is_in_grace_period`
 - Fee pipeline → `rule total_fee`, `rule final_fee`
@@ -156,6 +214,7 @@ Map logic:
 
 ```lemma
 spec library_fees
+uses lemma units
 
 data money: measure
   -> decimals 2
@@ -169,8 +228,10 @@ data book_kind: text
 
 data book_type:        book_kind
 data is_first_offense: boolean
-data days_overdue: number
-  -> minimum 0
+data due_date:         date
+data return_date:      date
+
+rule days_overdue: (due_date...return_date) as day as number
 
 rule daily_fee: 0 eur
   unless book_type is "regular"     then 0.25 eur
@@ -195,7 +256,9 @@ rule can_checkout: yes
 
 **Data: constraint definitions, not placeholders**
 
-`data` declares variables. Constraints define validity. Type-only `data` (no value) is input slot. `lemma show` lists static reachable data. Evaluator needs come from rule `missing_data` on `run` (not `show`). Use real domain values. Never `"TODO"` or dummy placeholders.
+`data` declares variables. Constraints define validity. Type-only `data` (no value) is an input slot. Use real domain values. Never `"TODO"` or dummy placeholders.
+
+For which inputs a rule still needs at runtime, call MCP `guide` with no topic (evaluate guide): `list` → `show` once → `evaluate` → ask one `missing_data` field → repeat. Load `guide` topic `full` only when authoring new specs. `show` is the static catalog — not a required-input checklist. `-> help` is the literal CS ask string; do not replace the question with a different one.
 
 **Example D — typed data (coffee order)**
 
@@ -268,7 +331,7 @@ data money: measure -> unit eur 1.00
 data wallet: money -> minimum 0 eur
 ```
 
-With help text:
+With help text (literal CS ask string):
 ```lemma
 spec payroll
 
@@ -276,6 +339,15 @@ data pay_period: text
   -> option "month"
   -> option "week"
   -> help "How often you are paid."
+```
+
+Boolean with usual-case suggest:
+```lemma
+spec returns
+
+data item_damaged: boolean
+  -> suggest false
+  -> help "Item damaged?"
 ```
 
 Constraints chain: `-> minimum`, `-> maximum`, `-> option`, `-> unit`, `-> decimals`, `-> suggest`, `-> help`, etc. Details in Reference.
@@ -428,9 +500,27 @@ rule this_year: event_date in calendar year
 
 **Rules and unless: last matching clause wins**
 
-Write default expression, then: `unless <condition> then <result>`. Evaluated in source order. If multiple match, **bottommost wins**. Order general first, specific overrides last.
+Default expression, then `unless <condition> then <result>`. Source order; **bottommost match wins**. General first, specific last. Snake_case names; boolean predicates (`is_eligible`, `can_ship`). Named pipeline rules — no opaque mega-expressions.
 
-Use **snake_case** rule names. Boolean rules as predicates: `is_eligible`, `can_ship`. Decompose logic into pipeline of named rules. No opaque single expressions.
+**Domain-principle default**
+
+Default is not "prefer yes/no." It is the answer **in principle for this rule's domain**. Experts must read top-to-bottom as: "In principle X; unless Y, then Z."
+
+1. Name the question (`can_ship` → "Can we ship this order?").
+2. Before special cases, what is true in principle? That is the default — from *this* rule's domain, not optimism or "start true and subtract failures."
+3. What positive facts change the answer? Those are `unless` conditions — not `… is false then flip`.
+4. Write `rule name: <principle> unless <positive conditions> then <exception>`.
+
+Examples by domain: shipping often earned (`no` unless grant); discount often `0%`; fees use the policy's usual fee — not "free unless expensive."
+
+Forbidden: double denial (`yes` / `unless … is false then no`); fail-each-check cascades; invented `*_compliant` default-yes helpers.
+
+```lemma-skip
+rule can_ship: no
+  unless in_stock
+    and address_complete
+    then yes
+```
 
 **Example F — overlapping unless (last wins)**
 
@@ -446,126 +536,50 @@ rule discount: 0%
   unless is_vip          then 25%
 ```
 
-VIP customer ordering 75 items gets **25%** (not 20%). Both `qty >= 50` and `is_vip` match; bottommost wins.
+VIP ordering 75 items gets **25%** (not 20%): both `qty >= 50` and `is_vip` match; bottommost wins.
 
 **Example G — progressive unless chain**
 
 ```lemma
 spec rules_and_unless
 
-data is_premium:   yes
-data base_price:   number -> minimum 0
-data customer_age: number -> minimum 0 -> maximum 120
-data qty:          number -> minimum 0
+data is_premium: yes
+data base_price: number -> minimum 0
+data qty:        number -> minimum 0
 
-rule total_before_discount:
-  base_price * qty
+rule total_before_discount: base_price * qty
 
-rule discount_percentage:
-  0%
+rule discount_percentage: 0%
   unless qty >= 10 then 10%
   unless qty >= 20 then 15%
-  unless is_premium   then 20%
+  unless is_premium then 20%
 
-rule discount_amount:
-  total_before_discount * discount_percentage
+rule discount_amount:      total_before_discount * discount_percentage
+rule total_after_discount: total_before_discount - discount_amount
 
-rule total_after_discount:
-  total_before_discount - discount_amount
-
-rule shipping_cost:
-  15
+rule shipping_cost: 15
   unless total_after_discount >= 100 then 10
   unless total_after_discount >= 200 then 0
 
-rule final_total:
-  total_after_discount + shipping_cost
+rule final_total: total_after_discount + shipping_cost
 ```
 
-Tiered discounts, derived rules referencing prior rules, unless on computed values.
-
-**Example H — decomposed shipping pipeline**
+**Example H — short pipeline sketch**
 
 ```lemma
-spec shipping_policy
+spec shipping_fees
 uses lemma units
 
-data destination_country: text
-  -> option "NL"
-  -> option "BE"
-  -> option "DE"
-  -> option "FR"
-  -> suggest "NL"
+data item_weight: units.mass
+data order_total: number -> minimum 0
 
-data customer_tier: text
-  -> option "standard"
-  -> option "silver"
-  -> option "gold"
-  -> option "platinum"
-  -> suggest "gold"
-
-data destination_region: text
-data is_expedited:       boolean
-data is_hazardous:       boolean
-data is_po_box:          boolean
-data item_weight:        units.mass
-data order_total:        number -> minimum 0
-
-rule base_shipping_rate: 35
-  unless destination_country is "NL" then 22
-  unless destination_country is "BE" then 25
-  unless destination_country is "DE" then 28
-  unless destination_country is "FR" then 30
-
+rule base_rate: 22
 rule weight_surcharge: 0
-  unless item_weight > 5 kilogram  then 7.5
-  unless item_weight > 20 kilogram
-    then veto "Item too heavy for standard shipping"
+  unless item_weight > 5 kilogram then 7.5
 
-rule po_box_fee: 0
-  unless is_po_box then 5
-
-rule expedited_fee: 0
-  unless is_expedited                           then 25
-  unless is_expedited and item_weight > 10 kilogram then 45
-
-rule hazardous_fee: 0
-  unless is_hazardous then 50
-  unless is_hazardous and destination_country is not "NL"
-    then veto "Cannot ship hazardous materials internationally"
-
-rule customer_discount: 0%
-  unless customer_tier is "silver"   then 10%
-  unless customer_tier is "gold"     then 20%
-  unless customer_tier is "platinum" then 30%
-
-rule free_shipping_eligible:
-  order_total >= 100 and destination_country is "NL"
-
-rule shipping_before_discount:
-  base_shipping_rate + weight_surcharge + po_box_fee
-  + expedited_fee + hazardous_fee
-
-rule shipping_discount_amount:
-  shipping_before_discount * customer_discount
-
-rule final_shipping:
-  shipping_before_discount - shipping_discount_amount
-  unless free_shipping_eligible then 0
-
-rule ships_to_location: true
-  unless is_po_box and is_hazardous
-    then veto "Cannot ship hazardous materials to PO boxes"
-  unless destination_region is "Svalbard"
-    then veto "Shipping not available to Svalbard"
-
-rule Summary: "Standard shipping"
-  unless free_shipping_eligible
-    then "Free shipping (order over €100)"
-  unless is_expedited then "Expedited shipping"
+rule final_shipping: base_rate + weight_surcharge
+  unless order_total >= 100 then 0
 ```
-
-Each fee is distinct rule. `item_weight` uses `units.mass`. Veto clauses placed last in `weight_surcharge` and `ships_to_location`. Eligibility separated from amount rules.
 
 
 ---
@@ -580,6 +594,10 @@ Veto is like Rust's `Err` — rule has **no value** and propagates to dependents
 | Unmapped choice / no rule applies | default `veto` + unless arm per choice |
 | Normal business "no" | `false` or `no` |
 | Test veto without propagating | `x is veto` (returns boolean) |
+
+**Litmus test:** Can the question be answered? If yes, even when the answer is negative, use `true`/`false`. If the question itself is unanswerable for this input, use veto. "Is the customer eligible?" is always answerable (`true` or `false`). "What is the price of this coffee?" when the product is not on the menu is unanswerable (veto).
+
+A vetoed rule is not `false`. `x is false` does not match a vetoed `x`. To test whether a rule vetoed, use `x is veto`.
 
 Place veto unless clauses **last** to override other branches.
 
@@ -679,9 +697,8 @@ If `validated_score` vetoes but `use_default` is true, `result` is 50. Unless br
 3. **Outputs**: every answerable question is a `rule`.
 4. **Factor**: intermediate calculations as named rules.
 5. **Unless**: default first, general to specific, vetoes last.
-6. **No inline comments**: no `#`, `//`. Commentary `"""..."""` only as first block after `spec`.
-7. **Validate**: verify reachable data with `show`, missing inputs via `run`, and correct override order.
-8. **Advanced**: use `uses lemma units`, ranges, compound units when needed.
+6. **Validate**: `check`, then `show`, then `evaluate` (MCP `guide` with no topic for `missing_data` intake; topic `full` only when authoring).
+7. **Advanced**: `uses lemma units`, ranges, compound units when needed.
 
 
 ---
@@ -690,63 +707,11 @@ If `validated_score` vetoes but `use_default` is true, `result` is 50. Unless br
 
 Inline comments (WRONG — `#` fails to parse):
 ```lemma-skip
-data customer_age: number -> minimum 0 -> maximum 120  # input slot
-data tax_rate: 21%  # fixed policy constant
-rule discount: 0%  # default: no discount
-  unless qty >= 10 then 10%  # bulk rate
+data customer_age: number -> minimum 0  # input
+rule discount: 0%  # default
 ```
 
-Commentary after `uses` (WRONG — fails to parse):
-```lemma-skip
-spec wholesale_nuts_pricing
-uses lemma units
-"""
-B2B pricing calculation for a wholesale nuts supplier.
-Handles product base pricing, organic premiums, and freight shipping.
-"""
-
-data base_price: number
-```
-
-Commentary after `data` (WRONG — fails to parse):
-```lemma-skip
-spec pricing
-
-data qty: number
-"""
-This is not valid commentary placement.
-"""
-
-rule discount: 0%
-```
-
-Commentary before `uses` (RIGHT):
-```lemma
-spec wholesale_nuts_pricing
-"""
-B2B pricing for a wholesale nuts supplier.
-Handles base pricing, organic premiums, volume discounts, and freight.
-"""
-
-uses lemma units
-
-data base_price: number
-```
-
-Commentary immediately after spec (RIGHT — no `uses`):
-```lemma
-spec pricing
-"""
-Customer age is an input; tax_rate is a fixed policy constant.
-"""
-
-data customer_age: number -> minimum 0 -> maximum 120
-data tax_rate: 21%
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
-```
+Commentary after `uses` (WRONG). RIGHT: commentary immediately after `spec` (see **Syntax**).
 
 Mega-rule (WRONG):
 ```lemma-skip
@@ -771,110 +736,56 @@ rule shipping_cost:        15 unless total_after_discount >= 100 then 10
 rule final_total:          total_after_discount + shipping_cost
 ```
 
-Hardcoded input (WRONG):
-```lemma-skip
-rule discount: 10 * 0.1
-```
+Hardcoded input (WRONG): `rule discount: 10 * 0.1`
+RIGHT: `data qty: number` then `rule discount: qty * 0.1`
 
-Input as data (RIGHT):
-```lemma
-spec bulk_discount
-
-data qty: number -> minimum 0
-rule discount: qty * 0.1
-```
-
-Wrong unless order (WRONG — VIP gets 20%, not 25%):
+Wrong unless order (WRONG — VIP gets 20% not 25%):
 ```lemma-skip
 rule discount: 0%
-  unless is_vip          then 25%
-  unless qty >= 50  then 20%
+  unless is_vip then 25%
+  unless qty >= 50 then 20%
 ```
+RIGHT: specific override last (`qty` tiers first, `is_vip` last).
 
-Correct order (RIGHT):
-```lemma
-spec tiered_discount
+Placeholder (WRONG): `data customer_name: "TODO"`
+RIGHT: `data customer_name: text`
 
-data qty: number
-data is_vip:   boolean
+Error vs Veto: `5 and "text"` = planning Error. `unless age > 120 then veto "…"` = runtime Veto.
 
-rule discount: 0%
-  unless qty >= 50  then 20%
-  unless is_vip          then 25%
-```
-
-Placeholder (WRONG):
+Veto-as-rejection (WRONG — denial is answerable; see **Veto**):
 ```lemma-skip
-data customer_name: "TODO"
+rule is_eligible: true
+  unless age < 18 then veto "Must be 18+"
+  unless has_id is false then veto "ID required"
 ```
+RIGHT: boolean rules composed with `and` (`is_old_enough and has_valid_id`).
 
-Type-only input (RIGHT):
-```lemma
-spec customer_record
+Unnecessary `repo` (WRONG). RIGHT: single-file `spec` without `repo`.
 
-data customer_name: text
-```
+No `or` (WRONG): `rule is_eligible: is_adult or has_guardian` — see **Syntax**; use `unless` or separate booleans.
 
-Error vs Veto: `5 and "text"` is planning Error (invalid Lemma). `unless age > 120 then veto "Invalid age"` is runtime Veto (valid spec, domain no-value). Do not confuse.
+Constraints on rules (WRONG): `rule discount: 10% -> help "…"` — `->` is data-only (see **Syntax**).
 
-Unnecessary repo (WRONG):
+Domain-blind polarity / double denial (WRONG):
 ```lemma-skip
-repo default
-
-spec pricing
-
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
+rule can_ship: yes
+  unless in_stock is false then no
+  unless address_complete is false then no
 ```
-
-Single-file spec (RIGHT):
-```lemma
-spec pricing
-
-data qty: number
-
-rule discount: 0%
-  unless qty >= 10 then 10%
+RIGHT: domain principle + positive grant (see **Rules**):
+```lemma-skip
+rule can_ship: no
+  unless in_stock and address_complete then yes
 ```
 
 
 ---
 
-## Docs
+## See also
 
-- [Learn guide](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/readme.md): specs, data, rules, unless, veto
-- [Reference](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/readme.md): operators, types, units, ranges, `uses`
-- [Veto](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/types_and_units.md#veto): propagation, `is veto`
-- [Composing specs](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/composing_specs.md): `uses`, temporal versions, pins
-- [CLI](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/cli.md): `run`, `show`, `format`
-- [Registry](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/registry.md): LemmaBase `@user/repo` imports
-- [LemmaBase search](https://lemmabase.com/search?q=): registry search
-- [Examples (docs)](https://github.com/lemma/lemma/tree/main/cli/documentation/examples): `.lemma` files
-- [Examples (tests)](https://github.com/lemma/lemma/tree/main/cli/tests/integrations/examples): progressives
+- [Learn guide](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/readme.md)
+- [Reference](https://github.com/lemma/lemma/blob/main/cli/documentation/reference/readme.md)
+- [LemmaBase search](https://lemmabase.com/search?q=)
+- [Examples](https://github.com/lemma/lemma/tree/main/cli/documentation/examples)
 
-## Examples by pattern
-
-- [Coffee order](https://github.com/lemma/lemma/blob/main/cli/documentation/examples/01_coffee_order.lemma): constraints, unless, veto enum
-- [Library fees](https://github.com/lemma/lemma/blob/main/cli/documentation/examples/02_library_fees.lemma): unless chains, bool vs veto
-- [Rules and unless](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/02_rules_and_unless.lemma): progressive unless
-- [Spec references](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/03_spec_references.lemma): compound units, `uses lemma units`
-- [Unit conversions](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/04_unit_conversions.lemma): duration, `as` conversion
-- [Spec composition](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/11_spec_composition.lemma): hierarchy
-- [Registry references](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/12_registry_references.lemma): registry import
-- [Shipping policy](https://github.com/lemma/lemma/blob/main/cli/tests/integrations/examples/07_shipping_policy.lemma): decomposed rules
-
-## Numeric precision (summary)
-
-Exact rationals (ℚ) for `+`, `−`, `×`, `÷`, comparisons, conversions. `^`, `sqrt`, trig, `log` use ~28-significant-digit Decimal. `floor`/`ceil`/`round` on measures use Decimal.
-
-**Boundary number contract:** WASM, HTTP JSON, Elixir NIF accept integers as numbers, reject float/decimal numbers. Pass decimals as strings. Example: `{ "quantity": 42, "rate": "0.075" }`. On Maven (JDK 21+), pass `BigDecimal` or decimal strings via `RunRequest.data(...)`; output is `BigDecimal`.
-
-## Optional
-
-- [LemmaBase](https://lemmabase.com): registry
-- [Numeric precision](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/precision.md): exact rational arithmetic, boundary contract
-- [JavaScript / TypeScript (WASM)](https://github.com/lemma/lemma/blob/main/cli/documentation/tools/javascript.md): browser and Node
-- [Maven (Java / Kotlin)](https://github.com/lemma/lemma/blob/main/cli/documentation/tools/maven.md): Central JNI package
-- [README](https://github.com/lemma/lemma/blob/main/README.md): install, quick start
+Decimals at JSON boundaries: pass as strings. Detail: [Numeric precision](https://github.com/lemma/lemma/blob/main/cli/documentation/learn/precision.md).

--- a/cli/documentation/reference/benchmarks/cli.md
+++ b/cli/documentation/reference/benchmarks/cli.md
@@ -14,7 +14,7 @@ Numbers are produced by `cargo benchmarks cli`. Measures the `lemma` binary and 
 
 - Spawns `lemma server --prefix cli/documentation/examples` on `127.0.0.1:19877` once per Criterion group.
 - Each iteration: blocking `reqwest` POST with `application/x-www-form-urlencoded` body (coffee order, library fees, Dutch net salary) or GET for show-only retrieval.
-- Examples loaded from [`cli/documentation/examples`](https://github.com/lemma/lemma/tree/e8d8687f11bcff28455be5abb7d0926ccb24e601/cli/documentation/examples).
+- Examples loaded from [`cli/documentation/examples`](https://github.com/lemma/lemma/tree/29121c6f461be9c25d7703ea6ec12812ffc53d3e/cli/documentation/examples).
 - Latency: Criterion (3s warmup, 10s measurement for evaluate group, 5s for show). Median and standard deviation reported.
 
 ### Engine profile (`engine_profile`)
@@ -27,7 +27,7 @@ Numbers are produced by `cargo benchmarks cli`. Measures the `lemma` binary and 
 ## Environment
 
 - Host: `Linux 7.0.0-28-generic x86_64`
-- Lemma git SHA: `e8d8687f11bcff28455be5abb7d0926ccb24e601`
+- Lemma git SHA: `29121c6f461be9c25d7703ea6ec12812ffc53d3e`
 - Rustc:
 
 ```
@@ -44,17 +44,17 @@ LLVM version: 21.1.3
 
 | Case | Median | Std dev |
 |------|-------:|--------:|
-| POST `/coffee_order` | 333.51 us | 32.47 us |
-| POST `/library_fees` | 176.04 us | 29.50 us |
-| POST `/net_salary` | 718.43 us | 45.43 us |
-| GET `/net_salary` (show only) | 194.70 us | 16.89 us |
+| POST `/coffee_order` | 288.92 us | 29.95 us |
+| POST `/library_fees` | 162.26 us | 17.78 us |
+| POST `/net_salary` | 656.37 us | 48.96 us |
+| GET `/net_salary` (show only) | 180.21 us | 8.27 us |
 
 ## Engine profile latency (Dutch net salary)
 
 | Case | Median | Std dev |
 |------|-------:|--------:|
-| Full `Engine::run` | 430.76 us | 23.69 us |
-| Single-rule evaluate (`periods_per_year`) | 24.60 us | 1.75 us |
-| Envelope JSON serialize | 20.94 us | 2.23 us |
-| Raw response JSON serialize | 2.72 us | 280 ns |
+| Full `Engine::run` | 407.23 us | 14.59 us |
+| Single-rule evaluate (`periods_per_year`) | 22.84 us | 518 ns |
+| Envelope JSON serialize | 20.23 us | 1.66 us |
+| Raw response JSON serialize | 2.52 us | 59 ns |
 

--- a/cli/documentation/reference/benchmarks/engine.md
+++ b/cli/documentation/reference/benchmarks/engine.md
@@ -23,7 +23,7 @@ Numbers are produced by `cargo benchmarks engine`. Hand-written Lemma specs and 
 ## Environment
 
 - Host: `Linux 7.0.0-28-generic x86_64`
-- Lemma git SHA: `e8d8687f11bcff28455be5abb7d0926ccb24e601`
+- Lemma git SHA: `29121c6f461be9c25d7703ea6ec12812ffc53d3e`
 - Python: `Python 3.12.3`
 - Rustc:
 
@@ -43,17 +43,17 @@ One-time cost per spec load. Not included in the Python/Lemma latency ratio; amo
 
 | Spec | Median | Std dev |
 |------|-------:|--------:|
-| `bench_shipping` | 2.855 ms | 113.49 us |
-| `bench_pricing` | 3.294 ms | 341.22 us |
-| `bench_order_pipeline` | 4.253 ms | 245.44 us |
+| `bench_shipping` | 2.638 ms | 49.31 us |
+| `bench_pricing` | 3.149 ms | 57.46 us |
+| `bench_order_pipeline` | 3.975 ms | 131.30 us |
 
 ## Latency
 
 | Spec | Terminal rule | Lemma median | Lemma std dev | Python median | Python iter | Python std dev | Python / Lemma |
 |------|---------------|-------------:|--------------:|--------------:|------------:|---------------:|---------------:|
-| `bench_shipping` | `total` | 13.53 us | 1.00 us | 7.35 us | 10000 | 2.65 us | 0.5435 |
-| `bench_pricing` | `total` | 37.32 us | 2.14 us | 29.24 us | 10000 | 7.81 us | 0.7834 |
-| `bench_order_pipeline` | `grand_total` | 65.99 us | 2.47 us | 50.02 us | 10000 | 15.20 us | 0.7579 |
+| `bench_shipping` | `total` | 12.81 us | 272 ns | 7.20 us | 10000 | 1.77 us | 0.5618 |
+| `bench_pricing` | `total` | 35.36 us | 458 ns | 29.09 us | 10000 | 4.20 us | 0.8227 |
+| `bench_order_pipeline` | `grand_total` | 62.21 us | 1.65 us | 49.03 us | 10000 | 5.87 us | 0.7881 |
 
 ## Explain latency (`evaluate_explain`)
 
@@ -61,9 +61,9 @@ Same fixtures and terminal rules as the latency table, with `explain: true`. Rat
 
 | Spec | Terminal rule | `evaluate` median | `evaluate_explain` median | Explain / `evaluate` |
 |------|---------------|------------------:|--------------------------:|---------------------:|
-| `bench_shipping` | `total` | 13.53 us | 102.16 us | 7.550 |
-| `bench_pricing` | `total` | 37.32 us | 350.08 us | 9.380 |
-| `bench_order_pipeline` | `grand_total` | 65.99 us | 743.71 us | 11.27 |
+| `bench_shipping` | `total` | 12.81 us | 97.32 us | 7.597 |
+| `bench_pricing` | `total` | 35.36 us | 342.42 us | 9.685 |
+| `bench_order_pipeline` | `grand_total` | 62.21 us | 708.06 us | 11.38 |
 
 ## Memory (per `evaluate` call)
 
@@ -79,7 +79,7 @@ Same fixtures and terminal rules as the latency table, with `explain: true`. Rat
 
 ## Python implementation
 
-Hand-written ports of the three Lemma specs live in [`engine/benches/python/business_rules`](https://github.com/lemma/lemma/tree/e8d8687f11bcff28455be5abb7d0926ccb24e601/engine/benches/python/business_rules). Each module exports `Inputs`, `Outputs`, `TERMINAL_RULE`, `build_inputs(raw)`, `compute_terminal(inputs)`, and `compute(inputs)`. Standard library only (`fractions`, `dataclasses`, `importlib`, `time`, `gc`, `pathlib`, `statistics`). The Python benchmark harness is [`engine/benches/python/benchmark.py`](https://github.com/lemma/lemma/blob/e8d8687f11bcff28455be5abb7d0926ccb24e601/engine/benches/python/benchmark.py).
+Hand-written ports of the three Lemma specs live in [`engine/benches/python/business_rules`](https://github.com/lemma/lemma/tree/29121c6f461be9c25d7703ea6ec12812ffc53d3e/engine/benches/python/business_rules). Each module exports `Inputs`, `Outputs`, `TERMINAL_RULE`, `build_inputs(raw)`, `compute_terminal(inputs)`, and `compute(inputs)`. Standard library only (`fractions`, `dataclasses`, `importlib`, `time`, `gc`, `pathlib`, `statistics`). The Python benchmark harness is [`engine/benches/python/benchmark.py`](https://github.com/lemma/lemma/blob/29121c6f461be9c25d7703ea6ec12812ffc53d3e/engine/benches/python/benchmark.py).
 
 ## Inputs
 
@@ -87,7 +87,7 @@ All fixtures share `effective = 2026-01-01T00:00:00Z` (no timezone). Input value
 
 ### `bench_shipping`
 
-Lemma source: [`engine/benches/specs/shipping.lemma`](https://github.com/lemma/lemma/blob/e8d8687f11bcff28455be5abb7d0926ccb24e601/engine/benches/specs/shipping.lemma). Python module: `business_rules.shipping`.
+Lemma source: [`engine/benches/specs/shipping.lemma`](https://github.com/lemma/lemma/blob/29121c6f461be9c25d7703ea6ec12812ffc53d3e/engine/benches/specs/shipping.lemma). Python module: `business_rules.shipping`.
 
 | Field | Value |
 |-------|-------|
@@ -97,7 +97,7 @@ Lemma source: [`engine/benches/specs/shipping.lemma`](https://github.com/lemma/l
 
 ### `bench_pricing`
 
-Lemma source: [`engine/benches/specs/pricing.lemma`](https://github.com/lemma/lemma/blob/e8d8687f11bcff28455be5abb7d0926ccb24e601/engine/benches/specs/pricing.lemma). Python module: `business_rules.pricing`.
+Lemma source: [`engine/benches/specs/pricing.lemma`](https://github.com/lemma/lemma/blob/29121c6f461be9c25d7703ea6ec12812ffc53d3e/engine/benches/specs/pricing.lemma). Python module: `business_rules.pricing`.
 
 | Field | Value |
 |-------|-------|
@@ -112,7 +112,7 @@ Lemma source: [`engine/benches/specs/pricing.lemma`](https://github.com/lemma/le
 
 ### `bench_order_pipeline`
 
-Lemma source: [`engine/benches/specs/order_pipeline.lemma`](https://github.com/lemma/lemma/blob/e8d8687f11bcff28455be5abb7d0926ccb24e601/engine/benches/specs/order_pipeline.lemma). Python module: `business_rules.order_pipeline`.
+Lemma source: [`engine/benches/specs/order_pipeline.lemma`](https://github.com/lemma/lemma/blob/29121c6f461be9c25d7703ea6ec12812ffc53d3e/engine/benches/specs/order_pipeline.lemma). Python module: `business_rules.order_pipeline`.
 
 | Field | Value |
 |-------|-------|

--- a/cli/documentation/reference/cli.md
+++ b/cli/documentation/reference/cli.md
@@ -178,6 +178,7 @@ lemma mcp [--prefix PATH] [--admin] [--request-timeout SECONDS]
 - `evaluate` — evaluate rules in a spec (always includes explanation trees; unlike CLI/HTTP/WASM, there is no opt-out). Measure/ratio results include every declared unit.
 - `list` — list loaded specs by repository
 - `show` — return the JSON Show for a spec (data and rules, including units)
+- `source` — return formatted Lemma source for a repository or spec
 - `check` — parse and plan a batch of labeled Lemma sources (ephemeral engine, does not mutate server state); returns success confirmation or structured diagnostics
 - `guide` — return a section of the embedded authoring guide (`syntax`, `data`, `rules`, `units`, `veto`, `composition`, `anti_patterns`)
 
@@ -185,7 +186,10 @@ lemma mcp [--prefix PATH] [--admin] [--request-timeout SECONDS]
 
 **Tools (with `--admin`):**
 - `add_spec` — load Lemma source into the engine (structured diagnostics on failure)
-- `source` — return formatted Lemma source for a repository or spec
+- `update_spec` — replace an existing spec with updated source
+- `remove_spec` — remove one temporal spec slice from the engine
+- `clear` — remove workspace and loaded dependency specs from the engine
+- `fetch` — fetch a registry dependency into `lemma_deps/` and load it
 
 ## Workspace
 

--- a/cli/documentation/reference/coverage/cli.md
+++ b/cli/documentation/reference/coverage/cli.md
@@ -40,14 +40,14 @@ LLVM version: 21.1.3
 
 | Metric | Covered | Total | Percent |
 |--------|--------:|------:|--------:|
-| Lines | 1450 | 3451 | 42.02% |
-| Functions | 143 | 333 | 42.94% |
-| Regions | 2201 | 5221 | 42.16% |
+| Lines | 1934 | 4251 | 45.50% |
+| Functions | 173 | 395 | 43.80% |
+| Regions | 2992 | 6481 | 46.17% |
 
 ## Test run
 
-- Total: 138
-- Passed: 138
+- Total: 164
+- Passed: 164
 - Skipped: 0
 - Failed: 0
 
@@ -59,16 +59,16 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 |--------|-------:|-----------:|---------:|--------------------:|
 | `server.rs` | 0.00 | 0.00 | 0.00 | 0/650 |
 | `interactive.rs` | 1.08 | 3.57 | 0.59 | 7/651 |
-| `main.rs` | 37.38 | 47.95 | 35.44 | 314/840 |
+| `main.rs` | 38.21 | 47.95 | 36.48 | 321/840 |
 | `error_formatter.rs` | 61.76 | 100.00 | 62.26 | 42/68 |
+| `mcp/server.rs` | 74.41 | 63.64 | 72.85 | 1288/1731 |
 | `formatter.rs` | 80.56 | 83.33 | 81.70 | 116/144 |
-| `mcp/server.rs` | 87.22 | 73.91 | 82.85 | 819/939 |
 | `data_json.rs` | 94.26 | 94.74 | 94.39 | 115/122 |
-| `mcp/guide.rs` | 100.00 | 100.00 | 100.00 | 37/37 |
+| `mcp/guide.rs` | 100.00 | 100.00 | 100.00 | 45/45 |
 
 ## Related docs
 
 - [CLI integration test catalog](../../../cli/tests/README.md)
 - [Engine test coverage](engine.md)
 - [CLI benchmarks](../benchmarks/cli.md)
-<!-- coverage-input-digest: 1ee823a78bf3ef48 -->
+<!-- coverage-input-digest: f29a005b150432e8 -->

--- a/cli/documentation/reference/coverage/engine.md
+++ b/cli/documentation/reference/coverage/engine.md
@@ -41,14 +41,14 @@ LLVM version: 21.1.3
 
 | Metric | Covered | Total | Percent |
 |--------|--------:|------:|--------:|
-| Lines | 34028 | 40036 | 84.99% |
-| Functions | 2565 | 2923 | 87.75% |
-| Regions | 50509 | 60299 | 83.76% |
+| Lines | 34371 | 40387 | 85.10% |
+| Functions | 2599 | 2958 | 87.86% |
+| Regions | 50861 | 60661 | 83.84% |
 
 ## Test run
 
-- Total: 2348
-- Passed: 2348
+- Total: 2358
+- Passed: 2358
 - Skipped: 2
 - Failed: 0
 
@@ -66,8 +66,8 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 | `evaluation/explanations.rs` | 74.74 | 76.92 | 73.01 | 142/190 |
 | `computation/arithmetic.rs` | 74.95 | 87.50 | 74.95 | 718/958 |
 | `planning/explanation.rs` | 78.57 | 75.00 | 77.27 | 22/28 |
-| `parsing/ast.rs` | 79.11 | 85.00 | 70.71 | 977/1235 |
 | `computation/bigint/signed.rs` | 79.12 | 81.08 | 73.87 | 197/249 |
+| `parsing/ast.rs` | 79.35 | 85.71 | 70.91 | 980/1235 |
 | `error.rs` | 80.32 | 79.63 | 74.93 | 453/564 |
 | `computation/units.rs` | 80.82 | 100.00 | 79.36 | 177/219 |
 | `planning/execution_plan.rs` | 80.96 | 82.41 | 76.91 | 1862/2300 |
@@ -87,9 +87,10 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 | `computation/rational.rs` | 89.21 | 96.72 | 82.04 | 488/547 |
 | `planning/spec_set.rs` | 90.20 | 90.91 | 90.26 | 138/153 |
 | `formatting/mod.rs` | 90.36 | 98.51 | 89.22 | 731/809 |
-| `engine.rs` | 90.58 | 90.09 | 91.31 | 1375/1518 |
 | `evaluation/conversion_trace.rs` | 91.25 | 100.00 | 91.75 | 146/160 |
 | `evaluation/tree.rs` | 91.32 | 92.86 | 92.19 | 1126/1233 |
+| `engine.rs` | 91.72 | 91.45 | 92.44 | 1429/1558 |
+| `quality.rs` | 91.96 | 89.66 | 89.91 | 286/311 |
 | `parsing/mod.rs` | 92.84 | 98.86 | 90.43 | 1257/1354 |
 | `evaluation/branch_semantics.rs` | 92.86 | 100.00 | 81.82 | 39/42 |
 | `planning/discovery.rs` | 93.13 | 97.06 | 93.96 | 1220/1310 |
@@ -109,4 +110,4 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 - [Engine integration test catalog](../../../engine/tests/README.md) — qualitative map of scenarios and subsystem overlap clusters
 - [CLI test coverage](cli.md)
 - [Engine benchmarks](../benchmarks/engine.md)
-<!-- coverage-input-digest: acb41682b12abac1 -->
+<!-- coverage-input-digest: 3e45f07edc9e9fbb -->

--- a/cli/documentation/tools/maven.md
+++ b/cli/documentation/tools/maven.md
@@ -17,14 +17,14 @@ Maven:
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
 </dependency>
 ```
 
 Gradle (Kotlin DSL) — consume the published artifact; this repository builds the package with Maven only:
 
 ```kotlin
-implementation("com.lemmabase:lemma-engine:0.9.2")
+implementation("com.lemmabase:lemma-engine:0.9.3")
 ```
 
 Requires JDK 21+.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,7 +140,7 @@ enum Commands {
         /// Workspace directory or `.lemma` file (default: current directory)
         #[arg(long, value_name = "PATH")]
         prefix: Option<PathBuf>,
-        /// Enable admin tools: add_spec, source (read-only by default)
+        /// Enable admin tools: add_spec, update_spec, remove_spec, clear, fetch (read-only by default)
         #[arg(long)]
         admin: bool,
         /// Wall-clock timeout for a single request, in second
@@ -699,7 +699,7 @@ fn mcp_command(workdir: &Path, admin: bool, request_timeout_secs: u64) -> Result
         "Starting MCP server with {} spec(s) loaded",
         unique_specs.len()
     );
-    mcp::server::start_server(engine, config)?;
+    mcp::server::start_server(engine, config, workdir)?;
     Ok(())
 }
 

--- a/cli/src/mcp/guide.rs
+++ b/cli/src/mcp/guide.rs
@@ -1,9 +1,12 @@
-//! Embedded Lemma authoring guide and example specs for MCP tools/resources.
+//! Embedded Lemma guides and example specs for MCP tools/resources.
 
 pub const LLMS_TXT: &str = include_str!("../../documentation/llms.txt");
+pub const EVALUATE_GUIDE: &str = include_str!("../../documentation/evaluate_guide.txt");
 
+const METHOD: &str = include_str!("../../documentation/guide/05_method.txt");
 const SYNTAX: &str = include_str!("../../documentation/guide/10_syntax.txt");
 const COMPOSITION: &str = include_str!("../../documentation/guide/20_composition.txt");
+const NATURAL_LANGUAGE: &str = include_str!("../../documentation/guide/25_natural_language.txt");
 const DATA: &str = include_str!("../../documentation/guide/30_data.txt");
 const UNITS: &str = include_str!("../../documentation/guide/40_units.txt");
 const RULES: &str = include_str!("../../documentation/guide/50_rules.txt");
@@ -23,38 +26,53 @@ pub const EXAMPLE_05_WEATHER_CLOTHING: &str =
 pub const EXAMPLE_NL_TAX_NET_SALARY: &str =
     include_str!("../../documentation/examples/nl/tax/net_salary.lemma");
 
-/// Guide topics map to fragment files under `cli/documentation/guide/`.
+/// Guide topics: authoring sections under `cli/documentation/guide/`,
+/// plus `evaluate` (default CS guide) and `full` (complete authoring llms.txt).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuideTopic {
+    Method,
     Syntax,
     Data,
     Rules,
     Units,
     Veto,
     Composition,
+    NaturalLanguage,
     AntiPatterns,
+    Evaluate,
+    Full,
 }
 
 impl GuideTopic {
     pub const ALL: &[GuideTopic] = &[
+        GuideTopic::Method,
         GuideTopic::Syntax,
         GuideTopic::Data,
         GuideTopic::Rules,
         GuideTopic::Units,
         GuideTopic::Veto,
         GuideTopic::Composition,
+        GuideTopic::NaturalLanguage,
         GuideTopic::AntiPatterns,
+        GuideTopic::Evaluate,
+        GuideTopic::Full,
     ];
+
+    pub const VALID_LIST: &str = "method, syntax, data, rules, units, veto, composition, natural_language, anti_patterns, evaluate, full";
 
     pub fn as_str(self) -> &'static str {
         match self {
+            GuideTopic::Method => "method",
             GuideTopic::Syntax => "syntax",
             GuideTopic::Data => "data",
             GuideTopic::Rules => "rules",
             GuideTopic::Units => "units",
             GuideTopic::Veto => "veto",
             GuideTopic::Composition => "composition",
+            GuideTopic::NaturalLanguage => "natural_language",
             GuideTopic::AntiPatterns => "anti_patterns",
+            GuideTopic::Evaluate => "evaluate",
+            GuideTopic::Full => "full",
         }
     }
 
@@ -65,13 +83,17 @@ impl GuideTopic {
     /// Guide topic content from corresponding fragment.
     pub fn section_text(self) -> &'static str {
         match self {
+            GuideTopic::Method => METHOD,
             GuideTopic::Syntax => SYNTAX,
             GuideTopic::Data => DATA,
             GuideTopic::Rules => RULES,
             GuideTopic::Units => UNITS,
             GuideTopic::Veto => VETO,
             GuideTopic::Composition => COMPOSITION,
+            GuideTopic::NaturalLanguage => NATURAL_LANGUAGE,
             GuideTopic::AntiPatterns => ANTI_PATTERNS,
+            GuideTopic::Evaluate => EVALUATE_GUIDE,
+            GuideTopic::Full => LLMS_TXT,
         }
     }
 }

--- a/cli/src/mcp/server.rs
+++ b/cli/src/mcp/server.rs
@@ -3,7 +3,9 @@ mod imp {
     use lemma::DateTimeValue;
     use lemma::Engine;
     use serde::{Deserialize, Serialize};
+    use std::fs;
     use std::io::{self, BufRead, Write};
+    use std::path::{Component, Path, PathBuf};
     use std::time::Duration;
     use tracing::{debug, error, info};
 
@@ -93,8 +95,8 @@ mod imp {
 
     /// Configuration for the MCP server.
     pub struct McpConfig {
-        /// When true, admin tools (`add_spec`, `source`) are
-        /// advertised and allowed. When false (default), the server is read-only.
+        /// When true, admin tools (`add_spec`, `update_spec`, `remove_spec`, `clear`, `fetch`)
+        /// are advertised and allowed. When false (default), the server is read-only.
         pub admin: bool,
         /// Wall-clock budget for handling a single request. Requests that
         /// exceed it get a JSON-RPC internal error; the worker finishes the
@@ -114,11 +116,152 @@ mod imp {
     struct McpServer {
         engine: Engine,
         config: McpConfig,
+        /// Workspace directory for admin persist (add / update / remove / clear / fetch).
+        workdir: PathBuf,
+    }
+
+    /// Resolve `workdir/source_path` for relative source ids. Rejects absolute paths and `..`.
+    fn validated_write_path(workdir: &Path, source_path: &Path) -> Result<PathBuf, McpError> {
+        if source_path.as_os_str().is_empty() {
+            return Err(McpError::invalid_params(
+                "source_id path must be non-empty".to_string(),
+            ));
+        }
+        if source_path.is_absolute() {
+            return Err(McpError::invalid_params(
+                "source_id must be a relative path within the workspace".to_string(),
+            ));
+        }
+        for component in source_path.components() {
+            match component {
+                Component::Normal(_) | Component::CurDir => {}
+                Component::ParentDir => {
+                    return Err(McpError::invalid_params(
+                        "source_id must not contain '..'".to_string(),
+                    ));
+                }
+                _ => {
+                    return Err(McpError::invalid_params(
+                        "source_id must be a relative path within the workspace".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(workdir.join(source_path))
+    }
+
+    /// Absolute Path sources (workspace load) must still resolve under workdir.
+    fn absolute_path_under_workdir(
+        workdir: &Path,
+        source_path: &Path,
+    ) -> Result<PathBuf, McpError> {
+        let workdir_canon = fs::canonicalize(workdir).map_err(|e| {
+            McpError::internal_error(format!(
+                "Failed to resolve workspace {}: {e}",
+                workdir.display()
+            ))
+        })?;
+        let path_canon =
+            fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
+        if !path_canon.starts_with(&workdir_canon) {
+            return Err(McpError::invalid_params(format!(
+                "path {} is outside the workspace",
+                source_path.display()
+            )));
+        }
+        Ok(path_canon)
+    }
+
+    /// Atomic write: temp file in same directory, fsync, rename.
+    fn atomic_write(path: &Path, contents: &str) -> io::Result<()> {
+        let file_name = path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "persist path must include a file name",
+            )
+        })?;
+        let dir = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => Path::new("."),
+        };
+        fs::create_dir_all(dir)?;
+        let tmp = dir.join(format!(".{}.tmp", file_name.to_string_lossy()));
+        match (|| -> io::Result<()> {
+            let mut f = fs::File::create(&tmp)?;
+            f.write_all(contents.as_bytes())?;
+            f.sync_all()?;
+            fs::rename(&tmp, path)?;
+            Ok(())
+        })() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp);
+                Err(e)
+            }
+        }
     }
 
     impl McpServer {
-        fn new(engine: Engine, config: McpConfig) -> Self {
-            Self { engine, config }
+        fn new(engine: Engine, config: McpConfig, workdir: PathBuf) -> Self {
+            Self {
+                engine,
+                config,
+                workdir,
+            }
+        }
+
+        /// Disk path for this source. Always a concrete path — never optional skip.
+        fn disk_path(&self, source_type: &lemma::SourceType) -> Result<PathBuf, McpError> {
+            match source_type {
+                lemma::SourceType::Path(source_path) => {
+                    let path = source_path.as_ref();
+                    if path.is_absolute() {
+                        absolute_path_under_workdir(&self.workdir, path)
+                    } else {
+                        validated_write_path(&self.workdir, path)
+                    }
+                }
+                lemma::SourceType::Dependency(id) if id == lemma::EMBEDDED_STDLIB_REPOSITORY => {
+                    Err(McpError::invalid_params(
+                        "cannot mutate the embedded standard library".to_string(),
+                    ))
+                }
+                lemma::SourceType::Dependency(id) => {
+                    Ok(lemma::deps::dependency_cache_file(&self.workdir, id))
+                }
+                lemma::SourceType::Volatile => Err(McpError::invalid_params(
+                    "volatile sources cannot be persisted".to_string(),
+                )),
+            }
+        }
+
+        fn formatted_persist_source(code: &str, source_type: &lemma::SourceType) -> String {
+            lemma::format_source(code, source_type.clone()).expect(
+                "BUG: format_source must succeed after engine load/update accepted the source",
+            )
+        }
+
+        /// Remove every spec that `code` defined (reverse parse order) so dependents
+        /// of an add can be torn down after a failed disk write.
+        fn rollback_added_source(&mut self, code: &str, source_type: &lemma::SourceType) {
+            let parsed = lemma::parse(code, source_type.clone(), &lemma::ResourceLimits::default())
+                .expect("BUG: source already loaded successfully must parse for rollback");
+            let mut removals: Vec<(Option<String>, String, Option<DateTimeValue>)> = Vec::new();
+            for (repo, specs) in parsed.repositories {
+                let repo_name = repo.name.clone();
+                for spec in specs {
+                    removals.push((
+                        repo_name.clone(),
+                        spec.name.clone(),
+                        spec.effective_from().cloned(),
+                    ));
+                }
+            }
+            for (repo, name, eff) in removals.into_iter().rev() {
+                self.engine
+                    .remove(repo.as_deref(), &name, eff.as_ref())
+                    .expect("BUG: rollback remove after failed persist must succeed");
+            }
         }
 
         /// JSON-RPC 2.0: requests with no `id` are notifications and MUST NOT
@@ -206,7 +349,7 @@ mod imp {
             let mut tools = vec![
                 serde_json::json!({
                     "name": "evaluate",
-                    "description": "Evaluate rules in a Lemma spec. Returns each rule's display value plus every declared measure/ratio unit map, and a step-by-step reasoning trace. Omit 'rule' to evaluate all rules. Prefer 'show' first to learn data/rule interfaces.",
+                    "description": "Evaluate rules. Pass `rule` to target one rule; omit for all. For human intake: call guide (default = evaluate guide; not topic full), then list, show once, evaluate. missing_data lines include name, type, and help. Primary loop: after each user turn, bind every field that utterance decides (entailments), re-evaluate; ask at most one open topic-question when something remains. Never ask the user what the policy means. Never dispose interpretation as truth; use “should” when a judgment call cannot be answered. When the rule answers, present details+answer in domain language for user verify (no tooling jargon to the user) before treating as done. No questionnaire dumps. No re-call show between asks. Do not dump every show data field into evaluate. Returns display values, unit maps, reasoning, and missing_data when inputs are still needed.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -221,7 +364,7 @@ mod imp {
                             "data": {
                                 "type": "array",
                                 "items": { "type": "string" },
-                                "description": "Optional data values as 'name=value' (e.g. ['price=100', 'measure=5'])",
+                                "description": "Optional data values as 'name=value' (e.g. ['price=100', 'measure=5']). Partial is fine.",
                                 "default": []
                             },
                             "effective": {
@@ -234,7 +377,7 @@ mod imp {
                 }),
                 serde_json::json!({
                     "name": "list",
-                    "description": "List loaded specs grouped by repository (metadata only: name, effective_from, effective_to). Use the show tool for data/rule interfaces.",
+                    "description": "List loaded specs by repository (name, effective_from, effective_to). Call this first when you do not already know the exact spec name. Do not invent or guess spec names. For human intake call guide (default evaluate guide), then show once and evaluate.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -242,7 +385,7 @@ mod imp {
                 }),
                 serde_json::json!({
                     "name": "show",
-                    "description": "Return the JSON Show for a spec: data inputs (types, constraints, suggestions, units) and rules (output types including units). Call this before evaluate.",
+                    "description": "Return JSON Show for a spec: data catalog (types, constraints, suggestions, units, help) and rule output types. Call once after list. Static interface — not a required-input list, not a questionnaire, not something to re-call between evaluate/ask turns. Human intake: call guide (default = evaluate guide).",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -259,62 +402,6 @@ mod imp {
                     }
                 }),
                 serde_json::json!({
-                    "name": "check",
-                    "description": "Parse and plan a batch of Lemma sources without mutating server state. On success confirms all sources planned. On failure returns structured diagnostics (kind, message, suggestion, source line/column). Sources resolve cross-file `uses` within the batch. A leading `@` label loads as a dependency. Lemma has no `#` or `//` comments; commentary is valid only as a docstring immediately after the `spec` line. Call guide for authoring rules before drafting.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "sources": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": { "type": "string" },
-                                    "minItems": 2,
-                                    "maxItems": 2
-                                },
-                                "description": "Array of [label, code] pairs. Label is the source path (e.g. 'pricing.lemma') or a dependency identifier (e.g. '@org/repo')."
-                            }
-                        },
-                        "required": ["sources"]
-                    }
-                }),
-                serde_json::json!({
-                    "name": "guide",
-                    "description": "Return a section of the Lemma authoring guide (llms.txt). Topics: syntax, data, rules, units, veto, composition, anti_patterns. Start with syntax and anti_patterns before writing specs. Lemma has no `#` or `//` comments.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "topic": {
-                                "type": "string",
-                                "enum": ["syntax", "data", "rules", "units", "veto", "composition", "anti_patterns"],
-                                "description": "Guide section to return"
-                            }
-                        },
-                        "required": ["topic"]
-                    }
-                }),
-            ];
-
-            if self.config.admin {
-                tools.push(serde_json::json!({
-                    "name": "add_spec",
-                    "description": "Load Lemma source into the engine (mutates state). Prefer check for draft validation. Returns each new spec's JSON Show on success; structured diagnostics with isError on failure. Commentary is valid only as a docstring immediately after the `spec` line; `#` and `//` comments do not exist.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "code": {
-                                "type": "string",
-                                "description": "The complete Lemma code to add"
-                            },
-                            "source_id": {
-                                "type": "string",
-                                "description": "Identifier for this source fragment (used as load path)"
-                            }
-                        },
-                        "required": ["code", "source_id"]
-                    }
-                }));
-                tools.push(serde_json::json!({
                     "name": "source",
                     "description": "Return formatted Lemma source. Pass `repository` (e.g. `lemma` for embedded units stdlib) for the whole repo, or `spec` for a workspace spec.",
                     "inputSchema": {
@@ -334,6 +421,140 @@ mod imp {
                             }
                         }
                     }
+                }),
+                serde_json::json!({
+                    "name": "check",
+                    "description": "Validate Lemma sources (does not load). On success confirms syntax is valid. Call add_spec to load after check passes. On failure returns structured diagnostics (kind, message, suggestion, source line/column). Sources resolve cross-file `uses` within the batch. A leading `@` label loads as a dependency. Lemma has no `#` or `//` comments; commentary is valid only as a docstring immediately after the `spec` line. Before drafting new specs, call guide with topic full.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": { "type": "string" },
+                                    "minItems": 2,
+                                    "maxItems": 2
+                                },
+                                "description": "Array of [label, code] pairs. Label is the source path (e.g. 'pricing.lemma') or a dependency identifier (e.g. '@org/repo')."
+                            }
+                        },
+                        "required": ["sources"]
+                    }
+                }),
+                serde_json::json!({
+                    "name": "guide",
+                    "description": "Return a Lemma guide. Omit topic for the evaluate guide (CS intake with loaded specs — default). Pass topic full only when authoring new Lemma specs (complete authoring guide). Other topics are authoring sections: method, syntax, data, rules, units, veto, composition, natural_language, anti_patterns; topic evaluate is the same as the default.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "topic": {
+                                "type": "string",
+                                "enum": ["method", "syntax", "data", "rules", "units", "veto", "composition", "natural_language", "anti_patterns", "evaluate", "full"],
+                                "description": "Optional. Omit for evaluate guide. Use full only when authoring new specs."
+                            }
+                        }
+                    }
+                }),
+            ];
+
+            if self.config.admin {
+                tools.push(serde_json::json!({
+                    "name": "add_spec",
+                    "description": "Load Lemma source as one or more specs (persists). Prefer check first; check alone does not load. On failure returns structured diagnostics. After success, present the full source in chat for user verify.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "description": "The complete Lemma code to add"
+                            },
+                            "source_id": {
+                                "type": "string",
+                                "description": "Stable id for this source (e.g. pricing.lemma)"
+                            }
+                        },
+                        "required": ["code", "source_id"]
+                    }
+                }));
+                tools.push(serde_json::json!({
+                    "name": "update_spec",
+                    "description": "Replace an existing spec with new source. After success, present the full source in chat for user verify.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "string",
+                                "description": "Name of the spec to replace"
+                            },
+                            "code": {
+                                "type": "string",
+                                "description": "The complete new Lemma source"
+                            },
+                            "source_id": {
+                                "type": "string",
+                                "description": "Stable id for this source (e.g. pricing.lemma)"
+                            },
+                            "repository": {
+                                "type": "string",
+                                "description": "Repository qualifier when the spec is not in the workspace"
+                            },
+                            "effective": {
+                                "type": "string",
+                                "description": "Effective datetime of the version to replace"
+                            }
+                        },
+                        "required": ["spec", "code", "source_id"]
+                    }
+                }));
+                tools.push(serde_json::json!({
+                    "name": "remove_spec",
+                    "description": "Remove one spec version. Omit effective to remove the origin version; pass effective to remove that version.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "string",
+                                "description": "Name of the spec to remove"
+                            },
+                            "repository": {
+                                "type": "string",
+                                "description": "Repository qualifier when the spec is not in the workspace"
+                            },
+                            "effective": {
+                                "type": "string",
+                                "description": "Effective datetime of the version to remove"
+                            }
+                        },
+                        "required": ["spec"]
+                    }
+                }));
+                tools.push(serde_json::json!({
+                    "name": "clear",
+                    "description": "Remove all specs.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }));
+                tools.push(serde_json::json!({
+                    "name": "fetch",
+                    "description": "Fetch a registry dependency (e.g. @iso/countries) and load it. Pass force=true to overwrite an existing copy.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "dependency": {
+                                "type": "string",
+                                "description": "Registry identifier including @, e.g. @iso/countries"
+                            },
+                            "force": {
+                                "type": "boolean",
+                                "description": "Overwrite if already present (default false)",
+                                "default": false
+                            }
+                        },
+                        "required": ["dependency"]
+                    }
                 }));
             }
 
@@ -343,9 +564,9 @@ mod imp {
         fn list_resources(&self) -> Result<serde_json::Value, McpError> {
             let mut resources = vec![serde_json::json!({
                 "uri": "lemma://guide",
-                "name": "Lemma authoring guide",
+                "name": "Lemma evaluate guide",
                 "mimeType": "text/plain",
-                "description": "Full llms.txt authoring guide. Prefer the guide tool with a topic for a focused slice."
+                "description": "Default evaluate guide for CS intake. Same as guide tool with no topic. Use lemma://guide/full only when authoring."
             })];
             for topic in crate::mcp::guide::GuideTopic::ALL {
                 resources.push(serde_json::json!({
@@ -387,12 +608,13 @@ mod imp {
 
         fn resource_text(&self, uri: &str) -> Result<&'static str, McpError> {
             if uri == "lemma://guide" {
-                return Ok(crate::mcp::guide::LLMS_TXT);
+                return Ok(crate::mcp::guide::EVALUATE_GUIDE);
             }
             if let Some(topic_name) = uri.strip_prefix("lemma://guide/") {
                 let topic = crate::mcp::guide::GuideTopic::parse(topic_name).ok_or_else(|| {
                     McpError::invalid_params(format!(
-                        "Unknown guide topic '{topic_name}'. Valid: syntax, data, rules, units, veto, composition, anti_patterns"
+                        "Unknown guide topic '{topic_name}'. Valid: {}",
+                        crate::mcp::guide::GuideTopic::VALID_LIST
                     ))
                 })?;
                 return Ok(topic.section_text());
@@ -425,11 +647,19 @@ mod imp {
             debug!("Calling tool: {}", tool_name);
 
             match tool_name {
-                "add_spec" | "source" if !self.config.admin => Err(McpError::invalid_params(
-                    "Admin tools are disabled. Start the server with --admin to enable them."
-                        .to_string(),
-                )),
+                "add_spec" | "update_spec" | "remove_spec" | "clear" | "fetch"
+                    if !self.config.admin =>
+                {
+                    Err(McpError::invalid_params(
+                        "Admin tools are disabled. Start the server with --admin to enable them."
+                            .to_string(),
+                    ))
+                }
                 "add_spec" => self.tool_add_spec(arguments),
+                "update_spec" => self.tool_update_spec(arguments),
+                "remove_spec" => self.tool_remove_spec(arguments),
+                "clear" => self.tool_clear(arguments),
+                "fetch" => self.tool_fetch(arguments),
                 "source" => self.tool_source(arguments),
                 "evaluate" => self.tool_evaluate(arguments),
                 "list" => self.tool_list(arguments),
@@ -480,6 +710,605 @@ mod imp {
             &mut self,
             args: &serde_json::Value,
         ) -> Result<serde_json::Value, McpError> {
+            let (code, source_type) = Self::parse_code_and_source(args)?;
+            let path = self.disk_path(&source_type)?;
+
+            if let Err(load_err) = self.engine.load([(source_type.clone(), code.to_string())]) {
+                return Ok(Self::load_diagnostics_tool_result(load_err));
+            }
+
+            let formatted = Self::formatted_persist_source(code, &source_type);
+            if let Err(e) = atomic_write(&path, &formatted) {
+                self.rollback_added_source(code, &source_type);
+                return Err(McpError::internal_error(format!(
+                    "Failed to persist source to {}: {e}",
+                    path.display()
+                )));
+            }
+
+            info!("Spec added from source '{source_type}'");
+
+            Ok(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": "Spec added successfully."
+                }]
+            }))
+        }
+
+        fn tool_update_spec(
+            &mut self,
+            args: &serde_json::Value,
+        ) -> Result<serde_json::Value, McpError> {
+            let spec = args["spec"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| McpError::invalid_params("Missing 'spec' field".to_string()))?;
+
+            let (code, source_type) = Self::parse_code_and_source(args)?;
+            let path = self.disk_path(&source_type)?;
+
+            let repository = args["repository"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+
+            let effective = match args.get("effective").and_then(|v| v.as_str()) {
+                None => None,
+                Some(raw) => Some(
+                    lemma::resolve_effective(Some(raw))
+                        .map_err(|e| McpError::invalid_params(e.to_string()))?,
+                ),
+            };
+
+            let rollback_snapshot =
+                match self
+                    .engine
+                    .source(repository, Some(spec), effective.as_ref())
+                {
+                    Ok(old_code) => {
+                        let show = self
+                            .engine
+                            .show(repository, spec, effective.as_ref())
+                            .expect("BUG: source succeeded so show must succeed for same identity");
+                        let old_source_type = show.source_type.expect(
+                            "BUG: loaded spec must carry source_type for update persist rollback",
+                        );
+                        Some((old_source_type, old_code))
+                    }
+                    Err(_) => None,
+                };
+
+            if let Err(load_err) = self.engine.update(
+                repository,
+                spec,
+                effective.as_ref(),
+                source_type.clone(),
+                code.to_string(),
+            ) {
+                return Ok(Self::load_diagnostics_tool_result(load_err));
+            }
+
+            let formatted = Self::formatted_persist_source(code, &source_type);
+            if let Err(e) = atomic_write(&path, &formatted) {
+                let (old_source_type, old_code) = rollback_snapshot
+                    .expect("BUG: successful update with persist requires rollback snapshot");
+                self.engine
+                    .update(
+                        repository,
+                        spec,
+                        effective.as_ref(),
+                        old_source_type,
+                        old_code,
+                    )
+                    .expect("BUG: restore previous spec after failed persist must succeed");
+                return Err(McpError::internal_error(format!(
+                    "Failed to persist source to {}: {e}",
+                    path.display()
+                )));
+            }
+
+            info!("Spec '{spec}' updated from source '{source_type}'");
+
+            Ok(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": "Spec updated successfully."
+                }]
+            }))
+        }
+
+        /// Remove every loaded temporal row whose `show.source_type` equals `source_type`.
+        fn remove_all_with_source_type(&mut self, source_type: &lemma::SourceType) {
+            let mut removals: Vec<(Option<String>, String, Option<DateTimeValue>)> = Vec::new();
+            for repo_group in self.engine.list() {
+                let repo = repo_group.repository.clone();
+                for listed in repo_group.specs {
+                    let show = self
+                        .engine
+                        .show(
+                            repo.as_deref(),
+                            &listed.name,
+                            listed.effective_from.as_ref(),
+                        )
+                        .expect("BUG: listed spec must show for source_type scan");
+                    if show.source_type.as_ref() == Some(source_type) {
+                        removals.push((repo.clone(), listed.name, listed.effective_from));
+                    }
+                }
+            }
+            for (repo, name, eff) in removals {
+                self.engine
+                    .remove(repo.as_deref(), &name, eff.as_ref())
+                    .expect("BUG: remove of previously listed source_type row must succeed");
+            }
+        }
+
+        fn tool_remove_spec(
+            &mut self,
+            args: &serde_json::Value,
+        ) -> Result<serde_json::Value, McpError> {
+            let spec = args["spec"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| McpError::invalid_params("Missing 'spec' field".to_string()))?;
+
+            let repository = args["repository"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+
+            let effective = match args.get("effective").and_then(|v| v.as_str()) {
+                None => None,
+                Some(raw) => Some(
+                    lemma::resolve_effective(Some(raw))
+                        .map_err(|e| McpError::invalid_params(e.to_string()))?,
+                ),
+            };
+
+            let show = match self.engine.show(repository, spec, effective.as_ref()) {
+                Ok(show) => show,
+                Err(err) => {
+                    error!("{}", err);
+                    let diagnostics = vec![lemma::EngineError::from(&err)];
+                    let text = serde_json::to_string_pretty(&diagnostics)
+                        .expect("BUG: EngineError diagnostics must serialize");
+                    return Ok(serde_json::json!({
+                        "content": [{
+                            "type": "text",
+                            "text": text
+                        }],
+                        "isError": true
+                    }));
+                }
+            };
+
+            let source_type = show
+                .source_type
+                .expect("BUG: loaded spec must carry source_type for remove");
+            let path = self.disk_path(&source_type)?;
+            let file_snapshot = fs::read_to_string(&path).map_err(|e| {
+                McpError::internal_error(format!(
+                    "Failed to snapshot {} before remove: {e}",
+                    path.display()
+                ))
+            })?;
+
+            // Sibling temporal rows that share this Path (exclude the row about to be removed).
+            let mut siblings: Vec<(Option<String>, String, Option<DateTimeValue>)> = Vec::new();
+            for repo_group in self.engine.list() {
+                let repo = repo_group.repository.clone();
+                for listed in repo_group.specs {
+                    let same_identity = repo.as_deref() == repository
+                        && listed.name == spec
+                        && listed.effective_from == effective;
+                    if same_identity {
+                        continue;
+                    }
+                    let sibling_show = self
+                        .engine
+                        .show(
+                            repo.as_deref(),
+                            &listed.name,
+                            listed.effective_from.as_ref(),
+                        )
+                        .expect("BUG: listed sibling must show");
+                    if sibling_show.source_type.as_ref() == Some(&source_type) {
+                        siblings.push((repo.clone(), listed.name, listed.effective_from));
+                    }
+                }
+            }
+
+            if let Err(err) = self.engine.remove(repository, spec, effective.as_ref()) {
+                error!("{}", err);
+                let diagnostics = vec![lemma::EngineError::from(&err)];
+                let text = serde_json::to_string_pretty(&diagnostics)
+                    .expect("BUG: EngineError diagnostics must serialize");
+                return Ok(serde_json::json!({
+                    "content": [{
+                        "type": "text",
+                        "text": text
+                    }],
+                    "isError": true
+                }));
+            }
+
+            let disk_result = if siblings.is_empty() {
+                match fs::remove_file(&path) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(e),
+                }
+            } else {
+                let mut pieces: Vec<String> = Vec::with_capacity(siblings.len());
+                for (repo, name, eff) in &siblings {
+                    let piece = self
+                        .engine
+                        .source(repo.as_deref(), Some(name), eff.as_ref())
+                        .expect("BUG: sibling remaining after remove must have source");
+                    pieces.push(piece);
+                }
+                atomic_write(&path, &pieces.join("\n\n"))
+            };
+
+            if let Err(e) = disk_result {
+                self.remove_all_with_source_type(&source_type);
+                self.engine
+                    .load([(source_type, file_snapshot)])
+                    .expect("BUG: restore file after failed remove persist must succeed");
+                return Err(McpError::internal_error(format!(
+                    "Failed to persist remove to {}: {e}",
+                    path.display()
+                )));
+            }
+
+            info!("Spec '{spec}' removed");
+
+            Ok(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!("Spec '{spec}' removed.")
+                }]
+            }))
+        }
+
+        fn tool_clear(&mut self, _args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
+            for path in Self::workspace_lemma_files(&self.workdir)? {
+                match fs::remove_file(&path) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        return Err(McpError::internal_error(format!(
+                            "Failed to delete {}: {e}",
+                            path.display()
+                        )));
+                    }
+                }
+            }
+
+            self.engine = Engine::new();
+            info!("Engine cleared");
+
+            Ok(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": "Removed all specs."
+                }]
+            }))
+        }
+
+        /// Every `.lemma` file under `workdir` (or `workdir` itself when it is a file).
+        fn workspace_lemma_files(workdir: &Path) -> Result<Vec<PathBuf>, McpError> {
+            if workdir.is_file() {
+                return Ok(vec![workdir.to_path_buf()]);
+            }
+            if !workdir.is_dir() {
+                return Ok(Vec::new());
+            }
+            let mut paths = Vec::new();
+            for entry in walkdir::WalkDir::new(workdir) {
+                let entry = entry.map_err(|e| {
+                    McpError::internal_error(format!("Failed to walk workspace during clear: {e}"))
+                })?;
+                if entry.file_type().is_file()
+                    && entry.path().extension().and_then(|s| s.to_str()) == Some("lemma")
+                {
+                    paths.push(entry.path().to_path_buf());
+                }
+            }
+            Ok(paths)
+        }
+
+        fn make_fetch_registry() -> Box<dyn lemma::Registry> {
+            match std::env::var_os("LEMMA_REGISTRY_FIXTURES") {
+                Some(dir) => Box::new(lemma::LemmaBase::with_fixture_dir(PathBuf::from(dir))),
+                None => Box::new(lemma::LemmaBase::new()),
+            }
+        }
+
+        fn dependency_in_engine(engine: &Engine, dependency: &str) -> bool {
+            engine
+                .list()
+                .iter()
+                .any(|repo| repo.repository.as_deref() == Some(dependency))
+        }
+
+        /// Remove every temporal row currently loaded under `dependency`.
+        fn unload_dependency(engine: &mut Engine, dependency: &str) {
+            let rows: Vec<(String, Option<DateTimeValue>)> = engine
+                .list()
+                .into_iter()
+                .find(|repo| repo.repository.as_deref() == Some(dependency))
+                .map(|repo| {
+                    repo.specs
+                        .into_iter()
+                        .map(|spec| (spec.name, spec.effective_from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            for (name, effective) in rows {
+                engine
+                    .remove(Some(dependency), &name, effective.as_ref())
+                    .expect("BUG: unload of previously listed dependency row must succeed");
+            }
+        }
+
+        fn tool_fetch(&mut self, args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
+            let dependency = args["dependency"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    McpError::invalid_params("Missing 'dependency' field".to_string())
+                })?;
+
+            if !dependency.starts_with('@') {
+                return Err(McpError::invalid_params(format!(
+                    "Dependency must be a registry identifier starting with '@' (got '{dependency}')"
+                )));
+            }
+
+            let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+
+            let workdir = &self.workdir;
+
+            lemma::parse_spec_set_id(dependency)
+                .map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+            let registry = Self::make_fetch_registry();
+            let runtime = tokio::runtime::Runtime::new().map_err(|e| {
+                McpError::internal_error(format!("Failed to start async runtime for fetch: {e}"))
+            })?;
+            let bundle = runtime.block_on(registry.get(dependency)).map_err(|e| {
+                McpError::internal_error(format!("Registry error for {dependency}: {}", e.message))
+            })?;
+
+            let source_text = bundle.source;
+            let limits = lemma::ResourceLimits::default();
+            let source_type = lemma::SourceType::Dependency(dependency.to_string());
+
+            let new_specs = lemma::parse(&source_text, source_type.clone(), &limits)
+                .map_err(|e| {
+                    McpError::internal_error(format!(
+                        "Registry returned unparseable dependency: {}",
+                        e.message()
+                    ))
+                })?
+                .into_flattened_specs();
+            let new_spec_names: std::collections::HashSet<String> =
+                new_specs.iter().map(|s| s.name.clone()).collect();
+
+            let deps_dir = lemma::deps::lemma_deps_dir(workdir);
+            let destination_relative = lemma::deps::relative_dependency_cache_path(dependency);
+            let destination_absolute = deps_dir.join(&destination_relative);
+
+            let mut conflict_paths: Vec<PathBuf> = Vec::new();
+            if deps_dir.exists() {
+                for entry in walkdir::WalkDir::new(&deps_dir) {
+                    let entry = entry.map_err(|e| {
+                        McpError::internal_error(format!("Failed to walk lemma_deps: {e}"))
+                    })?;
+                    if entry.path().extension().and_then(|s| s.to_str()) != Some("lemma") {
+                        continue;
+                    }
+                    let path = entry.path();
+                    let existing_content = fs::read_to_string(path).map_err(|e| {
+                        McpError::internal_error(format!("Failed to read {}: {e}", path.display()))
+                    })?;
+                    if existing_content == source_text && path == destination_absolute {
+                        if !Self::dependency_in_engine(&self.engine, dependency) {
+                            if let Err(load_err) = self
+                                .engine
+                                .load([(source_type.clone(), source_text.clone())])
+                            {
+                                return Ok(Self::load_diagnostics_tool_result(load_err));
+                            }
+                        }
+                        let message = format!(
+                            "Already up to date: {} -> {}",
+                            dependency,
+                            destination_relative.display()
+                        );
+                        info!("{message}");
+                        return Ok(serde_json::json!({
+                            "content": [{ "type": "text", "text": message }]
+                        }));
+                    }
+                    let existing_specs = match lemma::parse(
+                        &existing_content,
+                        lemma::SourceType::Path(std::sync::Arc::new(path.to_path_buf())),
+                        &limits,
+                    ) {
+                        Ok(parsed) => parsed.into_flattened_specs(),
+                        Err(_) => continue,
+                    };
+                    let conflict: Vec<&str> = existing_specs
+                        .iter()
+                        .filter(|s| new_spec_names.contains(&s.name))
+                        .map(|s| s.name.as_str())
+                        .collect();
+                    if !conflict.is_empty() {
+                        if path == destination_absolute {
+                            continue;
+                        }
+                        if !force {
+                            return Err(McpError::invalid_params(format!(
+                                "Dependency containing spec(s) {} already exists in {}.\n\
+                                 Content has changed on the registry. Re-run with force=true to overwrite.",
+                                conflict.join(", "),
+                                path.display()
+                            )));
+                        }
+                        conflict_paths.push(path.to_path_buf());
+                    }
+                }
+            }
+
+            if destination_absolute.exists() {
+                let existing = fs::read_to_string(&destination_absolute).map_err(|e| {
+                    McpError::internal_error(format!(
+                        "Failed to read {}: {e}",
+                        destination_absolute.display()
+                    ))
+                })?;
+                if existing == source_text && !force {
+                    if !Self::dependency_in_engine(&self.engine, dependency) {
+                        if let Err(load_err) = self
+                            .engine
+                            .load([(source_type.clone(), source_text.clone())])
+                        {
+                            return Ok(Self::load_diagnostics_tool_result(load_err));
+                        }
+                    }
+                    let message = format!(
+                        "Already up to date: {} -> {}",
+                        dependency,
+                        destination_relative.display()
+                    );
+                    info!("{message}");
+                    return Ok(serde_json::json!({
+                        "content": [{ "type": "text", "text": message }]
+                    }));
+                }
+            }
+
+            // Validate the bundle plans before mutating server state or disk.
+            let mut probe = Engine::new();
+            if let Err(load_err) = probe.load([(source_type.clone(), source_text.clone())]) {
+                return Ok(Self::load_diagnostics_tool_result(load_err));
+            }
+
+            let already_loaded = Self::dependency_in_engine(&self.engine, dependency);
+            let rollback_source = if already_loaded {
+                Some(
+                    self.engine
+                        .source(Some(dependency), None, None)
+                        .map_err(|e| {
+                            McpError::internal_error(format!(
+                                "Failed to snapshot existing dependency '{dependency}' for rollback: {e}"
+                            ))
+                        })?,
+                )
+            } else {
+                None
+            };
+
+            if already_loaded {
+                if !force
+                    && destination_absolute.exists()
+                    && fs::read_to_string(&destination_absolute)
+                        .map(|c| c == source_text)
+                        .unwrap_or(false)
+                {
+                    let message = format!(
+                        "Already up to date: {} -> {}",
+                        dependency,
+                        destination_relative.display()
+                    );
+                    return Ok(serde_json::json!({
+                        "content": [{ "type": "text", "text": message }]
+                    }));
+                }
+                if !force {
+                    return Err(McpError::invalid_params(format!(
+                        "Dependency '{dependency}' is already loaded. Re-run with force=true to overwrite."
+                    )));
+                }
+                Self::unload_dependency(&mut self.engine, dependency);
+            }
+
+            if let Err(load_err) = self
+                .engine
+                .load([(source_type.clone(), source_text.clone())])
+            {
+                if let Some(old) = rollback_source.as_ref() {
+                    self.engine
+                        .load([(
+                            lemma::SourceType::Dependency(dependency.to_string()),
+                            old.clone(),
+                        )])
+                        .expect("BUG: restore previous dependency after failed load must succeed");
+                }
+                return Ok(Self::load_diagnostics_tool_result(load_err));
+            }
+
+            let removed_conflict_snapshots: Vec<(PathBuf, String)> = {
+                let mut snaps = Vec::new();
+                for path in &conflict_paths {
+                    let content = fs::read_to_string(path).map_err(|e| {
+                        McpError::internal_error(format!(
+                            "Failed to snapshot conflict file {}: {e}",
+                            path.display()
+                        ))
+                    })?;
+                    snaps.push((path.clone(), content));
+                }
+                snaps
+            };
+
+            for (path, _) in &removed_conflict_snapshots {
+                fs::remove_file(path).map_err(|e| {
+                    McpError::internal_error(format!(
+                        "Failed to remove conflict file {}: {e}",
+                        path.display()
+                    ))
+                })?;
+            }
+
+            if let Err(e) = atomic_write(&destination_absolute, &source_text) {
+                for (path, content) in &removed_conflict_snapshots {
+                    let _ = atomic_write(path, content);
+                }
+                Self::unload_dependency(&mut self.engine, dependency);
+                if let Some(old) = rollback_source {
+                    self.engine
+                        .load([(lemma::SourceType::Dependency(dependency.to_string()), old)])
+                        .expect(
+                            "BUG: restore previous dependency after failed persist must succeed",
+                        );
+                }
+                return Err(McpError::internal_error(format!(
+                    "Failed to persist dependency to {}: {e}",
+                    destination_absolute.display()
+                )));
+            }
+
+            let message = format!(
+                "Fetched {} -> {}",
+                dependency,
+                destination_relative.display()
+            );
+            info!("{message}");
+            Ok(serde_json::json!({
+                "content": [{ "type": "text", "text": message }]
+            }))
+        }
+
+        fn parse_code_and_source(
+            args: &serde_json::Value,
+        ) -> Result<(&str, lemma::SourceType), McpError> {
             let code = args["code"]
                 .as_str()
                 .ok_or_else(|| McpError::invalid_params("Missing 'code' field".to_string()))?;
@@ -499,18 +1328,7 @@ mod imp {
             let source_type = lemma::SourceType::from_binding_label(source_id)
                 .map_err(McpError::invalid_params)?;
 
-            if let Err(load_err) = self.engine.load([(source_type, code.to_string())]) {
-                return Ok(Self::load_diagnostics_tool_result(load_err));
-            }
-
-            info!("Spec added from source '{}'", source_id);
-
-            Ok(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": "Spec added successfully."
-                }]
-            }))
+            Ok((code, source_type))
         }
 
         fn tool_check(args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
@@ -554,27 +1372,48 @@ mod imp {
                 return Ok(Self::load_diagnostics_tool_result(load_err));
             }
 
+            let recommendations = engine.quality();
+            let mut text = String::from(
+                "Parsed and planned. Syntax is valid; this does not verify the policy is correct.",
+            );
+            const MAX_RECOMMENDATIONS: usize = 20;
+            if !recommendations.is_empty() {
+                text.push_str("\n\nRecommendations:");
+                for (i, rec) in recommendations.iter().take(MAX_RECOMMENDATIONS).enumerate() {
+                    text.push_str(&format!("\n{}. {}", i + 1, rec));
+                }
+                let omitted = recommendations.len().saturating_sub(MAX_RECOMMENDATIONS);
+                if omitted > 0 {
+                    text.push_str(&format!("\n… and {omitted} more"));
+                }
+            }
+
             Ok(serde_json::json!({
                 "content": [{
                     "type": "text",
-                    "text": "All sources parsed and planned successfully."
+                    "text": text
                 }]
             }))
         }
 
         fn tool_guide(&self, args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
-            let topic_name = args["topic"]
-                .as_str()
-                .ok_or_else(|| McpError::invalid_params("Missing 'topic' field".to_string()))?;
-            let topic = crate::mcp::guide::GuideTopic::parse(topic_name).ok_or_else(|| {
-                McpError::invalid_params(format!(
-                    "Unknown guide topic '{topic_name}'. Valid: syntax, data, rules, units, veto, composition, anti_patterns"
-                ))
-            })?;
+            let text = match args.get("topic").and_then(|v| v.as_str()) {
+                None => crate::mcp::guide::EVALUATE_GUIDE,
+                Some(topic_name) => {
+                    let topic =
+                        crate::mcp::guide::GuideTopic::parse(topic_name).ok_or_else(|| {
+                            McpError::invalid_params(format!(
+                                "Unknown guide topic '{topic_name}'. Valid: {}",
+                                crate::mcp::guide::GuideTopic::VALID_LIST
+                            ))
+                        })?;
+                    topic.section_text()
+                }
+            };
             Ok(serde_json::json!({
                 "content": [{
                     "type": "text",
-                    "text": topic.section_text()
+                    "text": text
                 }]
             }))
         }
@@ -679,6 +1518,29 @@ mod imp {
                     McpError::internal_error(format!("Evaluation failed: {e}"))
                 })?;
 
+            let show_for_missing = if response
+                .results
+                .values()
+                .any(|result| !result.missing_data.is_empty())
+            {
+                Some(
+                    self.engine
+                        .show(None, &spec_name, Some(&now))
+                        .map_err(|e| {
+                            error!(
+                                "show failed after evaluate for '{}': {}",
+                                spec_set_id.trim(),
+                                e
+                            );
+                            McpError::internal_error(format!(
+                                "Failed to show spec for missing_data: {e}"
+                            ))
+                        })?,
+                )
+            } else {
+                None
+            };
+
             let mut output = String::new();
             output.push_str(&format!("spec: {}\n", spec_set_id.trim()));
             output.push_str(&format!("effective: {}\n", now));
@@ -707,6 +1569,27 @@ mod imp {
                     }
                 }
                 output.push('\n');
+
+                if !result.missing_data.is_empty() {
+                    let show = show_for_missing
+                        .as_ref()
+                        .expect("BUG: missing_data nonempty so show_for_missing must be Some");
+                    output.push_str("missing_data:\n");
+                    for name in &result.missing_data {
+                        let entry = show.data.get(name).unwrap_or_else(|| {
+                            panic!(
+                                "BUG: missing_data key {name:?} must exist in show.data after evaluate"
+                            )
+                        });
+                        let type_name = entry.lemma_type.specifications.to_string();
+                        let help = entry.lemma_type.specifications.help();
+                        if help.is_empty() {
+                            output.push_str(&format!("  {name}: {type_name}\n"));
+                        } else {
+                            output.push_str(&format!("  {name}: {type_name} — {help}\n"));
+                        }
+                    }
+                }
 
                 if let Some(explanation) = &result.explanation {
                     let steps = lemma::format_explanation(explanation);
@@ -865,7 +1748,7 @@ mod imp {
         }
     }
 
-    pub fn start_server(engine: Engine, config: McpConfig) -> Result<()> {
+    pub fn start_server(engine: Engine, config: McpConfig, workdir: &Path) -> Result<()> {
         tracing_subscriber::fmt()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
@@ -883,6 +1766,7 @@ mod imp {
         }
 
         let request_timeout = config.request_timeout;
+        let workdir = workdir.to_path_buf();
 
         // Requests are handled on a dedicated worker thread that owns the
         // engine state, so the reader loop can enforce a wall-clock timeout
@@ -892,7 +1776,7 @@ mod imp {
         let (request_tx, request_rx) = std::sync::mpsc::channel::<McpRequest>();
         let (response_tx, response_rx) = std::sync::mpsc::channel::<Option<McpResponse>>();
         std::thread::spawn(move || {
-            let mut server = McpServer::new(engine, config);
+            let mut server = McpServer::new(engine, config, workdir);
             for request in request_rx {
                 let request_id = request.id.clone();
                 let response = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -1054,7 +1938,7 @@ mod imp {
         use super::*;
 
         fn server() -> McpServer {
-            McpServer::new(Engine::new(), McpConfig::default())
+            McpServer::new(Engine::new(), McpConfig::default(), std::env::temp_dir())
         }
 
         fn parse(line: &str) -> McpRequest {
@@ -1187,6 +2071,40 @@ mod imp {
             input.push(b'\n');
             let lines = read_all_capped(&input, 10);
             assert!(matches!(&lines[0], CappedLine::Line(s) if s.len() == 10));
+        }
+
+        #[test]
+        fn validated_write_path_accepts_relative_file() {
+            let workdir = Path::new("/tmp/lemma-workspace");
+            let path = validated_write_path(workdir, Path::new("pricing.lemma"))
+                .expect("relative path must be accepted");
+            assert_eq!(path, PathBuf::from("/tmp/lemma-workspace/pricing.lemma"));
+        }
+
+        #[test]
+        fn validated_write_path_rejects_parent_dir() {
+            let err = validated_write_path(Path::new("/tmp/ws"), Path::new("../escape.lemma"))
+                .expect_err(".. must be rejected");
+            assert!(err.message.contains(".."));
+        }
+
+        #[test]
+        fn validated_write_path_rejects_absolute() {
+            let err = validated_write_path(Path::new("/tmp/ws"), Path::new("/etc/passwd"))
+                .expect_err("absolute path must be rejected");
+            assert!(err.message.contains("relative"));
+        }
+
+        #[test]
+        fn atomic_write_round_trip() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("out.lemma");
+            atomic_write(&path, "spec x\ndata a: 1\n").unwrap();
+            assert_eq!(fs::read_to_string(&path).unwrap(), "spec x\ndata a: 1\n");
+            assert!(
+                !dir.path().join(".out.lemma.tmp").exists(),
+                "temp file must be cleaned up"
+            );
         }
     }
 }

--- a/cli/tests/integrations/documentation_examples.rs
+++ b/cli/tests/integrations/documentation_examples.rs
@@ -115,7 +115,8 @@ fn test_02_library_fees() {
     let engine = load_specs_folder_examples();
 
     let mut data = HashMap::new();
-    data.insert("days_overdue".to_string(), "5".to_string());
+    data.insert("due_date".to_string(), "2024-01-01".to_string());
+    data.insert("return_date".to_string(), "2024-01-06".to_string());
     data.insert("book_type".to_string(), "regular".to_string());
     data.insert("is_first_offense".to_string(), "false".to_string());
 

--- a/cli/tests/integrations/lsp.rs
+++ b/cli/tests/integrations/lsp.rs
@@ -65,7 +65,18 @@ fn lsp_parse_error_publishes_diagnostics() {
 #[test]
 fn lsp_valid_spec_has_no_diagnostics() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let source = "spec t\ndata x: 1\n";
+    let source = r#"spec pricing 2026-01-01
+"""
+Bulk pricing.
+"""
+
+data qty: number
+  -> minimum 0
+  -> help "Order quantity."
+  -> suggest 10
+
+rule total: qty
+"#;
     let path = write_lemma_file(dir.path(), "valid.lemma", source);
     let uri = path_to_uri(&path);
 
@@ -80,7 +91,7 @@ fn lsp_valid_spec_has_no_diagnostics() {
         .expect("diagnostics array");
     assert!(
         diagnostics.is_empty(),
-        "expected no diagnostics for valid spec, got: {diagnostics:?}"
+        "expected no diagnostics for valid quality-clean spec, got: {diagnostics:?}"
     );
 
     session.shutdown();

--- a/cli/tests/integrations/mcp.rs
+++ b/cli/tests/integrations/mcp.rs
@@ -28,6 +28,16 @@ fn mcp_session_in_dir(
     admin: bool,
     messages: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
+    mcp_session_with_env(prefix, current_dir, admin, &[], messages)
+}
+
+fn mcp_session_with_env(
+    prefix: Option<&std::path::Path>,
+    current_dir: Option<&std::path::Path>,
+    admin: bool,
+    env: &[(&str, &str)],
+    messages: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
     let bin = env!("CARGO_BIN_EXE_lemma");
     let mut cmd = Command::new(bin);
     cmd.arg("mcp");
@@ -39,6 +49,9 @@ fn mcp_session_in_dir(
     }
     if admin {
         cmd.arg("--admin");
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
     }
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -70,6 +83,24 @@ fn mcp_session_in_dir(
 
     child.wait().unwrap();
     responses
+}
+
+fn registry_fixtures_dir() -> std::path::PathBuf {
+    lemma::LemmaBase::test_fixtures_dir()
+}
+
+fn mcp_fetch_session(
+    prefix: &std::path::Path,
+    messages: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
+    let fixtures = registry_fixtures_dir();
+    mcp_session_with_env(
+        Some(prefix),
+        None,
+        true,
+        &[("LEMMA_REGISTRY_FIXTURES", fixtures.to_str().unwrap())],
+        messages,
+    )
 }
 
 fn make_request(id: u64, method: &str, params: serde_json::Value) -> serde_json::Value {
@@ -186,6 +217,125 @@ fn test_mcp_evaluate_includes_reasoning() {
 }
 
 #[test]
+fn test_mcp_evaluate_reports_missing_data_when_partial() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_spec(
+        temp_dir.path(),
+        "pricing.lemma",
+        "spec pricing\ndata quantity: number\ndata price: number\nrule total: quantity * price\n",
+    );
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "evaluate",
+                    "arguments": {
+                        "spec": "pricing",
+                        "rule": "total",
+                        "data": ["quantity=2"]
+                    }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "evaluate",
+                    "arguments": {
+                        "spec": "pricing",
+                        "rule": "total",
+                        "data": ["quantity=2", "price=10"]
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+    let partial = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("partial evaluate text");
+    assert!(
+        partial.contains("missing_data:"),
+        "partial evaluate must report missing_data, got: {partial}"
+    );
+    assert!(
+        partial.contains("price:"),
+        "missing_data must include price with type, got: {partial}"
+    );
+
+    let complete = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("complete evaluate text");
+    assert!(
+        !complete.contains("missing_data:"),
+        "complete evaluate must omit missing_data, got: {complete}"
+    );
+    assert!(
+        complete.contains("total:"),
+        "complete evaluate must show rule result, got: {complete}"
+    );
+}
+
+#[test]
+fn test_mcp_evaluate_missing_data_includes_help() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_spec(
+        temp_dir.path(),
+        "pricing.lemma",
+        r#"spec pricing
+data quantity: number
+data price: number
+  -> help "Unit price of the item."
+rule total: quantity * price
+"#,
+    );
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "evaluate",
+                    "arguments": {
+                        "spec": "pricing",
+                        "rule": "total",
+                        "data": ["quantity=2"]
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("evaluate text");
+    assert!(
+        text.contains("missing_data:"),
+        "must report missing_data, got: {text}"
+    );
+    assert!(
+        text.contains("Unit price of the item."),
+        "missing_data line must include -> help text, got: {text}"
+    );
+    assert!(
+        text.contains("price:") && text.contains("number"),
+        "missing_data line must include name and type, got: {text}"
+    );
+}
+
+#[test]
 fn test_mcp_read_only_by_default() {
     let temp_dir = tempfile::tempdir().unwrap();
 
@@ -224,8 +374,28 @@ fn test_mcp_read_only_by_default() {
         tool_names
     );
     assert!(
-        !tool_names.contains(&"source"),
-        "source should not be listed in read-only mode, got: {:?}",
+        !tool_names.contains(&"update_spec"),
+        "update_spec should not be listed in read-only mode, got: {:?}",
+        tool_names
+    );
+    assert!(
+        !tool_names.contains(&"remove_spec"),
+        "remove_spec should not be listed in read-only mode, got: {:?}",
+        tool_names
+    );
+    assert!(
+        !tool_names.contains(&"clear"),
+        "clear should not be listed in read-only mode, got: {:?}",
+        tool_names
+    );
+    assert!(
+        !tool_names.contains(&"fetch"),
+        "fetch should not be listed in read-only mode, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"source"),
+        "source should be listed in read-only mode, got: {:?}",
         tool_names
     );
 
@@ -285,8 +455,28 @@ fn test_mcp_admin_enables_add_spec() {
         tool_names
     );
     assert!(
+        tool_names.contains(&"update_spec"),
+        "update_spec should be listed with --admin, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"remove_spec"),
+        "remove_spec should be listed with --admin, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"clear"),
+        "clear should be listed with --admin, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"fetch"),
+        "fetch should be listed with --admin, got: {:?}",
+        tool_names
+    );
+    assert!(
         tool_names.contains(&"source"),
-        "source should be listed with --admin, got: {:?}",
+        "source should be listed (default tool), got: {:?}",
         tool_names
     );
 
@@ -303,7 +493,7 @@ fn test_mcp_source() {
 
     let responses = mcp_session(
         Some(temp_dir.path()),
-        true,
+        false,
         &[
             make_request(1, "initialize", json!({})),
             make_request(
@@ -344,7 +534,7 @@ fn test_mcp_source_embedded_lemma_repository() {
 
     let responses = mcp_session(
         Some(temp_dir.path()),
-        true,
+        false,
         &[
             make_request(1, "initialize", json!({})),
             make_request(
@@ -373,7 +563,7 @@ fn test_mcp_source_embedded_lemma_repository() {
 }
 
 #[test]
-fn test_mcp_source_blocked_without_admin() {
+fn test_mcp_source_without_admin() {
     let temp_dir = tempfile::tempdir().unwrap();
     write_spec(
         temp_dir.path(),
@@ -401,18 +591,12 @@ fn test_mcp_source_blocked_without_admin() {
 
     assert!(responses.len() >= 2, "Expected at least 2 responses");
 
-    let error = &responses[1]["error"];
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("source should return text without --admin");
     assert!(
-        error.is_object(),
-        "source should return an error without --admin"
-    );
-    assert!(
-        error["message"]
-            .as_str()
-            .unwrap()
-            .contains("Admin tools are disabled"),
-        "Error should mention admin tools are disabled, got: {}",
-        error["message"]
+        text.contains("spec pricing"),
+        "source without --admin should return formatted source, got: {text}"
     );
 }
 
@@ -1291,13 +1475,531 @@ fn test_mcp_tools_list_read_only_tools() {
     );
     assert!(tool_names.contains(&"list"), "Should list list tool");
     assert!(tool_names.contains(&"show"), "Should list show tool");
+    assert!(tool_names.contains(&"source"), "Should list source tool");
     assert!(tool_names.contains(&"check"), "Should list check tool");
     assert!(tool_names.contains(&"guide"), "Should list guide tool");
     assert_eq!(
         tool_names.len(),
-        5,
-        "Read-only mode should have exactly 5 tools, got: {:?}",
+        6,
+        "Read-only mode should have exactly 6 tools, got: {:?}",
         tool_names
+    );
+}
+
+#[test]
+fn test_mcp_remove_spec_and_clear() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": "spec draft\ndata x: number\nrule y: x\n",
+                        "source_id": "draft.lemma"
+                    }
+                }),
+            ),
+            make_request(3, "tools/call", json!({ "name": "list", "arguments": {} })),
+            make_request(
+                4,
+                "tools/call",
+                json!({
+                    "name": "remove_spec",
+                    "arguments": { "spec": "draft" }
+                }),
+            ),
+            make_request(5, "tools/call", json!({ "name": "list", "arguments": {} })),
+            make_request(
+                6,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": "spec again\ndata z: 1\nrule r: z\n",
+                        "source_id": "again.lemma"
+                    }
+                }),
+            ),
+            make_request(7, "tools/call", json!({ "name": "clear", "arguments": {} })),
+            make_request(8, "tools/call", json!({ "name": "list", "arguments": {} })),
+        ],
+    );
+
+    assert!(responses.len() >= 8);
+    assert_eq!(
+        responses[1]["result"]["content"][0]["text"],
+        "Spec added successfully."
+    );
+    let list_after_add = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        list_after_add.contains("draft"),
+        "draft must appear after add, got: {list_after_add}"
+    );
+
+    let remove_text = responses[3]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("remove text");
+    assert!(
+        remove_text.contains("removed"),
+        "remove must confirm, got: {remove_text}"
+    );
+    assert!(
+        responses[3]["result"].get("isError").is_none()
+            || responses[3]["result"]["isError"] != true,
+        "remove must succeed"
+    );
+    // Full session already ran remove_spec; draft.lemma must be gone on disk.
+    assert!(
+        !temp_dir.path().join("draft.lemma").exists(),
+        "remove_spec must delete draft.lemma from disk"
+    );
+
+    let list_after_remove = responses[4]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        !list_after_remove.contains("draft"),
+        "draft must be gone after remove, got: {list_after_remove}"
+    );
+
+    let clear_text = responses[6]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("clear text");
+    assert_eq!(
+        clear_text, "Removed all specs.",
+        "clear must confirm remove-all without stdlib chatter, got: {clear_text}"
+    );
+    assert!(
+        !temp_dir.path().join("again.lemma").exists(),
+        "clear must delete again.lemma from disk"
+    );
+
+    let list_after_clear = responses[7]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        !list_after_clear.contains("again"),
+        "workspace specs must be gone after clear, got: {list_after_clear}"
+    );
+}
+
+#[test]
+fn test_mcp_remove_spec_rewrites_shared_path_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": "spec first\ndata a: 1\nrule x: a\n\nspec second\ndata b: 2\nrule y: b\n",
+                        "source_id": "pair.lemma"
+                    }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "remove_spec",
+                    "arguments": { "spec": "first" }
+                }),
+            ),
+            make_request(4, "tools/call", json!({ "name": "list", "arguments": {} })),
+        ],
+    );
+
+    assert!(responses.len() >= 4);
+    assert!(
+        temp_dir.path().join("pair.lemma").exists(),
+        "shared Path file must remain after removing one of two specs"
+    );
+    let on_disk = std::fs::read_to_string(temp_dir.path().join("pair.lemma")).unwrap();
+    assert!(
+        on_disk.contains("spec second") && !on_disk.contains("spec first"),
+        "file must be rewritten without first, got: {on_disk}"
+    );
+    let list_text = responses[3]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        list_text.contains("second") && !list_text.contains("first"),
+        "engine must keep only second, got: {list_text}"
+    );
+}
+
+#[test]
+fn test_mcp_remove_spec_deletes_startup_loaded_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let policy = temp_dir.path().join("workspace_policy.lemma");
+    std::fs::write(
+        &policy,
+        "spec workspace_policy\ndata x: number\nrule y: x\n",
+    )
+    .unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "remove_spec",
+                    "arguments": { "spec": "workspace_policy" }
+                }),
+            ),
+            make_request(3, "tools/call", json!({ "name": "list", "arguments": {} })),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+    assert_eq!(
+        responses[1]["result"]["content"][0]["text"],
+        "Spec 'workspace_policy' removed."
+    );
+    assert!(
+        !policy.exists(),
+        "remove_spec must delete startup-loaded .lemma from disk"
+    );
+    let list_after = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        !list_after.contains("workspace_policy"),
+        "spec must be gone after remove, got: {list_after}"
+    );
+}
+
+#[test]
+fn test_mcp_clear_deletes_startup_loaded_workspace_files() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let policy = temp_dir.path().join("workspace_policy.lemma");
+    std::fs::write(
+        &policy,
+        "spec workspace_policy\ndata x: number\nrule y: x\n",
+    )
+    .unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(2, "tools/call", json!({ "name": "list", "arguments": {} })),
+            make_request(3, "tools/call", json!({ "name": "clear", "arguments": {} })),
+            make_request(4, "tools/call", json!({ "name": "list", "arguments": {} })),
+        ],
+    );
+
+    assert!(responses.len() >= 4);
+    let list_before = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        list_before.contains("workspace_policy"),
+        "startup load must see workspace file, got: {list_before}"
+    );
+
+    assert_eq!(
+        responses[2]["result"]["content"][0]["text"],
+        "Removed all specs."
+    );
+    assert!(
+        !policy.exists(),
+        "clear must delete startup-loaded .lemma from disk"
+    );
+
+    let list_after = responses[3]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        !list_after.contains("workspace_policy"),
+        "spec must be gone after clear, got: {list_after}"
+    );
+}
+
+#[test]
+fn test_mcp_clear_description_leads_with_remove_all() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(2, "tools/list", json!({})),
+        ],
+    );
+    let tools = responses[1]["result"]["tools"].as_array().expect("tools");
+    let clear = tools
+        .iter()
+        .find(|t| t["name"] == "clear")
+        .expect("clear tool");
+    let description = clear["description"].as_str().expect("description");
+    assert_eq!(
+        description, "Remove all specs.",
+        "clear description must be remove-all only, got: {description}"
+    );
+}
+
+#[test]
+fn test_mcp_remove_spec_blocked_without_admin() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "remove_spec",
+                    "arguments": { "spec": "anything" }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "clear",
+                    "arguments": {}
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+    for i in [1, 2] {
+        let error = &responses[i]["error"];
+        assert!(
+            error.is_object(),
+            "admin tool call {i} must error without --admin"
+        );
+        assert!(
+            error["message"]
+                .as_str()
+                .unwrap()
+                .contains("Admin tools are disabled"),
+            "got: {}",
+            error["message"]
+        );
+    }
+}
+
+#[test]
+fn test_mcp_fetch_writes_file_and_loads() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_fetch_session(
+        temp_dir.path(),
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@iso/countries" }
+                }),
+            ),
+            make_request(3, "tools/call", json!({ "name": "list", "arguments": {} })),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+    let fetch_text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("fetch text");
+    assert!(
+        fetch_text.contains("Fetched @iso/countries"),
+        "got: {fetch_text}"
+    );
+
+    let dep_path = temp_dir
+        .path()
+        .join("lemma_deps")
+        .join("@iso")
+        .join("countries.lemma");
+    assert!(dep_path.exists(), "fetch must write {}", dep_path.display());
+    let on_disk = std::fs::read_to_string(&dep_path).unwrap();
+    assert!(
+        on_disk.contains("spec alpha2"),
+        "disk content must include fixture specs, got: {on_disk}"
+    );
+
+    let list_text = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list text");
+    assert!(
+        list_text.contains("@iso/countries") && list_text.contains("alpha2"),
+        "engine must list fetched dependency, got: {list_text}"
+    );
+}
+
+#[test]
+fn test_mcp_fetch_blocked_without_admin() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let fixtures = registry_fixtures_dir();
+
+    let responses = mcp_session_with_env(
+        Some(temp_dir.path()),
+        None,
+        false,
+        &[("LEMMA_REGISTRY_FIXTURES", fixtures.to_str().unwrap())],
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@iso/countries" }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let error = &responses[1]["error"];
+    assert!(error.is_object(), "fetch without admin must error");
+    assert!(
+        error["message"]
+            .as_str()
+            .unwrap()
+            .contains("Admin tools are disabled"),
+        "got: {}",
+        error["message"]
+    );
+    assert!(
+        !temp_dir.path().join("lemma_deps").exists(),
+        "fetch without admin must not write lemma_deps"
+    );
+}
+
+#[test]
+fn test_mcp_fetch_skips_unchanged_unless_force() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let first = mcp_fetch_session(
+        temp_dir.path(),
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@iso/countries" }
+                }),
+            ),
+        ],
+    );
+    let first_text = first[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("first fetch");
+    assert!(
+        first_text.contains("Fetched @iso/countries"),
+        "got: {first_text}"
+    );
+
+    let second = mcp_fetch_session(
+        temp_dir.path(),
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@iso/countries" }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@iso/countries", "force": true }
+                }),
+            ),
+        ],
+    );
+
+    let skip_text = second[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("skip fetch");
+    assert!(
+        skip_text.contains("Already up to date"),
+        "second fetch without force must skip, got: {skip_text}"
+    );
+
+    let force_text = second[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("force fetch");
+    assert!(
+        force_text.contains("Fetched @iso/countries") || force_text.contains("Already up to date"),
+        "force with identical content may rewrite or report up to date, got: {force_text}"
+    );
+}
+
+#[test]
+fn test_mcp_fetch_missing_registry_spec_errors() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_fetch_session(
+        temp_dir.path(),
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "fetch",
+                    "arguments": { "dependency": "@org/does-not-exist" }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let error = &responses[1]["error"];
+    assert!(
+        error.is_object(),
+        "missing registry dependency must error, got: {}",
+        responses[1]
+    );
+    let message = error["message"].as_str().unwrap();
+    assert!(
+        message.contains("@org/does-not-exist") || message.contains("Registry error"),
+        "got: {message}"
+    );
+    assert!(
+        !temp_dir
+            .path()
+            .join("lemma_deps")
+            .join("@org")
+            .join("does-not-exist.lemma")
+            .exists(),
+        "failed fetch must not write lemma_deps file"
     );
 }
 
@@ -1333,13 +2035,26 @@ fn test_mcp_tools_list_admin_tools() {
         "Should list add_spec tool in admin mode"
     );
     assert!(
-        tool_names.contains(&"source"),
-        "Should list source tool in admin mode"
+        tool_names.contains(&"update_spec"),
+        "Should list update_spec tool in admin mode"
     );
+    assert!(
+        tool_names.contains(&"remove_spec"),
+        "Should list remove_spec tool in admin mode"
+    );
+    assert!(
+        tool_names.contains(&"clear"),
+        "Should list clear tool in admin mode"
+    );
+    assert!(
+        tool_names.contains(&"fetch"),
+        "Should list fetch tool in admin mode"
+    );
+    assert!(tool_names.contains(&"source"), "Should list source tool");
     assert_eq!(
         tool_names.len(),
-        7,
-        "Admin mode should have exactly 7 tools, got: {:?}",
+        11,
+        "Admin mode should have exactly 11 tools, got: {:?}",
         tool_names
     );
 }
@@ -1476,6 +2191,266 @@ fn test_mcp_add_spec_then_evaluate() {
     );
 }
 
+#[test]
+fn test_mcp_update_spec_with_dependents() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_spec(
+        temp_dir.path(),
+        "workspace.lemma",
+        r#"
+spec dep
+data value: 10
+rule out: value
+
+spec consumer
+uses d: dep
+rule total: d.value
+"#,
+    );
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "update_spec",
+                    "arguments": {
+                        "spec": "dep",
+                        "code": "spec dep\ndata value: 20\nrule out: value\n",
+                        "source_id": "dep.lemma"
+                    }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "evaluate",
+                    "arguments": { "spec": "consumer" }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+
+    let update_text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("update_spec should return text");
+    assert_eq!(update_text, "Spec updated successfully.");
+
+    let eval_text = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("evaluate should return text");
+    assert!(
+        eval_text.contains("total:"),
+        "Should contain total rule, got: {eval_text}"
+    );
+    assert!(
+        eval_text.contains("20"),
+        "total should be 20 after update, got: {eval_text}"
+    );
+}
+
+#[test]
+fn test_add_spec_persists_to_disk() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let code = "spec dynamic\ndata n: 7\nrule doubled: n * 2\n";
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": code,
+                        "source_id": "dynamic.lemma"
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    assert_eq!(
+        responses[1]["result"]["content"][0]["text"],
+        "Spec added successfully."
+    );
+
+    let path = temp_dir.path().join("dynamic.lemma");
+    let on_disk = std::fs::read_to_string(&path).expect("dynamic.lemma must exist after add_spec");
+    let expected = lemma::format_source(
+        code,
+        lemma::SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from(
+            "dynamic.lemma",
+        ))),
+    )
+    .expect("fixture must format");
+    assert_eq!(on_disk, expected);
+}
+
+#[test]
+fn test_update_spec_persists_to_disk() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_spec(
+        temp_dir.path(),
+        "dep.lemma",
+        "spec dep\ndata value: 10\nrule out: value\n",
+    );
+
+    let new_code = "spec dep\ndata value: 20\nrule out: value\n";
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "update_spec",
+                    "arguments": {
+                        "spec": "dep",
+                        "code": new_code,
+                        "source_id": "dep.lemma"
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    assert_eq!(
+        responses[1]["result"]["content"][0]["text"],
+        "Spec updated successfully."
+    );
+
+    let on_disk =
+        std::fs::read_to_string(temp_dir.path().join("dep.lemma")).expect("dep.lemma must exist");
+    let expected = lemma::format_source(
+        new_code,
+        lemma::SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from("dep.lemma"))),
+    )
+    .expect("fixture must format");
+    assert_eq!(on_disk, expected);
+    assert!(on_disk.contains("20"));
+}
+
+#[test]
+fn test_add_spec_path_traversal_rejected() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": "spec escape\ndata x: 1\nrule y: x\n",
+                        "source_id": "../escape.lemma"
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let error = &responses[1]["error"];
+    assert!(
+        error.is_object(),
+        "path traversal must return JSON-RPC error, got: {}",
+        responses[1]
+    );
+    let message = error["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains(".."),
+        "error should mention '..', got: {message}"
+    );
+    assert!(
+        !temp_dir.path().join("../escape.lemma").exists()
+            || !std::fs::read_to_string(temp_dir.path().join("../escape.lemma"))
+                .unwrap_or_default()
+                .contains("spec escape"),
+        "must not write escaped path"
+    );
+}
+
+#[test]
+fn test_add_spec_write_failure_rolls_back_engine() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    // Parent path component is a file, so create_dir_all / write must fail.
+    std::fs::write(temp_dir.path().join("blocked"), "not a directory").unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        true,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "add_spec",
+                    "arguments": {
+                        "code": "spec trapped\ndata x: 1\nrule y: x\n",
+                        "source_id": "blocked/trapped.lemma"
+                    }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "list",
+                    "arguments": {}
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 3);
+    let error = &responses[1]["error"];
+    assert!(
+        error.is_object(),
+        "write failure must return JSON-RPC error, got: {}",
+        responses[1]
+    );
+    assert!(
+        error["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Failed to persist"),
+        "error should mention persist failure, got: {}",
+        error["message"]
+    );
+
+    let list_text = responses[2]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("list should return text");
+    assert!(
+        !list_text.contains("trapped"),
+        "engine must roll back failed persist; list was: {list_text}"
+    );
+    assert!(
+        !temp_dir.path().join("blocked/trapped.lemma").exists(),
+        "failed write must leave no target file"
+    );
+}
+
 // ── source for missing spec ─────────────────────────────────────────────
 
 #[test]
@@ -1484,7 +2459,7 @@ fn test_mcp_source_missing_spec() {
 
     let responses = mcp_session(
         Some(temp_dir.path()),
-        true,
+        false,
         &[
             make_request(1, "initialize", json!({})),
             make_request(
@@ -1787,9 +2762,9 @@ fn test_mcp_check_does_not_mutate_list() {
             || responses[2]["result"]["isError"] != true,
         "valid check must succeed"
     );
-    assert_eq!(
-        check_text, "All sources parsed and planned successfully.",
-        "check should return success message"
+    assert!(
+        check_text.contains("Parsed and planned"),
+        "check should return success message, got: {check_text}"
     );
     let list_after = responses[3]["result"]["content"][0]["text"]
         .as_str()
@@ -1841,9 +2816,9 @@ fn test_mcp_check_resolves_workspace_and_units() {
         "check with uses lemma units + cross-spec uses must succeed, got: {result}"
     );
     let text = result["content"][0]["text"].as_str().expect("text");
-    assert_eq!(
-        text, "All sources parsed and planned successfully.",
-        "check should return success message"
+    assert!(
+        text.contains("Parsed and planned"),
+        "check should return success message, got: {text}"
     );
 }
 
@@ -1877,6 +2852,141 @@ fn test_mcp_check_resolves_registry_dependency() {
     assert!(
         result.get("isError").is_none() || result["isError"] != true,
         "check with @owner/repo dependency must succeed, got: {result}"
+    );
+}
+
+#[test]
+fn test_mcp_check_reports_veto_cascade_recommendation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let code = r#"spec eligibility 2026-01-01
+"""
+Age gate.
+"""
+
+data age: number
+  -> help "Customer age."
+  -> suggest 30
+
+rule is_eligible: true
+  unless age < 18 then veto "Must be 18+"
+"#;
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "check",
+                    "arguments": {
+                        "sources": [["eligibility.lemma", code]]
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let result = &responses[1]["result"];
+    assert!(
+        result.get("isError").is_none() || result["isError"] != true,
+        "check must succeed with recommendations, got: {result}"
+    );
+    let text = result["content"][0]["text"].as_str().expect("text");
+    assert!(
+        text.contains("Parsed and planned"),
+        "success path must keep advisory framing, got: {text}"
+    );
+    assert!(
+        text.contains("Recommendations:"),
+        "must list recommendations, got: {text}"
+    );
+    assert!(
+        text.contains("is_eligible") && text.contains("veto"),
+        "must report veto-as-rejection cascade, got: {text}"
+    );
+}
+
+#[test]
+fn test_mcp_check_clean_spec_has_no_recommendations() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let code = r#"spec pricing 2026-01-01
+"""
+Bulk pricing.
+"""
+
+data qty: number
+  -> minimum 0
+  -> help "Order quantity."
+  -> suggest 10
+
+rule total: qty
+"#;
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "check",
+                    "arguments": {
+                        "sources": [["pricing.lemma", code]]
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let result = &responses[1]["result"];
+    assert!(
+        result.get("isError").is_none() || result["isError"] != true,
+        "clean check must succeed, got: {result}"
+    );
+    let text = result["content"][0]["text"].as_str().expect("text");
+    assert!(text.contains("Parsed and planned"), "got: {text}");
+    assert!(
+        !text.contains("Recommendations:"),
+        "clean spec must not emit recommendations, got: {text}"
+    );
+}
+
+#[test]
+fn test_mcp_check_invalid_skips_recommendations() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "check",
+                    "arguments": {
+                        "sources": [["bad.lemma", "this is not valid lemma code !!!"]]
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], true);
+    let text = result["content"][0]["text"].as_str().expect("text");
+    assert!(
+        !text.contains("Recommendations:"),
+        "failed plan must not include recommendations, got: {text}"
     );
 }
 
@@ -2001,13 +3111,17 @@ fn test_mcp_evaluate_renders_unit_map() {
 fn test_mcp_guide_topics() {
     let temp_dir = tempfile::tempdir().unwrap();
     let topics = [
+        "method",
         "syntax",
         "data",
         "rules",
         "units",
         "veto",
         "composition",
+        "natural_language",
         "anti_patterns",
+        "evaluate",
+        "full",
     ];
     let mut messages = vec![make_request(1, "initialize", json!({}))];
     for (i, topic) in topics.iter().enumerate() {
@@ -2030,6 +3144,136 @@ fn test_mcp_guide_topics() {
         assert!(!text.is_empty(), "guide topic {topic} must not be empty");
 
         match *topic {
+            "method" => {
+                assert!(
+                    text.contains("**Method: write as a policy consultant"),
+                    "method must include consultant heading"
+                );
+                assert!(
+                    text.contains("**Output contract (mandatory)**"),
+                    "method must include output contract"
+                );
+                assert!(
+                    text.contains("**What to ask (and what not to)**"),
+                    "method must teach ask-only-real-gaps filter"
+                );
+                assert!(
+                    !text.contains("**Consuming loaded specs**"),
+                    "method must not include consuming section (moved to evaluate guide)"
+                );
+                assert!(
+                    !text.contains("Defective on arrival?"),
+                    "method must not train laundry-list edge-case questions"
+                );
+                assert!(
+                    text.contains("Always paste the full Lemma source"),
+                    "method must require pasting full source at deliver"
+                );
+                assert!(
+                    text.contains("user can verify what was saved"),
+                    "method must require user verify of saved/loaded source"
+                );
+                assert!(
+                    text.contains("if anything requires adjustment"),
+                    "method must invite adjustment with a statement, not a confirm question"
+                );
+            }
+            "evaluate" => {
+                assert!(
+                    text.contains("**Evaluating loaded specs**"),
+                    "evaluate must include evaluating heading"
+                );
+                assert!(
+                    text.contains("**User-facing language**"),
+                    "evaluate must include User-facing language"
+                );
+                assert!(
+                    text.contains("Do not say bindings"),
+                    "evaluate must forbid saying bindings to the user"
+                );
+                assert!(
+                    text.contains("Never ask the user what the policy means"),
+                    "evaluate must forbid asking the user to interpret policy"
+                );
+                assert!(
+                    text.contains("Never dispose your interpretation as the truth"),
+                    "evaluate must forbid disposing interpretation as truth"
+                );
+                assert!(
+                    text.contains("use *should*"),
+                    "evaluate must require should when judgment call cannot be answered"
+                );
+                assert!(
+                    text.contains("A reply can close many fields"),
+                    "evaluate must teach multi-bind from replies"
+                );
+                assert!(
+                    text.contains("After every user turn (primary loop)"),
+                    "evaluate must make utterance multi-bind the primary loop"
+                );
+                assert!(
+                    text.contains("Synonym probes of the same claim are forbidden"),
+                    "evaluate must forbid synonym leaf-walk"
+                );
+                assert!(
+                    text.contains("At most one unanswered question in flight"),
+                    "evaluate must limit open questions"
+                );
+                assert!(
+                    text.contains("When the rule answers (verify before done)"),
+                    "evaluate must require verify before done"
+                );
+                assert!(
+                    text.contains("**Details**") && text.contains("**Answer**"),
+                    "evaluate must require details+answer verify table"
+                );
+                assert!(
+                    text.contains("Close with a statement, not a question"),
+                    "evaluate must close verify with a statement, not a question"
+                );
+                assert!(
+                    text.contains("if anything requires adjustment"),
+                    "evaluate must invite adjustment after verify table"
+                );
+                assert!(
+                    text.contains("missing_data"),
+                    "evaluate must mention missing_data"
+                );
+                assert!(
+                    !text.contains("copy help verbatim"),
+                    "evaluate must not force dumping help as the entire message"
+                );
+            }
+            "full" => {
+                assert!(
+                    text.contains("**Method: write as a policy consultant"),
+                    "full must include authoring method"
+                );
+                assert!(
+                    text.contains("Always paste the full Lemma source"),
+                    "full must require pasting full source at deliver"
+                );
+                assert!(
+                    text.contains("user can verify what was saved"),
+                    "full must require user verify of saved/loaded source"
+                );
+                assert!(
+                    text.contains("if anything requires adjustment"),
+                    "full must invite adjustment with a statement, not a confirm question"
+                );
+                assert!(
+                    text.contains("**Mandatory spec opening order:**"),
+                    "full must include syntax"
+                );
+                assert!(
+                    text.contains("## See also"),
+                    "full must include See also footer"
+                );
+                assert!(
+                    !text.contains("**Evaluating loaded specs**"),
+                    "full authoring guide must not include evaluate guide"
+                );
+            }
             "syntax" => {
                 assert!(
                     text.contains("**Mandatory spec opening order:**"),
@@ -2050,6 +3294,16 @@ fn test_mcp_guide_topics() {
                     "composition must include LemmaBase"
                 );
             }
+            "natural_language" => {
+                assert!(
+                    text.contains("**Natural language"),
+                    "natural_language must include heading"
+                );
+                assert!(
+                    text.contains("**Example C"),
+                    "natural_language must include Example C"
+                );
+            }
             "data" => {
                 assert!(text.contains("**Example D"), "data must include Example D");
                 assert!(text.contains("**Example E"), "data must include Example E");
@@ -2064,6 +3318,7 @@ fn test_mcp_guide_topics() {
             "rules" => {
                 assert!(text.contains("**Example F"), "rules must include Example F");
                 assert!(text.contains("**Example G"), "rules must include Example G");
+                assert!(text.contains("**Example H"), "rules must include Example H");
             }
             "veto" => {
                 assert!(text.contains("**Example I"), "veto must include Example I");
@@ -2078,13 +3333,135 @@ fn test_mcp_guide_topics() {
                     "anti_patterns must include inline comments example"
                 );
                 assert!(
-                    !text.contains("## Docs"),
-                    "anti_patterns must not include Docs footer"
+                    !text.contains("## See also"),
+                    "anti_patterns must not include footer"
                 );
             }
             _ => panic!("unknown topic: {topic}"),
         }
     }
+}
+
+#[test]
+fn test_mcp_guide_default_is_evaluate() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "guide",
+                    "arguments": {}
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("default guide text");
+    assert!(
+        text.contains("**Evaluating loaded specs**"),
+        "default guide (no topic) must be evaluate guide"
+    );
+    assert!(
+        text.contains("**User-facing language**"),
+        "default guide must include User-facing language"
+    );
+    assert!(
+        text.contains("Do not say bindings"),
+        "default guide must forbid saying bindings to the user"
+    );
+    assert!(
+        text.contains("Never ask the user what the policy means"),
+        "default guide must forbid asking the user to interpret policy"
+    );
+    assert!(
+        text.contains("Never dispose your interpretation as the truth"),
+        "default guide must forbid disposing interpretation as truth"
+    );
+    assert!(
+        text.contains("use *should*"),
+        "default guide must require should when judgment call cannot be answered"
+    );
+    assert!(
+        text.contains("A reply can close many fields"),
+        "default guide must teach multi-bind from replies"
+    );
+    assert!(
+        text.contains("When the rule answers (verify before done)"),
+        "default guide must require verify before done"
+    );
+    assert!(
+        text.contains("Close with a statement, not a question"),
+        "default guide must close verify with a statement, not a question"
+    );
+    assert!(
+        text.contains("if anything requires adjustment"),
+        "default guide must invite adjustment after verify table"
+    );
+    assert!(
+        !text.contains("copy help verbatim"),
+        "default guide must not force dumping help as the entire message"
+    );
+    assert!(
+        !text.contains("**Mandatory spec opening order:**"),
+        "default guide must not be the full authoring guide"
+    );
+}
+
+#[test]
+fn test_mcp_guide_full_topic_is_authoring() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "initialize", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "guide",
+                    "arguments": { "topic": "full" }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("full guide text");
+    assert!(
+        text.contains("**Mandatory spec opening order:**"),
+        "full guide must include syntax section"
+    );
+    assert!(
+        text.contains("**Method: write as a policy consultant"),
+        "full guide must include method section"
+    );
+    assert!(
+        !text.contains("**Evaluating loaded specs**"),
+        "full authoring guide must not include evaluate guide"
+    );
+    assert!(
+        !text.contains("**Consuming loaded specs**"),
+        "full authoring guide must not include old consuming section"
+    );
+    assert!(
+        text.contains("**Workflow checklist**"),
+        "full guide must include veto section"
+    );
+    assert!(
+        text.contains("## See also"),
+        "full guide must include See also footer"
+    );
 }
 
 #[test]

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.9.2"
+lemma-engine = "0.9.3"
 ```
 
 ### Minimal example
@@ -232,7 +232,7 @@ Build: `node build.js` (from `engine/packages/npm/`). See [packages/npm/README.m
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
 </dependency>
 ```
 

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.2", path = "..", features = ["registry"] }
+lemma = { package = "lemma-engine", version = "=0.9.3", path = "..", features = ["registry"] }
 serde_json.workspace = true
 
 # Native: tokio (multi-threaded) + tower-lsp with stdio transport

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "icon": "lemma_128.png",

--- a/engine/lsp/src/diagnostics.rs
+++ b/engine/lsp/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use lemma::Error;
+use lemma::{Error, Recommendation};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 /// Convert a byte offset to an LSP Position (0-based line and UTF-16 code unit column).
@@ -119,6 +119,45 @@ pub fn errors_to_diagnostics(
     }
 
     diagnostics
+}
+
+/// Convert quality Recommendations into LSP HINT diagnostics for a given file.
+pub fn recommendations_to_diagnostics(
+    recommendations: &[Recommendation],
+    text: &str,
+    file_attribute: &str,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for recommendation in recommendations {
+        if recommendation.source_location.source_type.to_string() != file_attribute {
+            continue;
+        }
+        diagnostics.push(single_recommendation_to_diagnostic(recommendation, text));
+    }
+    diagnostics
+}
+
+fn single_recommendation_to_diagnostic(recommendation: &Recommendation, text: &str) -> Diagnostic {
+    let source = &recommendation.source_location;
+    let start = source.span.start;
+    let end = source.span.end;
+    let range = if start == 0 && end == 0 {
+        default_range()
+    } else {
+        span_to_range(text, start, end)
+    };
+
+    Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::HINT),
+        code: None,
+        code_description: None,
+        source: Some("lemma".to_string()),
+        message: recommendation.to_string(),
+        related_information: None,
+        tags: None,
+        data: None,
+    }
 }
 
 #[cfg(test)]
@@ -258,5 +297,40 @@ mod tests {
             errors_to_diagnostics(&[error_in_file, error_in_other_file], text, "file_a.lemma");
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("bad syntax"));
+    }
+
+    #[test]
+    fn recommendations_map_to_hint_severity() {
+        use lemma::{RecommendationKind, Source, SourceType, Span};
+        use std::sync::Arc;
+
+        let recommendation = Recommendation {
+            kind: RecommendationKind::SpecMissingCommentary,
+            repository: None,
+            spec: "pricing".to_string(),
+            source_location: Source::new(
+                SourceType::Path(Arc::new(std::path::PathBuf::from("pricing.lemma"))),
+                Span {
+                    start: 0,
+                    end: 0,
+                    line: 1,
+                    col: 0,
+                },
+            ),
+        };
+        let diagnostics =
+            recommendations_to_diagnostics(&[recommendation], "spec pricing", "pricing.lemma");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::HINT));
+        assert!(diagnostics[0].message.contains("commentary"));
+    }
+
+    #[test]
+    fn errors_keep_error_severity_alongside_hints() {
+        let error =
+            Error::resource_limit_exceeded("limit_a", "100", "200", "fix a", None, None, None);
+        let diagnostics = errors_to_diagnostics(&[error], "spec test", "test.lemma");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     }
 }

--- a/engine/lsp/src/server.rs
+++ b/engine/lsp/src/server.rs
@@ -33,11 +33,16 @@ async fn publish_workspace_diagnostics(client: &Client, workspace: &WorkspaceMod
         }
     };
     for file_diag in file_diagnostics {
-        let lsp_diagnostics = diagnostics::errors_to_diagnostics(
+        let mut lsp_diagnostics = diagnostics::errors_to_diagnostics(
             &file_diag.errors,
             &file_diag.text,
             &file_diag.attribute,
         );
+        lsp_diagnostics.extend(diagnostics::recommendations_to_diagnostics(
+            &file_diag.recommendations,
+            &file_diag.text,
+            &file_diag.attribute,
+        ));
         client
             .publish_diagnostics(file_diag.url, lsp_diagnostics, None)
             .await;

--- a/engine/lsp/src/workspace.rs
+++ b/engine/lsp/src/workspace.rs
@@ -1,4 +1,4 @@
-use lemma::{parse, Error, ParseResult, ResourceLimits, SourceType};
+use lemma::{parse, Error, ParseResult, Recommendation, ResourceLimits, SourceType};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -36,6 +36,8 @@ pub struct FileDiagnostics {
     pub attribute: String,
     /// All errors for this file (parse errors + planning errors).
     pub errors: Vec<Error>,
+    /// Quality Recommendations for this file (advisory only).
+    pub recommendations: Vec<Recommendation>,
 }
 
 /// In-memory workspace model.
@@ -197,6 +199,7 @@ impl WorkspaceModel {
     pub fn validate_workspace(&self) -> Vec<FileDiagnostics> {
         let mut engine = lemma::Engine::new();
         let load_errors_by_attribute = self.load_tracked_files_into(&mut engine);
+        let recommendations = engine.quality();
 
         let mut results = Vec::new();
         for (attribute, tracked) in &self.files {
@@ -207,11 +210,17 @@ impl WorkspaceModel {
             if let Some(load_errors) = load_errors_by_attribute.get(attribute) {
                 file_errors.extend(load_errors.iter().cloned());
             }
+            let file_recommendations: Vec<Recommendation> = recommendations
+                .iter()
+                .filter(|r| r.source_location.source_type.to_string() == *attribute)
+                .cloned()
+                .collect();
             results.push(FileDiagnostics {
                 url: tracked.url.clone(),
                 text: tracked.text.clone(),
                 attribute: attribute.clone(),
                 errors: file_errors,
+                recommendations: file_recommendations,
             });
         }
         results

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.9.2"
+  @version "0.9.3"
   @source_url "https://github.com/lemma/lemma"
 
   def project do

--- a/engine/packages/maven/README.md
+++ b/engine/packages/maven/README.md
@@ -6,7 +6,7 @@ JVM binding for the Lemma rules engine. Coordinates: `com.lemmabase:lemma-engine
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
 </dependency>
 ```
 

--- a/engine/packages/maven/pom.xml
+++ b/engine/packages/maven/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
   <packaging>jar</packaging>
 
   <name>Lemma Engine</name>

--- a/engine/packages/npm/README.md
+++ b/engine/packages/npm/README.md
@@ -119,6 +119,7 @@ A pre-wired Monaco adapter ships at `@lemmabase/lemma-engine/monaco`.
 | `source(repo, spec?, effective?)` | Canonical Lemma source text. Omit `spec` for whole repository. |
 | `run({ spec, repository?, effective?, data?, rules?, explain? })` | Evaluate. Omit `rules` for all rules; pass a non-empty array to scope. `[]` errors. Returns a `Response`. `explain: true` adds per-rule explanation trees. |
 | `remove(repo, name, effective?)` | Remove a temporal spec slice. |
+| `update(repo, name, effective?, code, attribute?)` | Replace a temporal spec slice (atomic remove + load). |
 | `limits()` | Resource limits for this engine. |
 | `format(code, attribute?)` | Canonical formatting; throws `EngineError` on parse error. |
 

--- a/engine/packages/npm/lemma.d.ts
+++ b/engine/packages/npm/lemma.d.ts
@@ -60,6 +60,18 @@ declare module './lemma.bindings.js' {
       effective?: string | null,
     ): void;
 
+    /**
+     * Replace a temporal spec slice with new source (atomic remove + load).
+     * `attribute` is the source label (path or `@owner/repo`); omit for volatile.
+     */
+    update(
+      repository: string | null | undefined,
+      spec: string,
+      effective: string | null | undefined,
+      code: string,
+      attribute?: string | null,
+    ): void;
+
     /** Resource limits configured for this engine. */
     limits(): ResourceLimits;
 

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -253,6 +253,22 @@ impl Context {
 
 // ─── Engine ──────────────────────────────────────────────────────────
 
+/// One mutation in a transactional [`Engine::apply`] batch.
+///
+/// Removes are applied before loads so replace = `[Remove, Load]` for the same
+/// identity cannot hit the duplicate-spec error or a mid-batch missing-dep replan.
+enum Mutation {
+    Remove {
+        repository: Option<String>,
+        spec: String,
+        effective: Option<DateTimeValue>,
+    },
+    Load {
+        source_type: SourceType,
+        code: String,
+    },
+}
+
 /// Engine for evaluating Lemma rules.
 ///
 /// Pure Rust implementation that evaluates Lemma specs directly from the AST.
@@ -286,11 +302,11 @@ impl Engine {
             limits,
         };
         engine
-            .add_sources_inner(
-                IndexMap::from([(
-                    SourceType::Dependency(EMBEDDED_STDLIB_REPOSITORY.to_string()),
-                    crate::stdlib::UNITS_LEMMA.to_string(),
-                )]),
+            .apply(
+                vec![Mutation::Load {
+                    source_type: SourceType::Dependency(EMBEDDED_STDLIB_REPOSITORY.to_string()),
+                    code: crate::stdlib::UNITS_LEMMA.to_string(),
+                }],
                 true,
             )
             .expect("BUG: embedded stdlib must load");
@@ -311,23 +327,62 @@ impl Engine {
         &mut self,
         sources: impl IntoIterator<Item = (SourceType, impl Into<String>)>,
     ) -> Result<(), Errors> {
-        let mut map = IndexMap::new();
-        let mut attempted = HashMap::new();
-        for (source_type, code) in sources {
-            let code = code.into();
-            if map.contains_key(&source_type) {
-                return Err(Errors {
-                    errors: vec![Error::request(
-                        format!("Duplicate source key: {source_type}"),
-                        None::<String>,
-                    )],
-                    sources: attempted,
-                });
-            }
-            attempted.insert(source_type.clone(), code.clone());
-            map.insert(source_type, code);
-        }
-        self.add_sources_inner(map, false)
+        let mutations = sources
+            .into_iter()
+            .map(|(source_type, code)| Mutation::Load {
+                source_type,
+                code: code.into(),
+            })
+            .collect();
+        self.apply(mutations, false)
+    }
+
+    /// Replace one temporal spec slice with new source in a single planning pass.
+    ///
+    /// Equivalent to remove then load, but atomic: dependents of `spec` stay valid
+    /// across the swap when the new source still satisfies them.
+    pub fn update(
+        &mut self,
+        repository: Option<&str>,
+        spec: &str,
+        effective: Option<&DateTimeValue>,
+        source_type: SourceType,
+        code: String,
+    ) -> Result<(), Errors> {
+        self.apply(
+            vec![
+                Mutation::Remove {
+                    repository: repository.map(str::to_string),
+                    spec: spec.to_string(),
+                    effective: effective.cloned(),
+                },
+                Mutation::Load { source_type, code },
+            ],
+            false,
+        )
+    }
+
+    /// Remove a temporal spec slice and replan remaining specs.
+    pub fn remove(
+        &mut self,
+        repository: Option<&str>,
+        spec: &str,
+        effective: Option<&DateTimeValue>,
+    ) -> Result<(), Error> {
+        self.apply(
+            vec![Mutation::Remove {
+                repository: repository.map(str::to_string),
+                spec: spec.to_string(),
+                effective: effective.cloned(),
+            }],
+            false,
+        )
+        .map_err(|errs| {
+            errs.errors
+                .into_iter()
+                .next()
+                .expect("BUG: apply Errors must contain at least one error")
+        })
     }
 
     /// Every loaded repository in insertion order (workspace, embedded stdlib [`EMBEDDED_STDLIB_REPOSITORY`], dependencies).
@@ -528,35 +583,6 @@ impl Engine {
         Ok(response)
     }
 
-    pub fn remove(
-        &mut self,
-        repository: Option<&str>,
-        spec: &str,
-        effective: Option<&DateTimeValue>,
-    ) -> Result<(), Error> {
-        let effective = self.effective_or_now(effective);
-        let repository_arc = match repository {
-            Some(q) => self.context.find_repository(q).ok_or_else(|| {
-                Error::request_not_found(
-                    format!("Repository '{q}' not loaded"),
-                    Some("List repositories with `lemma list` after loading your workspace"),
-                )
-            })?,
-            None => self.context.workspace(),
-        };
-        let spec_to_remove = self.get_spec(spec, repository, Some(&effective))?.clone();
-        self.context.remove_spec(&repository_arc, &spec_to_remove);
-        let result = crate::planning::plan(&self.context, &self.limits);
-        if let Some(error) = result.errors.into_iter().next() {
-            self.context
-                .insert_spec(Arc::clone(&repository_arc), spec_to_remove)
-                .expect("BUG: restore removed spec for rollback");
-            return Err(error);
-        }
-        self.plans.replace(result.plans);
-        Ok(())
-    }
-
     fn format_repository_source(&self, repository: Option<&str>) -> Result<String, Error> {
         let repo_arc = self.resolve_repository(repository)?;
         let mut all_specs: Vec<&LemmaSpec> = self
@@ -628,13 +654,89 @@ impl Engine {
         effective.cloned().unwrap_or_else(DateTimeValue::now)
     }
 
-    /// `sources` is order-preserving so multi-source parse errors are reported in submission
-    /// order rather than scrambled by hash iteration.
-    fn add_sources_inner(
-        &mut self,
+    fn reserved_stdlib_error(source: Option<crate::parsing::source::Source>) -> Error {
+        Error::validation(
+            format!(
+                "Repository '{EMBEDDED_STDLIB_REPOSITORY}' is reserved for the embedded standard library and cannot be loaded via load; use @owner/repo qualifiers (e.g. '@iso/countries'), not the reserved 'lemma' repository"
+            ),
+            source,
+            Some(
+                "Load registry dependencies with @owner/repo qualifiers, not the reserved 'lemma' stdlib repository"
+                    .to_string(),
+            ),
+        )
+    }
+
+    fn resource_limit_errors(
+        name: &str,
+        limit: impl ToString,
+        actual: impl ToString,
+        hint: &str,
         sources: IndexMap<SourceType, String>,
-        embedded_stdlib: bool,
-    ) -> Result<(), Errors> {
+    ) -> Errors {
+        Errors {
+            errors: vec![Error::resource_limit_exceeded(
+                name,
+                limit.to_string(),
+                actual.to_string(),
+                hint,
+                None::<crate::parsing::source::Source>,
+                None,
+                None,
+            )],
+            sources: sources.into_iter().collect(),
+        }
+    }
+
+    /// Apply removes then loads in one planning pass. Rolls back the whole batch on failure.
+    ///
+    /// Load sources are order-preserving so multi-source parse errors are reported in
+    /// submission order rather than scrambled by hash iteration.
+    fn apply(&mut self, mutations: Vec<Mutation>, embedded_stdlib: bool) -> Result<(), Errors> {
+        let mut sources: IndexMap<SourceType, String> = IndexMap::new();
+        let mut errors: Vec<Error> = Vec::new();
+        let mut to_restore: Vec<(Arc<LemmaRepository>, LemmaSpec)> = Vec::new();
+
+        for mutation in mutations {
+            match mutation {
+                Mutation::Remove {
+                    repository,
+                    spec,
+                    effective,
+                } => {
+                    let repo_ref = repository.as_deref();
+                    let effective_dt = self.effective_or_now(effective.as_ref());
+                    match self.get_spec(&spec, repo_ref, Some(&effective_dt)) {
+                        Ok(spec_to_remove) => {
+                            let repository_arc = self
+                                .resolve_repository(repo_ref)
+                                .expect("BUG: get_spec succeeded so repository exists");
+                            to_restore.push((repository_arc, spec_to_remove.clone()));
+                        }
+                        Err(e) => errors.push(e),
+                    }
+                }
+                Mutation::Load { source_type, code } => {
+                    if sources.insert(source_type.clone(), code).is_some() {
+                        return Err(Errors {
+                            errors: vec![Error::request(
+                                format!("Duplicate source key: {source_type}"),
+                                None::<String>,
+                            )],
+                            sources: sources.into_iter().collect(),
+                        });
+                    }
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Errors {
+                errors,
+                sources: sources.into_iter().collect(),
+            });
+        }
+
         for st in sources.keys() {
             match st {
                 SourceType::Path(p) if p.as_os_str().to_string_lossy().trim().is_empty() => {
@@ -659,65 +761,45 @@ impl Engine {
                     if !embedded_stdlib && id == EMBEDDED_STDLIB_REPOSITORY =>
                 {
                     return Err(Errors {
-                        errors: vec![Error::validation(
-                            format!(
-                                "Repository '{EMBEDDED_STDLIB_REPOSITORY}' is reserved for the embedded standard library and cannot be loaded via load; use @owner/repo qualifiers (e.g. '@iso/countries'), not the reserved 'lemma' repository"
-                            ),
-                            None,
-                            Some("Load registry dependencies with @owner/repo qualifiers, not the reserved 'lemma' stdlib repository".to_string()),
-                        )],
+                        errors: vec![Self::reserved_stdlib_error(None)],
                         sources: HashMap::new(),
                     });
                 }
                 _ => {}
             }
         }
-        if !embedded_stdlib {
+        if !embedded_stdlib && !sources.is_empty() {
             let limits = &self.limits;
             if sources.len() > limits.max_sources {
-                return Err(Errors {
-                    errors: vec![Error::resource_limit_exceeded(
-                        "max_sources",
-                        limits.max_sources.to_string(),
-                        sources.len().to_string(),
-                        "Reduce the number of paths or sources in one load",
-                        None::<crate::parsing::source::Source>,
-                        None,
-                        None,
-                    )],
-                    sources: sources.into_iter().collect(),
-                });
+                return Err(Self::resource_limit_errors(
+                    "max_sources",
+                    limits.max_sources,
+                    sources.len(),
+                    "Reduce the number of paths or sources in one load",
+                    sources,
+                ));
             }
             let total_loaded_bytes: usize = sources.values().map(|s| s.len()).sum();
             if total_loaded_bytes > limits.max_loaded_bytes {
-                return Err(Errors {
-                    errors: vec![Error::resource_limit_exceeded(
-                        "max_loaded_bytes",
-                        limits.max_loaded_bytes.to_string(),
-                        total_loaded_bytes.to_string(),
-                        "Load fewer or smaller sources",
-                        None::<crate::parsing::source::Source>,
-                        None,
-                        None,
-                    )],
-                    sources: sources.into_iter().collect(),
-                });
+                return Err(Self::resource_limit_errors(
+                    "max_loaded_bytes",
+                    limits.max_loaded_bytes,
+                    total_loaded_bytes,
+                    "Load fewer or smaller sources",
+                    sources,
+                ));
             }
-            for code in sources.values() {
-                if code.len() > limits.max_source_size_bytes {
-                    return Err(Errors {
-                        errors: vec![Error::resource_limit_exceeded(
-                            "max_source_size_bytes",
-                            limits.max_source_size_bytes.to_string(),
-                            code.len().to_string(),
-                            "Use a smaller source text or increase limit",
-                            None::<crate::parsing::source::Source>,
-                            None,
-                            None,
-                        )],
-                        sources: sources.into_iter().collect(),
-                    });
-                }
+            if let Some(code) = sources
+                .values()
+                .find(|code| code.len() > limits.max_source_size_bytes)
+            {
+                return Err(Self::resource_limit_errors(
+                    "max_source_size_bytes",
+                    limits.max_source_size_bytes,
+                    code.len(),
+                    "Use a smaller source text or increase limit",
+                    sources,
+                ));
             }
         }
 
@@ -726,7 +808,6 @@ impl Engine {
         } else {
             &self.limits
         };
-        let mut errors: Vec<Error> = Vec::new();
         let mut staged: Vec<(SourceType, Arc<LemmaRepository>, LemmaSpec)> = Vec::new();
 
         for (source_id, code) in &sources {
@@ -767,16 +848,7 @@ impl Engine {
                                     col: 0,
                                 },
                             );
-                            errors.push(Error::validation(
-                                format!(
-                                    "Repository '{EMBEDDED_STDLIB_REPOSITORY}' is reserved for the embedded standard library and cannot be loaded via load; use @owner/repo qualifiers (e.g. '@iso/countries'), not the reserved 'lemma' repository"
-                                ),
-                                Some(source),
-                                Some(
-                                    "Load registry dependencies with @owner/repo qualifiers, not the reserved 'lemma' stdlib repository"
-                                        .to_string(),
-                                ),
-                            ));
+                            errors.push(Self::reserved_stdlib_error(Some(source)));
                             continue;
                         }
                         for spec in specs {
@@ -793,6 +865,10 @@ impl Engine {
                 errors,
                 sources: sources.into_iter().collect(),
             });
+        }
+
+        for (repo, spec) in &to_restore {
+            self.context.remove_spec(repo, spec);
         }
 
         let mut inserted: Vec<(Arc<LemmaRepository>, String, EffectiveDate)> = Vec::new();
@@ -817,13 +893,7 @@ impl Engine {
                         Some(source),
                         None::<String>,
                     ));
-                    for (repo, inserted_name, inserted_effective) in inserted.iter().rev() {
-                        self.context.remove_spec_by_identity(
-                            repo,
-                            inserted_name,
-                            inserted_effective.as_ref(),
-                        );
-                    }
+                    self.rollback_apply(&inserted, &to_restore);
                     return Err(Errors {
                         errors,
                         sources: sources.into_iter().collect(),
@@ -834,13 +904,7 @@ impl Engine {
 
         let result = crate::planning::plan(&self.context, &self.limits);
         if !result.errors.is_empty() {
-            for (repo, inserted_name, inserted_effective) in inserted.iter().rev() {
-                self.context.remove_spec_by_identity(
-                    repo,
-                    inserted_name,
-                    inserted_effective.as_ref(),
-                );
-            }
+            self.rollback_apply(&inserted, &to_restore);
             return Err(Errors {
                 errors: result.errors,
                 sources: sources.into_iter().collect(),
@@ -849,6 +913,22 @@ impl Engine {
 
         self.plans.replace(result.plans);
         Ok(())
+    }
+
+    fn rollback_apply(
+        &mut self,
+        inserted: &[(Arc<LemmaRepository>, String, EffectiveDate)],
+        removed: &[(Arc<LemmaRepository>, LemmaSpec)],
+    ) {
+        for (repo, inserted_name, inserted_effective) in inserted.iter().rev() {
+            self.context
+                .remove_spec_by_identity(repo, inserted_name, inserted_effective.as_ref());
+        }
+        for (repo, spec) in removed.iter().rev() {
+            self.context
+                .insert_spec(Arc::clone(repo), spec.clone())
+                .expect("BUG: restore removed spec for rollback");
+        }
     }
 
     /// Active [`LemmaSpec`] slice for `name` at the resolved effective instant in `repository`.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod limits;
 pub(crate) mod literals;
 pub(crate) mod parsing;
 pub(crate) mod planning;
+pub mod quality;
 pub(crate) mod registry;
 pub mod result_value;
 pub(crate) mod spec_set_id;
@@ -73,6 +74,7 @@ pub use parsing::ast::{
 pub use parsing::lexer::{Lexer, TokenKind};
 pub use parsing::source::Source;
 pub use parsing::{parse, ParseResult};
+pub use quality::{Recommendation, RecommendationKind};
 
 // Tier 2 — registry network (feature-gated)
 #[cfg(feature = "registry")]

--- a/engine/src/quality.rs
+++ b/engine/src/quality.rs
@@ -1,0 +1,417 @@
+//! Structural quality analysis over loaded specs.
+//!
+//! Advisory only: never affects planning or evaluation. Distinct from [`Error`] /
+//! Veto / panic.
+
+use crate::literals::Value;
+use crate::parsing::ast::{
+    DataValue, Expression, ExpressionKind, LemmaData, LemmaRule, LemmaSpec, ParentType,
+    PrimitiveKind, TypeConstraintCommand,
+};
+use crate::parsing::source::{Source, SourceType};
+use crate::Engine;
+use std::fmt;
+
+/// Kind of structural quality Recommendation.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum RecommendationKind {
+    SpecMissingCommentary,
+    SpecMissingEffectiveDate,
+    DataMissingHelp { data: String },
+    TextDataWithoutOptions { data: String },
+    OpenInputWithoutSuggestion { data: String },
+    VetoAsRejectionCascade { rule: String },
+}
+
+/// One structural quality Recommendation from [`Engine::quality`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Recommendation {
+    pub kind: RecommendationKind,
+    pub repository: Option<String>,
+    pub spec: String,
+    pub source_location: Source,
+}
+
+impl fmt::Display for Recommendation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            RecommendationKind::SpecMissingCommentary => write!(
+                f,
+                "Spec '{}' has no commentary block. Add `\"\"\"...\"\"\"` immediately after the spec line so callers know what this policy covers.",
+                self.spec
+            ),
+            RecommendationKind::SpecMissingEffectiveDate => write!(
+                f,
+                "Spec '{}' has no effective date. If this encodes a dated policy, declare `spec {} YYYY-MM-DD` so temporal history stays answerable; if the policy is timeless, confirm with the author.",
+                self.spec, self.spec
+            ),
+            RecommendationKind::DataMissingHelp { data } => write!(
+                f,
+                "`{data}` has no `-> help`. Where does a user find this value? Confirm with the author, then document it."
+            ),
+            RecommendationKind::TextDataWithoutOptions { data } => write!(
+                f,
+                "`{data}` accepts any text. If the policy defines a closed set, declare them with `-> option`; if free text is intended, confirm with the author."
+            ),
+            RecommendationKind::OpenInputWithoutSuggestion { data } => write!(
+                f,
+                "`{data}` is an open input with no `-> suggest`. If a common default exists in the policy, declare it as a suggestion (UI hint only); otherwise confirm with the author."
+            ),
+            RecommendationKind::VetoAsRejectionCascade { rule } => write!(
+                f,
+                "`{rule}` defaults to a boolean and overrides only with veto. Denial is a valid answer (`false`), not an unanswerable question (veto). Prefer boolean sub-rules composed with `and`; confirm the intended outcome with the author."
+            ),
+        }
+    }
+}
+
+impl Engine {
+    /// Structural quality Recommendations across all loaded specs and their relationships.
+    ///
+    /// Advisory only: never affects planning or evaluation. Skips dependency
+    /// repositories (embedded stdlib and `@owner/repo` imports).
+    #[must_use]
+    pub fn quality(&self) -> Vec<Recommendation> {
+        let mut out = Vec::new();
+        for (repository, inner) in self.context.repositories().iter() {
+            if repository.dependency.is_some() {
+                continue;
+            }
+            let repo_name = repository.name.clone();
+            for (_, spec_set) in inner.iter() {
+                for spec in spec_set.iter_specs() {
+                    analyze_spec(repo_name.clone(), spec, &mut out);
+                }
+            }
+        }
+        out.sort_by(|a, b| {
+            (
+                a.repository.as_deref().unwrap_or(""),
+                a.spec.as_str(),
+                a.source_location.span.line,
+                a.source_location.span.col,
+                a.source_location.span.start,
+            )
+                .cmp(&(
+                    b.repository.as_deref().unwrap_or(""),
+                    b.spec.as_str(),
+                    b.source_location.span.line,
+                    b.source_location.span.col,
+                    b.source_location.span.start,
+                ))
+        });
+        out
+    }
+}
+
+fn analyze_spec(repository: Option<String>, spec: &LemmaSpec, out: &mut Vec<Recommendation>) {
+    let loc = spec_location(spec);
+    if spec.commentary.is_none() {
+        out.push(Recommendation {
+            kind: RecommendationKind::SpecMissingCommentary,
+            repository: repository.clone(),
+            spec: spec.name.clone(),
+            source_location: loc.clone(),
+        });
+    }
+    if spec.effective_from.is_origin() {
+        out.push(Recommendation {
+            kind: RecommendationKind::SpecMissingEffectiveDate,
+            repository: repository.clone(),
+            spec: spec.name.clone(),
+            source_location: loc,
+        });
+    }
+
+    for data in &spec.data {
+        analyze_data(repository.clone(), &spec.name, data, out);
+    }
+    for rule in &spec.rules {
+        analyze_rule(repository.clone(), &spec.name, rule, out);
+    }
+}
+
+fn spec_location(spec: &LemmaSpec) -> Source {
+    Source::new(
+        spec.source_type.clone().unwrap_or(SourceType::Volatile),
+        crate::parsing::ast::Span {
+            start: 0,
+            end: 0,
+            line: spec.start_line,
+            col: 0,
+        },
+    )
+}
+
+fn analyze_data(
+    repository: Option<String>,
+    spec_name: &str,
+    data: &LemmaData,
+    out: &mut Vec<Recommendation>,
+) {
+    let DataValue::Definition {
+        base,
+        constraints,
+        value,
+    } = &data.value
+    else {
+        return;
+    };
+
+    let name = data.reference.name.clone();
+    let constraints = constraints.as_deref().unwrap_or(&[]);
+    let has_help = constraints
+        .iter()
+        .any(|(c, _)| matches!(c, TypeConstraintCommand::Help));
+    let has_option = constraints.iter().any(|(c, _)| {
+        matches!(
+            c,
+            TypeConstraintCommand::Option | TypeConstraintCommand::Options
+        )
+    });
+    let has_suggest = constraints
+        .iter()
+        .any(|(c, _)| matches!(c, TypeConstraintCommand::Suggest));
+
+    if !has_help {
+        out.push(Recommendation {
+            kind: RecommendationKind::DataMissingHelp { data: name.clone() },
+            repository: repository.clone(),
+            spec: spec_name.to_string(),
+            source_location: data.source_location.clone(),
+        });
+    }
+
+    if is_primitive_text(base.as_ref()) && !has_option {
+        out.push(Recommendation {
+            kind: RecommendationKind::TextDataWithoutOptions { data: name.clone() },
+            repository: repository.clone(),
+            spec: spec_name.to_string(),
+            source_location: data.source_location.clone(),
+        });
+    }
+
+    if value.is_none() && !has_suggest {
+        out.push(Recommendation {
+            kind: RecommendationKind::OpenInputWithoutSuggestion { data: name },
+            repository,
+            spec: spec_name.to_string(),
+            source_location: data.source_location.clone(),
+        });
+    }
+}
+
+fn is_primitive_text(base: Option<&ParentType>) -> bool {
+    matches!(
+        base,
+        Some(ParentType::Primitive {
+            primitive: PrimitiveKind::Text
+        })
+    )
+}
+
+fn analyze_rule(
+    repository: Option<String>,
+    spec_name: &str,
+    rule: &LemmaRule,
+    out: &mut Vec<Recommendation>,
+) {
+    if !is_boolean_literal(&rule.expression) {
+        return;
+    }
+    if rule.unless_clauses.is_empty() {
+        return;
+    }
+    let all_veto = rule
+        .unless_clauses
+        .iter()
+        .all(|u| matches!(u.result.kind, ExpressionKind::Veto(_)));
+    if !all_veto {
+        return;
+    }
+    out.push(Recommendation {
+        kind: RecommendationKind::VetoAsRejectionCascade {
+            rule: rule.name.clone(),
+        },
+        repository,
+        spec: spec_name.to_string(),
+        source_location: rule.source_location.clone(),
+    });
+}
+
+fn is_boolean_literal(expr: &Expression) -> bool {
+    matches!(&expr.kind, ExpressionKind::Literal(Value::Boolean(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parsing::source::SourceType;
+
+    fn load(code: &str) -> Engine {
+        let mut engine = Engine::new();
+        engine
+            .load([(
+                SourceType::Path(std::sync::Arc::new(std::path::PathBuf::from("test.lemma"))),
+                code.to_string(),
+            )])
+            .expect("BUG: test source must load");
+        engine
+    }
+
+    fn kinds(engine: &Engine) -> Vec<RecommendationKind> {
+        engine.quality().into_iter().map(|r| r.kind).collect()
+    }
+
+    #[test]
+    fn missing_commentary_and_effective_date() {
+        let engine = load("spec pricing\ndata x: number\nrule y: x\n");
+        let ks = kinds(&engine);
+        assert!(ks.contains(&RecommendationKind::SpecMissingCommentary));
+        assert!(ks.contains(&RecommendationKind::SpecMissingEffectiveDate));
+    }
+
+    #[test]
+    fn clean_spec_has_no_recommendations() {
+        let engine = load(
+            r#"spec pricing 2026-01-01
+"""
+Bulk pricing.
+"""
+
+data qty: number
+  -> minimum 0
+  -> help "Order quantity."
+  -> suggest 10
+
+rule total: qty
+"#,
+        );
+        assert!(engine.quality().is_empty(), "got: {:?}", engine.quality());
+    }
+
+    #[test]
+    fn data_missing_help() {
+        let engine = load(
+            r#"spec pricing 2026-01-01
+"""
+x
+"""
+
+data qty: number -> suggest 1
+rule total: qty
+"#,
+        );
+        assert!(kinds(&engine).iter().any(|k| matches!(
+            k,
+            RecommendationKind::DataMissingHelp { data } if data == "qty"
+        )));
+    }
+
+    #[test]
+    fn text_without_options() {
+        let engine = load(
+            r#"spec pricing 2026-01-01
+"""
+x
+"""
+
+data status: text
+  -> help "Status."
+  -> suggest "active"
+rule ok: status is "active"
+"#,
+        );
+        assert!(kinds(&engine).iter().any(|k| matches!(
+            k,
+            RecommendationKind::TextDataWithoutOptions { data } if data == "status"
+        )));
+    }
+
+    #[test]
+    fn open_input_without_suggestion() {
+        let engine = load(
+            r#"spec pricing 2026-01-01
+"""
+x
+"""
+
+data qty: number
+  -> help "Quantity."
+rule total: qty
+"#,
+        );
+        assert!(kinds(&engine).iter().any(|k| matches!(
+            k,
+            RecommendationKind::OpenInputWithoutSuggestion { data } if data == "qty"
+        )));
+    }
+
+    #[test]
+    fn veto_as_rejection_cascade() {
+        let engine = load(
+            r#"spec eligibility 2026-01-01
+"""
+Age gate.
+"""
+
+data age: number
+  -> help "Customer age."
+  -> suggest 30
+
+rule is_eligible: true
+  unless age < 18 then veto "Must be 18+"
+"#,
+        );
+        assert!(kinds(&engine).iter().any(|k| matches!(
+            k,
+            RecommendationKind::VetoAsRejectionCascade { rule } if rule == "is_eligible"
+        )));
+    }
+
+    #[test]
+    fn boolean_denial_is_not_cascade() {
+        let engine = load(
+            r#"spec eligibility 2026-01-01
+"""
+Age gate.
+"""
+
+data age: number
+  -> help "Customer age."
+  -> suggest 30
+
+rule is_eligible: true
+  unless age < 18 then false
+"#,
+        );
+        assert!(!kinds(&engine)
+            .iter()
+            .any(|k| matches!(k, RecommendationKind::VetoAsRejectionCascade { .. })));
+    }
+
+    #[test]
+    fn stdlib_dependency_not_reported() {
+        let engine = load(
+            r#"spec ship 2026-01-01
+"""
+Weight check.
+"""
+
+uses lemma units
+
+data package_weight: units.mass
+  -> help "Package weight."
+  -> suggest 1 kilogram
+
+rule heavy: package_weight > 20 kilogram
+"#,
+        );
+        let recs = engine.quality();
+        assert!(
+            recs.iter().all(|r| r.spec != "units"),
+            "stdlib units must not appear: {recs:?}"
+        );
+    }
+}

--- a/engine/src/wasm.rs
+++ b/engine/src/wasm.rs
@@ -175,19 +175,42 @@ impl WasmEngine {
         spec: &str,
         effective: Option<String>,
     ) -> Result<(), JsValue> {
-        let effective_dt = match effective {
-            None => None,
-            Some(s) => {
-                Some(crate::resolve_effective(Some(s.as_str())).map_err(|e| error_to_js(&e))?)
-            }
-        };
-        let repo = repository
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
+        let (repo, effective_dt) = parse_repo_and_effective(repository.as_ref(), effective)?;
         self.engine
             .remove(repo, spec, effective_dt.as_ref())
             .map_err(|e| error_to_js(&e))
+    }
+
+    /// Replace a temporal spec slice with new source (atomic remove + load).
+    ///
+    /// `attribute` is the source label (path or `@owner/repo`). Omit for a volatile source.
+    #[wasm_bindgen(js_name = update)]
+    pub fn update_wasm(
+        &mut self,
+        repository: Option<String>,
+        spec: &str,
+        effective: Option<String>,
+        code: &str,
+        attribute: Option<String>,
+    ) -> Result<(), JsValue> {
+        let (repo, effective_dt) = parse_repo_and_effective(repository.as_ref(), effective)?;
+        let source_type = match attribute
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => SourceType::Volatile,
+            Some(label) => SourceType::from_binding_label(label).map_err(js_err)?,
+        };
+        self.engine
+            .update(
+                repo,
+                spec,
+                effective_dt.as_ref(),
+                source_type,
+                code.to_string(),
+            )
+            .map_err(serialize_load_errors)
     }
 
     /// Resource limits configured for this engine.
@@ -214,6 +237,21 @@ impl WasmEngine {
             Err(e) => Err(error_to_js(&e)),
         }
     }
+}
+
+fn parse_repo_and_effective(
+    repository: Option<&String>,
+    effective: Option<String>,
+) -> Result<(Option<&str>, Option<crate::DateTimeValue>), JsValue> {
+    let effective_dt = match effective {
+        None => None,
+        Some(s) => Some(crate::resolve_effective(Some(s.as_str())).map_err(|e| error_to_js(&e))?),
+    };
+    let repo = repository
+        .map(|s| s.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    Ok((repo, effective_dt))
 }
 
 /// Options for [`WasmEngine::run`].

--- a/engine/tests/transactional_load_remove.rs
+++ b/engine/tests/transactional_load_remove.rs
@@ -111,3 +111,109 @@ rule total: d.value
         .run(None, "consumer", Some(&now), HashMap::new(), None, false)
         .expect("consumer still runs after failed remove");
 }
+
+#[test]
+fn update_replaces_spec_with_dependents() {
+    let mut engine = Engine::new();
+    engine
+        .load([(
+            SourceType::Volatile,
+            r#"
+spec dep
+data value: 10
+rule out: value
+
+spec consumer
+uses d: dep
+rule total: d.value
+"#
+            .to_string(),
+        )])
+        .expect("load dep + consumer");
+
+    let now = DateTimeValue::now();
+    engine
+        .update(
+            None,
+            "dep",
+            Some(&now),
+            SourceType::Volatile,
+            r#"
+spec dep
+data value: 20
+rule out: value
+"#
+            .to_string(),
+        )
+        .expect("update dep while consumer depends on it");
+
+    let response = engine
+        .run(None, "consumer", Some(&now), HashMap::new(), None, false)
+        .expect("consumer runs after update");
+    let total = response
+        .results
+        .get("total")
+        .expect("total rule")
+        .display()
+        .expect("total display");
+    assert_eq!(total, "20", "consumer must see updated dep value");
+}
+
+#[test]
+fn update_rolls_back_when_new_source_invalid() {
+    let mut engine = Engine::new();
+    engine
+        .load([(
+            SourceType::Volatile,
+            r#"
+spec dep
+data value: 10
+rule out: value
+
+spec consumer
+uses d: dep
+rule total: d.value
+"#
+            .to_string(),
+        )])
+        .expect("load dep + consumer");
+
+    let now = DateTimeValue::now();
+    let before = engine
+        .run(None, "consumer", Some(&now), HashMap::new(), None, false)
+        .expect("consumer runs before");
+
+    let bad = engine.update(
+        None,
+        "dep",
+        Some(&now),
+        SourceType::Volatile,
+        r#"
+spec dep
+uses missing: nonexistent_spec
+data value: 99
+rule out: value + missing.x
+"#
+        .to_string(),
+    );
+    assert!(bad.is_err(), "update with broken deps must fail");
+
+    let listed = engine.list();
+    let workspace = listed
+        .iter()
+        .find(|r| r.repository.is_none())
+        .expect("workspace");
+    assert!(
+        workspace.specs.iter().any(|s| s.name == "dep"),
+        "dep must remain after failed update"
+    );
+
+    let after = engine
+        .run(None, "consumer", Some(&now), HashMap::new(), None, false)
+        .expect("consumer still runs after failed update");
+    assert_eq!(
+        before.results.get("total").and_then(|r| r.display()),
+        after.results.get("total").and_then(|r| r.display()),
+        "old dep value must be restored"
+    );
+}

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.2", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.9.3", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
## [0.9.3] - 2026-08-05

0.9.3 makes engine mutations transactional, adds structural quality Recommendations, and expands the MCP authoring/evaluate loop (`update_spec`, evaluate guide, richer admin tools).

### Added

- **Transactional `Engine::update`**: replace a temporal spec slice with new source in one atomic apply (rollback on failure). Exposed on WASM/TS as `update(...)`.
- **MCP admin mutators**: `update_spec`, `remove_spec`, `clear`, and `fetch` (with `--admin`).
- **Structural quality**: `Engine::quality()` returns advisory `Recommendation` values (missing commentary/effective date/`-> help`, open text without options, open inputs without suggest, veto-as-rejection cascades). MCP `check` appends them on success; LSP publishes them as Hint diagnostics.
- **Evaluate guide**: MCP `guide` with no topic (and `lemma://guide`) returns the CS evaluate guide. Authoring uses `topic: "full"` / `lemma://guide/full`. New section topics: `method`, `natural_language`.

### Changed

- **`load` / `remove` / `update`**: share one transactional apply path; failed batches leave the engine unchanged.
- **MCP `source`**: available in read-only mode (no longer requires `--admin`).
- **Authoring guide**: refreshed fragments (rules method, anti-patterns, veto, data, composition) and `llms.txt`.
