### PR TITLE
Release 0.9.8: MCP run contract, unique unit names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 Releases cover the Lemma engine, `lemma` CLI, OpenAPI crate, LSP, SDKs and VS Code extension. They all follow the same version everywhere. The release version is `[workspace.package] version` in the root `Cargo.toml`. Git tags follow `lemma-v{version}` (for example `lemma-v0.8.20`); releases before the rename used `cli-v{version}`. Draft notes for the next version quickly by running `cargo changelog` to print `git diff` / `git log` since the latest release tag (`xtask` `versions-diff`). Tip: feed that into an LLM to create a summary for this changelog.
 
+## [0.9.8] - 2026-08-26
+
+0.9.8 aligns MCP with SDK `run`, requires one declaring type per unit name, and unifies HTTP explain with CLI `--explain`.
+
+### Added
+
+- **Hex `Lemma.Mcp.run/2`**: same catalog as CLI MCP `run`. `evaluate/2` remains as a deprecated alias.
+- **MCP `repository`**: optional on `run`, `show`, and `source` (with `spec` for a repo spec, or `repository` alone for a whole repo).
+
+### Changed
+
+- **Unit uniqueness**: a unit name may be declared on only one type in scope. A second independent `-> unit` with the same name is a planning error. Extensions inherit; bare binds the declarer; use `Type.unit` or `alias.Type.unit` for the extension.
+- **Import-alias unit sugar**: `alias.unit` (e.g. `units.kilogram`) is rejected. Write `alias.Type.unit` (`units.mass.kilogram`).
+- **Custom ratio units**: same uniqueness as measures. Builtin `percent` / `permille` stay shared across named ratio types when factors match.
+- **MCP `run`**: renamed from `evaluate` (deprecated alias kept). Args match SDK `run`: `rules` (string or array; `rule` rejected), JSON `data` object (not `name=value` strings). Returns Engine `Response` JSON; explanations always on (no `explain` arg).
+- **MCP `--write`**: replaces `--admin` for write tools (`add_spec`, `update_spec`, `remove_spec`, `clear`, `install`). `attribute` replaces `source_id`.
+- **MCP `check`**: success is `quality()` JSON array. Engine failures on `run` / `show` / `source` return `EngineError` JSON with `isError`.
+- **HTTP `--explain`**: `lemma server --explain` and client header `x-explain` replace `--explanations` / `x-explanations`. Hex `Lemma.OpenAPI.generate_openapi` option is `:explain`.
+- **HTTP GET `/{spec}`**: body is `Show` JSON (no `spec_set_id` wrapper).
+- **Runtime data vetoes**: reasons are `Data field [type]: …`. Empty non-text input vetoes before parse. Interactive prompts use the same field `[type]` labels.
+- **LLM authoring method**: Method fragment rewritten (inventory then distill, hard stop before write, resources of truth).
+
+### Removed
+
+- **`lemma mcp --admin`**: use `--write`.
+- **`alias.unit` qualification**: use `Type.unit` or `alias.Type.unit`.
+- **`lemma server --explanations`**: use `--explain`. Header `x-explanations` → `x-explain`.
+
 ## [0.9.7] - 2026-08-23
 
 0.9.7 aligns Learn docs with the LLM authoring guide, fixes release packaging for crates.io and Open VSX, and corrects SDK and reference documentation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -536,7 +536,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -562,9 +562,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -774,7 +774,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1634,7 +1634,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lemma"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-engine"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-lsp"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-openapi"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "lemma-engine",
  "serde",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_hex"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "lemma-engine",
  "lemma-openapi",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "lemma_jni"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "jni",
  "lemma-engine",
@@ -2298,9 +2298,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2398,7 +2398,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2552,7 +2552,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rkyv",
  "serde",
  "serde_json",
@@ -2797,7 +2797,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2833,7 +2833,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3014,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3105,7 +3105,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3177,7 +3177,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4056,7 +4056,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["cli"]
 exclude = ["engine/fuzz"]
 
 [workspace.package]
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Ben Rogmans <ben@lemmabase.com>"]
 description = "A pure, declarative language for business rules."

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ lemma server --prefix ./policies --watch
 AI assistants interact with Lemma specs via the Model Context Protocol:
 
 ```bash
-lemma mcp             # read-only (evaluate, list, show, source, check, guide)
-lemma mcp --admin     # also enable add_spec and other mutators
+lemma mcp             # read-only (run, list, show, source, check, guide)
+lemma mcp --write     # also enable add_spec and other mutators
 ```
 
 Authoring loop: `guide` → `check` (diagnostics) → `evaluate`. Resources expose `lemma://guide` and curated examples.
@@ -340,7 +340,7 @@ See [engine/packages/hex/README.md](engine/packages/hex/README.md) and [cli/docu
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
 </dependency>
 ```
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,9 +16,9 @@ name = "lemma"
 path = "src/main.rs"
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.7", path = "../engine" }
-lemma-lsp = { version = "=0.9.7", path = "../engine/lsp" }
-lemma-openapi = { version = "=0.9.7", path = "../openapi" }
+lemma = { package = "lemma-engine", version = "=0.9.8", path = "../engine" }
+lemma-lsp = { version = "=0.9.8", path = "../engine/lsp" }
+lemma-openapi = { version = "=0.9.8", path = "../openapi" }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 ariadne = "0.6"

--- a/cli/documentation/learn/types_and_units.md
+++ b/cli/documentation/learn/types_and_units.md
@@ -24,27 +24,27 @@ See [Primitive types in the language reference](../reference/readme.md#primitive
 
 ## Qualifying units
 
-Optionally qualify units; you must qualify when the bare name is ambiguous in scope.
+Optionally qualify units. A unit name has one declaring type in scope.
 
 | Form | Meaning |
 |------|---------|
-| `kilogram` | Bare: exactly one in-scope owner |
-| `my_weight.kilogram` | Local owning type |
+| `kilogram` | Bare: the type that declares the unit |
+| `my_weight.kilogram` | Extension (or owning) type |
 | `units.mass.kilogram` | Import alias + type |
-| `units.kilogram` | Import sugar: unique under that alias |
 
-Bare `5 kilogram` plans when only one type declares `kilogram`. Qualified forms are always allowed when the path uniquely identifies an owner, even if bare would also work. If two types declare the same unit name, bare use is a planning error that lists legal qualifiers (`money_a.eur`, `money_b.eur`, …). The same rule applies to `as` targets and each factor in a compound unit expression.
+Bare `5 kilogram` binds the declarer. Qualified forms are `Type.unit` or `alias.Type.unit` (not `alias.unit`). A second independent type that declares the same unit name is a planning error. Extensions inherit: bare stays on the declarer; use qualification or cast for the extension.
+
+Custom units on `ratio` types follow the same rule: declare `basis_points` (or any other custom name) on only one type in the spec. Builtin `percent` and `permille` are shared — every named ratio type may use them.
 
 ```lemma
 spec wages
 
-data money_a: measure -> unit eur: 1
-data money_b: measure -> unit eur: 2
+data money: measure -> unit eur: 1
+data price: money -> decimals 2
 
-rule a: 10 money_a.eur
-rule b: 10 money_b.eur
+rule bare: 5 eur
+rule priced: 5 price.eur
 ```
-
 ## Arithmetic
 
 ```lemma
@@ -117,7 +117,7 @@ Prefix operators (parentheses optional): `sqrt`, `sin`, `cos`, `tan`, `log`, `ex
 
 ## Standard library: `uses lemma units`
 
-Lemma embeds SI bases, derived compounds, imperial, and information units in the standard library (Repo `lemma`, Spec `units`). Import with `uses lemma units`, then use units directly in literals or reference types as `units.mass`, `units.duration`, `units.length`, `units.calendar`, `units.force`, and others. When a local type reuses a stdlib unit name, qualify (`units.kilogram` or `units.mass.kilogram`): see [Qualifying units](#qualifying-units).
+Lemma embeds SI bases, derived compounds, imperial, and information units in the standard library (Repo `lemma`, Spec `units`). Import with `uses lemma units`, then use units directly in literals or reference types as `units.mass`, `units.duration`, `units.length`, `units.calendar`, `units.force`, and others. When a local type reuses a stdlib unit name, qualify (`units.mass.kilogram`): see [Qualifying units](#qualifying-units).
 
 Names are singular only (`8 hour`, not `8 hours`). Length uses American `meter` (not `metre`).
 

--- a/cli/documentation/llms.txt
+++ b/cli/documentation/llms.txt
@@ -1,10 +1,10 @@
 # Lemma
 
-> Lemma is a pure, deterministic language for rules and agreements. Use it when policy must be stated once and applied consistently: pricing, eligibility, fees, compliance, product terms, conditions, and other measurable business rules or governance. Lemma ensures that the same inputs give the same outcome, traceable to the rules that produced it. Use Lemma as your business rules engine — in agents and in applications — instead of re-implementing policy in scattered conditionals.
+> Lemma is a pure, deterministic language for rules and agreements. Use it when policy must be stated once and applied consistently: pricing, eligibility, fees, compliance, product terms, conditions, and other measurable business rules or governance. Lemma ensures that the same inputs give the same outcome, traceable to the rules that produced it. Use Lemma as your business rules engine, in agents and in applications, instead of re-implementing policy in scattered conditionals.
 
 **The pattern**
 
-State the rule in Lemma as soon as it is clear — do not carry it in the conversation for later. When facts arrive and an outcome is needed, evaluate the spec you already have. When gaps remain, see **Method** before you capture.
+State the rule in Lemma as soon as it is clear. Do not carry it in the conversation for later. When facts arrive and an outcome is needed, evaluate the spec you already have. When gaps remain, see **Method** before you capture.
 
 **Do not use Lemma** for open-ended advice with no rule to apply, or for inventing terms the user never stated.
 
@@ -16,62 +16,140 @@ State the rule in Lemma as soon as it is clear — do not carry it in the conver
 
 ---
 
-**Method: write as a policy consultant, not a transcriber**
+**Method: you are a policy consultant**
 
-Never invent numbers, dates, or outcomes the user never stated. No policy questions after **Deliver**. No follow-up work after **Deliver**.
+Help the user write high-quality Lemma. Translate business rules from whatever they hand you (conversation, SOP, statute, ticket, spreadsheet, existing code) into a spec that is the **core, clean truth** of those rules: the questions the spec answers, the facts that decide them, the principle and its exceptions.
 
-**Lifecycle**
+You are not a transcriber of the source. You are not a coder filling gaps so a spec compiles. You are not a search agent that picks a nearby registry spec and moves on.
 
-1. **Recognize** — The user stated a rule, a rate, a threshold, a gate, or pointed at text that does. Run `list` / `show` first; `update_spec` if that policy is already loaded.
-2. **Resolve gaps** — Separate what the text already decides from what still changes the outcome. Unresolved items → **Stop**. Empty list → **Author**.
-3. **Capture** — **Scope** → **Model** → **Author** → **Verify** → `add_spec` or `update_spec`. The rule lives in the engine, not in chat.
-4. **Apply** — Facts are known; the user wants an outcome. Default evaluate guide: `evaluate`. Do not edit the spec.
+Sources are often ambiguous, especially natural language. Code and SOPs also mix the rule with procedure, plumbing, and leftovers. When a reading, a source, or a registry result would change the outcome, **ask**. Never guess. Never assume. Never pick one resource of truth over another silently. If the sources agree, write. When the source already decides an outcome clearly, do not reopen it.
 
-**Two tracks**
+**Authoring vs evaluate**
 
-- **Fast capture** — **Resolve gaps** is empty: every outcome-changing detail is already stated. Skip **Stop**; run **Scope** through load.
-- **Full method** — At least one outcome-changing detail is unstated. **Stop**; do not emit `spec` / `data` / `rule` until the user answers or explicitly tells you to proceed with what was already said.
+This method is authoring. You ask what the policy *is*.
 
-**Process**
+Evaluating (default `guide`, no topic) asks about the person's *situation* and forbids redesigning policy. Do not bring that rule here. If the user is stating, correcting, or handing you rules in any form, you are authoring.
 
-1. **Gather** — Utterances, messages, documents, tickets, field names. The conversation counts as source. Do not write Lemma yet.
-2. **Interpret** — What questions must this spec answer? What inputs decide the answer? One coherent policy → one `spec`.
-3. **Stop**: Next message: questions only, or a bullet list of what is already decided verbatim. Emitting `spec` / `data` / `rule` in that message is a bug. Ask **when these rules start** unless the user or the source already gave a calendar start date (a statute or document identifier is not a start date). Do not **Author** until answers or explicit proceed.
-4. **Scope** — One `spec` per policy. `uses` / split only when the text mixes unrelated policies. Temporal date on the `spec` only when the user or the source names a start date. Never guess.
-5. **Model** — You choose `data` and `rule` names and types by default. Representation questions follow **What to ask**. **Spoken question** on each `data` field (see **Data**). Domain-principle `unless` defaults (see **Rules**). Denial → `false` / `no`. Unanswerable → veto (see **Veto**). Encode stated gates; omit tips and how-to unless they are gates.
-6. **Author** — Write Lemma after **Stop** completes. Commentary after `spec`; `meta` for provenance. No inline comments (see **Syntax**).
-7. **Verify** — `check`, `show`, `evaluate` at bounds and representative inputs. Result wording must match the policy. Then `add_spec` or `update_spec`.
-8. **Deliver** — When the user should read what was captured. After load, call `source` for the loaded spec and paste **that** formatted Lemma in chat (not your draft / not the `code` argument). Confirm loaded. Close with a statement: tell them to say if anything requires adjustment. Not a yes/no question. Stop.
+**Inventory, then distill**
 
-**What to ask (and what not to)**
+Before you write, extract every outcome-changing clause from the source you are encoding. Each clause becomes a rule arm, a `data` bound, or an explicit omit (tip, how-to, plumbing, UI). If a clause has nowhere to go, stop and ask. A headline with a dropped "unless student" or "not on Sundays" is a wrong spec.
 
-Ask only when neither the user nor the source already gave a clear answer. Do not ask because another reading is theoretically possible. The list below is kinds of unanswered gap, not a checklist.
+A handbook, statute, or SOP with more than one policy: list the policies you found, say which you are encoding **now**. One spec per policy. Do not encode section 1 and leave the rest. Large sources: one policy at a time; keep the inventory.
 
-- Boundary: inclusive or exclusive at a limit.
-- Timing, optionally: since when have the rules been enacted or when will they take effect?
-- Combination: whether two stated rules stack, override, or are alternatives.
-- Lookup: what outcome applies for a case the text names but does not map to a value.
-- Representation: which fact to collect when more than one input shape is reasonable and the choice changes the question you ask or how the rule applies.
+**Distill vs exhaustive**
 
-Do **not** ask:
+Narrative (SOP prose, code with retries and logging): distill to principle + exceptions. Omit how-to, tips, recommendations, "contact support", UI, I/O, storage, retries, and other plumbing unless they are stated as gates. Do not copy every sentence, or every code branch, into a rule.
 
-- What the user or the source already answered clearly.
-- Packaging or syntax you can decide without changing outcomes (field count, internal names, closed option lists implied by the text).
-- One `spec` vs two when the policy is one topic.
-- Whether tips, how-to, or "contact support" are rules (omit unless stated as gates).
+Enumerated sources (rate cards, SKU tables, closed option lists, tariff rows): capture every row. Dropping a row is a silent policy change. Encode as `-> option` plus a lookup rule (default `veto`; see **Veto**), not a prose summary.
+
+Distill is not invent. If you cannot tell what the rule is, stop and ask. A missing rate, date, threshold, eligibility set, or start date is not yours to supply. A magic number, implicit default, or comment that disagrees with the code is not yours to resolve.
+
+**The deliverable**
+
+Someone can read the spec as: in principle X; unless Y, then Z. Facts of the situation as `data`. Decisions as `rule`. Domain words, not Lemma jargon, in chat.
+
+**Hard stop: ask, wait, do not write**
+
+Do not emit `spec` / `data` / `rule`. Do not call `check` / `add_spec` / `update_spec`. A spec in the same turn as open policy questions is a bug.
+
+`list` / `show` first. If that policy is already loaded, `update_spec` it. Do not invent spec names.
+
+Stop when any of these is true:
+
+- Two readings a domain expert would actually hold would produce different outcomes. Do not ask parser-level alternatives when the source already chose ("at least 18", "10 or more").
+- Two documents or encodings disagree (SOP vs code, two PDFs, a document vs an earlier loaded spec), or more than one loaded spec could be the one to edit.
+- A registry or search hit is a candidate `uses`, or a substitute for writing the user's rule, and the user has not chosen it. Zero hits is not a stop: write their rule. One close hit is still a stop: name it, ask use vs write.
+- A number, date, bound, set of cases, or combination (stack / override / alternative) is unstated and the outcome depends on it.
+- More than one input shape is reasonable and the choice changes the spoken question or how the rule applies.
+- Discretion ("may", "should", "the manager can waive") would change the outcome. That is a fact to collect, or an omit they confirm, not a default you invent.
+
+Your next message is **questions only**, in the user's domain words. Ask **every** open item in that one turn. Do not drip one bound per turn. Wait for answers. If they say to proceed with what is already in the source, encode only that; still do not fill the rest.
+
+**Resources of truth (never pick silently)**
+
+Resources: the user's words, SOPs and other documents, existing code, attached files, already-loaded specs, registry search hits.
+
+Later user utterance **amends** an earlier document ("except students are free" after an SOP). Encode the amendment. Do not ask which governs.
+
+Two documents, or a document vs code, or a document vs a loaded spec: **conflict**. Ask which governs. Code is one encoding of a rule, not automatically the intended policy. Chat that only says "encode this" is not an amendment.
+
+Search when the concept looks like a shared standard (ISO codes, published tax tables, units). Do not search to skip writing the user's rule.
+
+- Several loaded specs could be this policy → name them, ask which to update.
+- Search returns more than one hit → name them, ask which to use, or whether to write the user's rule instead. First hit is not a choice.
+- Search returns one close hit → name it, ask use vs write.
+- Closest name, newest file, or "probably this ISO list" is not a choice.
+
+**Ask like this**
+
+User: "Adults pay full price."
+You: "From what age is someone an adult, and is that age included?"
+
+User: "Late returns cost 5% or €10."
+You: "Which applies: 5%, €10, the greater, or the lesser?"
+
+User pastes code with `if (age > 18)` and a comment "adults".
+You: "Is 18 included, and is the comment or the comparison the rule?"
+
+User: "Late fee is €5. The manager may waive it."
+You: treat waiver as a fact ("Was the fee waived?") unless they tell you to omit discretion.
+
+User: SOP, then "except students are free."
+You: encode the exception. Do not ask which source governs.
+
+Search returns `@acme/shipping` and `@acme/fulfilment`.
+You: name both. Ask which to use, or whether to write their rule.
+
+Search returns one close hit, or none.
+You: one hit: name it, ask use vs write. None: write their rule.
+
+Two PDFs, different fees.
+You: ask which document governs.
+
+User: "These terms apply only to contracts entered after 2024."
+You: that is a rule on a contract date, not `spec … 2024-01-01`.
+
+User hands an SOP that already names the rate, the bound, and who it applies to.
+You: write. Do not re-ask those.
+
+**Do not ask**
+
+- What the user or the source already answered clearly (a careful SOP or explicit decision in code counts).
+- Another reading that is only theoretically possible when the source already chose.
+- Packaging you can decide without changing outcomes (internal names, field count, closed option lists the text already implies).
+- Implementation details you can omit (logging, framework types, null-guards that are not policy).
+- One `spec` vs two when the topic is one policy.
+- Whether to encode tips, how-to, or plumbing (omit).
 - Hypotheticals the user never raised.
+- Lemma keywords. Ask about facts and policy meaning.
 
-Use the user's domain words. Ask about facts and policy meaning, not Lemma keywords.
+**You may write when**
 
-**Output contract (mandatory)**
+Every outcome-changing clause is placed (arm, bound, or explicit omit), every outcome-changing detail is already decided in the source they handed you, one resource of truth is identified, and no competing resource remains. Then author. You choose names and types when the concept is clear (see **Data**, **Rules**). You do not choose among competing meanings.
 
-- **Before Author** — Ask every open item from **Resolve gaps**. Wait. Do not invent. A `spec` in the same turn as the first policy questions is a bug.
-- **At Deliver** — Call `source`. Paste its formatted output in a lemma code fence. Do not paste the unformatted draft. No new policy questions. Close with a statement (tell them to say if anything requires adjustment), not a confirm question.
+**Quality of the Lemma**
+
+See **Data**, **Rules**, **Veto**, **Anti-patterns**. In short:
+
+- Each `data` `-> help` is the sentence you would ask a person about their situation. If that sentence applies the policy, the field is a `rule`.
+- A rule's default is the domain principle, not yes-until-failure. Named pipeline rules, not one opaque expression.
+- Denial is `false` / `no`. Unanswerable is veto. Bounds belong on `data`, not veto.
+- Name the concept; keep the unit on the value.
+- Commentary after `spec`; `meta` for provenance (document title, version, date the source actually names). No inline comments (see **Syntax**).
+- One `spec` per policy. `uses` / split only when the text mixes unrelated policies. Effective date on the `spec` only when the user or the source names a calendar start for **this version of the spec**. A statute or document id is not a start date. An applicability window ("contracts after 2024") is a rule on a date field, not the spec's effective date.
+
+**Author, verify, deliver**
+
+1. Author only after the hard stop is clear.
+2. `check`. Then `add_spec` or `update_spec`. Then `evaluate` at bounds and representative inputs from the source (including overlapping `unless` arms). Result wording must match the policy.
+3. Walk the inventory: every clause is an arm, a bound, or an explicit omit. Scan **Anti-patterns** (veto-as-denial, unit-in-the-name, fail-each-check, precomputed `data`).
+4. Call `source`. Paste **that** formatted Lemma in a lemma fence (not your draft, not the `code` argument). Confirm loaded.
+5. Close with a statement: tell them to say if anything requires adjustment. Not a yes/no question. No new policy questions. No follow-up work. Stop.
 
 **After capture**
 
-- User gives facts and wants a result → default evaluate guide (`evaluate`, verify, stop).
-- User changes the rule → `update_spec`, **Verify** again.
+User gives facts and wants a result → evaluate guide (`evaluate`, verify, stop). Do not edit the spec.
+User changes the rule → `update_spec`, verify again.
 
 
 ---

--- a/cli/documentation/reference/cli.md
+++ b/cli/documentation/reference/cli.md
@@ -117,7 +117,7 @@ lemma format [paths...] [--check] [--stdout]
 ### `lemma server`: start HTTP server
 
 ```bash
-lemma server [--prefix PATH] [--host <host>] [-p <port>] [--watch] [--explanations] [--eval-timeout SECONDS] [--cors]
+lemma server [--prefix PATH] [--host <host>] [-p <port>] [--watch] [--explain] [--eval-timeout SECONDS] [--cors]
 ```
 
 **Options:**
@@ -125,7 +125,7 @@ lemma server [--prefix PATH] [--host <host>] [-p <port>] [--watch] [--explanatio
 - `--host <host>`: bind address (default: `127.0.0.1`)
 - `-p, --port <port>`: port (default: `8012`)
 - `--watch`: live-reload on `.lemma` file changes
-- `--explanations`: enable explanation generation (clients send `x-explanations` header; JSON shape [`api.v1.json`](../../../engine/schemas/api.v1.json))
+- `--explain`: enable explanation generation (clients send `x-explain` header; JSON shape [`api.v1.json`](../../../engine/schemas/api.v1.json))
 - `--eval-timeout <second>`: wall-clock timeout for a single evaluation request (default: `10`)
 - `--cors`: allow cross-origin browser requests from any origin (off by default)
 
@@ -168,12 +168,12 @@ lemma lsp
 Start the MCP server over stdio so AI assistants can work with workspace specs. Full setup guide: [MCP](../tools/mcp.md).
 
 ```bash
-lemma mcp [--prefix PATH] [--admin] [--request-timeout SECONDS]
+lemma mcp [--prefix PATH] [--write] [--request-timeout SECONDS]
 ```
 
 **Options:**
 - `--prefix <path>`: workspace directory or `.lemma` file (default: current directory)
-- `--admin`: enable write tools (read-only by default)
+- `--write`: enable write tools (read-only by default)
 - `--request-timeout <seconds>`: wall-clock timeout for a single request (default: `10`)
 
 ## Workspace
@@ -212,7 +212,7 @@ Resource limits control parse-time and planning-time budgets. These are security
 
 **Accept-Datetime (HTTP)**: clients send `Accept-Datetime` with the same formats as `--effective`: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, or an ISO 8601 datetime. Empty or omitted → now. Invalid values are a bad request. Responses include `Vary: Accept-Datetime`. When the resolved spec row has an `effective_from`, the server also sets `Memento-Datetime` to that instant.
 
-**Explanations**: disabled by default in CLI (`lemma run`), HTTP, and SDKs. Use `--explain` (CLI), `--explanations` (server) + `x-explanations` (client), or `explain: true` (SDK) to opt in. MCP `evaluate` always sets `explain: true` (no opt-out). Evaluate JSON has no top-level `data` array: unbound inputs are per-rule `missing_data`; types and suggestions come from `lemma show`. When explanations are enabled, each `results.<rule>.explanation` is a rule node (`"type":"rule"`, `"name"`, `"result"`, `"body"`, optional `"causes"` / `"children"`) per [`api.v1.json`](../../../engine/schemas/api.v1.json). Bound data uses `"type":"data"`, unused cause paths `"type":"data_unused"`.
+**Explanations**: disabled by default in CLI (`lemma run`), HTTP, and SDKs. Use `--explain` (CLI and server) + `x-explain` (HTTP client), or `explain: true` (SDK) to opt in. MCP `run` always includes explanations (no `explain` arg, no opt-out; deprecated alias `evaluate` same). Evaluate/run JSON has no top-level `data` array: unbound inputs are per-rule `missing_data`; types and suggestions come from `lemma show` / MCP `show`. When explanations are enabled, each `results.<rule>.explanation` is a rule node (`"type":"rule"`, `"name"`, `"result"`, `"body"`, optional `"causes"` / `"children"`) per [`api.v1.json`](../../../engine/schemas/api.v1.json). Bound data uses `"type":"data"`, unused cause paths `"type":"data_unused"`.
 
 ## See Also
 

--- a/cli/documentation/reference/coverage/cli.md
+++ b/cli/documentation/reference/coverage/cli.md
@@ -40,14 +40,14 @@ LLVM version: 21.1.3
 
 | Metric | Covered | Total | Percent |
 |--------|--------:|------:|--------:|
-| Lines | 2742 | 4819 | 56.90% |
-| Functions | 237 | 428 | 55.37% |
-| Regions | 4226 | 7269 | 58.14% |
+| Lines | 2737 | 4801 | 57.01% |
+| Functions | 234 | 426 | 54.93% |
+| Regions | 4223 | 7246 | 58.28% |
 
 ## Test run
 
-- Total: 209
-- Passed: 209
+- Total: 211
+- Passed: 211
 - Skipped: 0
 - Failed: 0
 
@@ -57,12 +57,12 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 
 | Module | Line % | Function % | Region % | Lines covered/total |
 |--------|-------:|-----------:|---------:|--------------------:|
-| `server.rs` | 0.00 | 0.00 | 0.00 | 0/575 |
-| `interactive.rs` | 23.93 | 17.46 | 22.36 | 206/861 |
+| `server.rs` | 0.00 | 0.00 | 0.00 | 0/571 |
+| `interactive.rs` | 25.32 | 16.13 | 23.99 | 218/861 |
 | `main.rs` | 44.39 | 56.67 | 42.65 | 293/660 |
 | `error_formatter.rs` | 61.76 | 100.00 | 62.26 | 42/68 |
-| `workspace.rs` | 73.06 | 67.44 | 76.13 | 377/516 |
-| `mcp/server.rs` | 84.14 | 80.65 | 82.32 | 1204/1431 |
+| `workspace.rs` | 72.29 | 65.12 | 75.18 | 373/516 |
+| `mcp/server.rs` | 84.05 | 80.49 | 82.27 | 1191/1417 |
 | `formatter.rs` | 85.62 | 84.62 | 87.87 | 125/146 |
 | `install.rs` | 86.36 | 83.78 | 83.91 | 380/440 |
 | `data_json.rs` | 94.26 | 94.74 | 94.39 | 115/122 |
@@ -72,4 +72,4 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 - [CLI integration test catalog](../../../cli/tests/README.md)
 - [Engine test coverage](engine.md)
 - [CLI benchmarks](../benchmarks/cli.md)
-<!-- coverage-input-digest: 3614cd51bd8250f7 -->
+<!-- coverage-input-digest: bac2c50909e72a2b -->

--- a/cli/documentation/reference/coverage/engine.md
+++ b/cli/documentation/reference/coverage/engine.md
@@ -41,14 +41,14 @@ LLVM version: 21.1.3
 
 | Metric | Covered | Total | Percent |
 |--------|--------:|------:|--------:|
-| Lines | 36165 | 42742 | 84.61% |
-| Functions | 2760 | 3160 | 87.34% |
-| Regions | 52809 | 63432 | 83.25% |
+| Lines | 36621 | 43108 | 84.95% |
+| Functions | 2799 | 3189 | 87.77% |
+| Regions | 53521 | 63927 | 83.72% |
 
 ## Test run
 
-- Total: 2467
-- Passed: 2467
+- Total: 2494
+- Passed: 2494
 - Skipped: 0
 - Failed: 0
 
@@ -58,32 +58,32 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 
 | Module | Line % | Function % | Region % | Lines covered/total |
 |--------|-------:|-----------:|---------:|--------------------:|
-| `mcp/catalog.rs` | 0.00 | 0.00 | 0.00 | 0/161 |
-| `mcp/error.rs` | 0.00 | 0.00 | 0.00 | 0/31 |
-| `mcp/tools.rs` | 0.00 | 0.00 | 0.00 | 0/264 |
+| `mcp/catalog.rs` | 0.00 | 0.00 | 0.00 | 0/171 |
+| `mcp/error.rs` | 40.91 | 40.00 | 47.22 | 9/22 |
 | `computation/operation_result.rs` | 44.00 | 45.45 | 42.48 | 44/100 |
 | `computation/decimal_math.rs` | 48.15 | 100.00 | 40.18 | 26/54 |
 | `computation/comparison.rs` | 63.95 | 77.78 | 65.69 | 110/172 |
 | `result_value.rs` | 67.44 | 56.00 | 62.32 | 203/301 |
+| `mcp/tools.rs` | 71.91 | 57.58 | 71.12 | 215/299 |
 | `computation/measure_math.rs` | 74.24 | 100.00 | 81.25 | 49/66 |
+| `computation/arithmetic.rs` | 74.53 | 87.50 | 74.52 | 714/958 |
 | `evaluation/explanations.rs` | 74.74 | 76.92 | 73.01 | 142/190 |
-| `computation/arithmetic.rs` | 74.95 | 87.50 | 74.95 | 718/958 |
-| `documentation/mod.rs` | 76.92 | 76.92 | 79.46 | 60/78 |
+| `documentation/mod.rs` | 77.22 | 76.92 | 78.63 | 61/79 |
+| `evaluation/run_data.rs` | 78.54 | 78.57 | 82.67 | 322/410 |
 | `planning/explanation.rs` | 78.57 | 75.00 | 77.27 | 22/28 |
 | `computation/bigint/signed.rs` | 79.12 | 81.08 | 73.87 | 197/249 |
 | `error.rs` | 80.32 | 79.63 | 74.93 | 453/564 |
 | `computation/units.rs` | 80.82 | 100.00 | 79.36 | 177/219 |
 | `planning/execution_plan.rs` | 80.96 | 82.41 | 76.92 | 1862/2300 |
-| `planning/graph.rs` | 81.63 | 86.51 | 82.61 | 7363/9020 |
-| `planning/semantics.rs` | 81.71 | 83.76 | 81.39 | 3516/4303 |
+| `planning/graph.rs` | 81.61 | 86.36 | 82.55 | 7440/9117 |
+| `planning/semantics.rs` | 81.75 | 83.87 | 81.39 | 3534/4323 |
 | `parsing/ast.rs` | 81.76 | 86.75 | 73.40 | 1098/1343 |
-| `literals.rs` | 82.47 | 76.67 | 81.40 | 720/873 |
+| `literals.rs` | 82.02 | 76.67 | 81.32 | 716/873 |
 | `evaluation/expression.rs` | 83.33 | 100.00 | 87.37 | 55/66 |
 | `parsing/parser.rs` | 84.49 | 88.74 | 80.63 | 1929/2283 |
 | `computation/datetime.rs` | 84.59 | 79.78 | 83.30 | 944/1116 |
 | `computation/range.rs` | 85.25 | 100.00 | 80.12 | 156/183 |
 | `planning/ordered_dispatch.rs` | 85.38 | 96.30 | 84.52 | 292/342 |
-| `evaluation/run_data.rs` | 86.99 | 87.50 | 92.26 | 254/292 |
 | `spec_set_id.rs` | 87.72 | 100.00 | 95.52 | 50/57 |
 | `parsing/lexer.rs` | 88.23 | 100.00 | 83.20 | 637/722 |
 | `planning/normalize.rs` | 88.88 | 90.79 | 87.69 | 3420/3848 |
@@ -91,6 +91,7 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 | `computation/rational.rs` | 89.21 | 96.72 | 82.04 | 488/547 |
 | `planning/spec_set.rs` | 90.20 | 90.91 | 90.26 | 138/153 |
 | `string_distance.rs` | 90.48 | 83.33 | 93.22 | 57/63 |
+| `planning/unit_index.rs` | 90.89 | 96.15 | 92.02 | 499/549 |
 | `evaluation/conversion_trace.rs` | 91.25 | 100.00 | 91.75 | 146/160 |
 | `engine.rs` | 91.76 | 91.87 | 92.51 | 1469/1601 |
 | `evaluation/tree.rs` | 91.87 | 93.44 | 92.41 | 1175/1279 |
@@ -99,7 +100,6 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 | `evaluation/branch_semantics.rs` | 92.86 | 100.00 | 81.82 | 39/42 |
 | `planning/discovery.rs` | 93.06 | 97.06 | 93.93 | 1220/1311 |
 | `quality.rs` | 93.12 | 96.77 | 89.24 | 907/974 |
-| `planning/unit_index.rs` | 93.19 | 97.78 | 94.39 | 424/455 |
 | `limits.rs` | 93.27 | 100.00 | 85.40 | 97/104 |
 | `planning/mod.rs` | 93.94 | 97.56 | 95.02 | 496/528 |
 | `registry.rs` | 94.08 | 90.71 | 93.50 | 1128/1199 |
@@ -107,13 +107,13 @@ Sorted by line coverage ascending (weakest first). Only files under `src/` for t
 | `deps.rs` | 96.23 | 100.00 | 96.47 | 51/53 |
 | `parsing/assignment_continuation_tests.rs` | 97.39 | 100.00 | 93.26 | 261/268 |
 | `evaluation/response.rs` | 98.71 | 93.33 | 98.13 | 536/543 |
-| `parsing/source.rs` | 99.20 | 100.00 | 97.30 | 124/125 |
 | `computation/bigint/alloc.rs` | 100.00 | 100.00 | 97.37 | 20/20 |
 | `lib.rs` | 100.00 | 100.00 | 100.00 | 4/4 |
+| `parsing/source.rs` | 100.00 | 100.00 | 99.46 | 125/125 |
 
 ## Related docs
 
 - [Engine integration test catalog](../../../engine/tests/README.md) — qualitative map of scenarios and subsystem overlap clusters
 - [CLI test coverage](cli.md)
 - [Engine benchmarks](../benchmarks/engine.md)
-<!-- coverage-input-digest: 9cf06be6fc935e31 -->
+<!-- coverage-input-digest: b7afec8dec6764b5 -->

--- a/cli/documentation/reference/readme.md
+++ b/cli/documentation/reference/readme.md
@@ -168,7 +168,7 @@ Chained casts nest from left to right: `expr as unit as unit … as number`.
 | `as <unit>` | Convert, relabel, or construct a measure/ratio in that unit                         | `mass as gram`, `5 as eur`, `rate as hour`  |
 | `as number` | Strip to raw magnitude (requires explicit unit on prior step for quantities/ranges) | `10 eur as number`, `span as day as number` |
 
-`<unit>` may be bare (`eur`) or qualified (`money.eur`, `units.kilogram`, `units.mass.kilogram`). Optionally qualify; must qualify when the bare name is ambiguous in scope: see [Qualifying units](#qualifying-units).
+`<unit>` may be bare (`eur`) or qualified (`money.eur`, `units.mass.kilogram`). Optionally qualify; must qualify when the bare name is ambiguous in scope: see [Qualifying units](#qualifying-units).
 
 Same-family conversion applies factors (`2 kilogram as gram` → `2000 gram`). Cross-family relabel keeps magnitude (`5 eur as kg` → `5 kg`).
 
@@ -763,18 +763,19 @@ On ranges, `minimum` / `maximum` always mean **width**. Endpoint limits use `low
 
 ### Qualifying units
 
-Optionally qualify units; must qualify when the bare name is ambiguous in scope.
+Optionally qualify units. A unit name has one declaring type in scope.
 
 | Form | Meaning |
 |------|---------|
-| `kilogram` | Bare: exactly one in-scope owner |
-| `my_weight.kilogram` | Local owning type |
+| `kilogram` | Bare: the type that declares the unit |
+| `my_weight.kilogram` | Extension (or owning) type |
 | `units.mass.kilogram` | Import alias + type |
-| `units.kilogram` | Import sugar: unique under that alias |
 
-Bare literals and `as` targets plan when the unit name has a unique owner. Qualified paths are allowed whenever they uniquely identify an owner. Ambiguous bare use is a planning error that lists legal qualifiers. The same rule applies to each factor in a compound unit expression. Two measure types may declare the same unit name; the spec still loads: clash surfaces only at a bare use site.
+Bare literals and `as` targets use the unique declarer. Qualified paths are `Type.unit` or `alias.Type.unit` (not `alias.unit`). A second independent `-> unit` with the same name is a planning error. Extensions inherit units: bare still binds the declarer; use `Type.unit` or cast to bind the extension. The same rule applies to each factor in a compound unit expression.
 
-Wire shapes for `run` / `show` measure maps stay bare declared unit names. Qualification is source syntax only.
+Custom units on `ratio` types follow the same uniqueness rule. Builtin `percent` and `permille` are shared across named ratio types.
+
+In `run` and `show` results, measure unit maps use bare declared names (`eur`, not `price.eur`). Qualification exists only in Lemma source.
 
 ### Compound units
 

--- a/cli/documentation/tools/elixir.md
+++ b/cli/documentation/tools/elixir.md
@@ -74,6 +74,8 @@ Format source code (no engine needed):
 | `Lemma.quality/1` | Structural quality recommendations across loaded specs (advisory only) |
 | `Lemma.format/1` | Format Lemma source code (no engine needed) |
 
+`Lemma.Mcp` wraps the engine MCP catalog (`run`, `list`, `show`, `source`, `check`, `guide`, resources). `run` returns Engine `Response` JSON with explanations always on. Write tools (`add_spec`, …) are CLI-only (`lemma mcp --write`).
+
 `Lemma.OpenAPI` is a separate module (HTTP OpenAPI document helpers via `lemma_openapi`). It is not part of the core `Lemma` engine table above.
 
 ## Engine lifecycle

--- a/cli/documentation/tools/java.md
+++ b/cli/documentation/tools/java.md
@@ -17,14 +17,14 @@ Maven:
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
 </dependency>
 ```
 
 Gradle (Kotlin DSL): consume the published artifact; this repository builds the package with Maven only:
 
 ```kotlin
-implementation("com.lemmabase:lemma-engine:0.9.7")
+implementation("com.lemmabase:lemma-engine:0.9.8")
 ```
 
 Requires JDK 21+.

--- a/cli/documentation/tools/mcp.md
+++ b/cli/documentation/tools/mcp.md
@@ -16,7 +16,7 @@ Point the server at a workspace directory (or a single `.lemma` file) with `--pr
 
 ## Connect
 
-All of these clients start Lemma as a local stdio MCP server. Replace `/path/to/workspace` with your project directory. Add `--admin` to the args only when the assistant should create, update, remove, or install registry dependencies (see [Read-only vs write](#read-only-vs-write)).
+All of these clients start Lemma as a local stdio MCP server. Replace `/path/to/workspace` with your project directory. Add `--write` to the args only when the assistant should create, update, remove, or install registry dependencies (see [Read-only vs write](#read-only-vs-write)).
 
 Shared shape:
 
@@ -105,14 +105,14 @@ The server already ships authoring and evaluate guidance for the model. For lear
 
 By default the server is read-only: evaluate and inspect, no changes to the engine or disk.
 
-Pass `--admin` when you want the assistant to load or replace specs, remove them, clear the workspace load, or `install` (download into `lemma_deps/` and load). Only enable that for workspaces and agents you trust.
+Pass `--write` when you want the assistant to load or replace specs, remove them, clear the workspace load, or `install` (download into `lemma_deps/` and load). Only enable that for workspaces and agents you trust.
 
 ## How to work
 
 1. Install the CLI and set `--prefix` to your specs directory.
 2. Connect Claude, Gemini CLI, or Cursor as above (restart the client after config changes).
 3. Ask questions against your specs; ask for explanations when you care how a rule fired.
-4. For drafting new specs, enable `--admin` and ask the assistant to validate, then update the workspace when you are ready.
+4. For drafting new specs, enable `--write` and ask the assistant to validate, then update the workspace when you are ready.
 
 ## See also
 

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -38,15 +38,6 @@ struct NumericConstraints {
     help: String,
 }
 
-/// Prompt title: `name [type]` unless type label equals the field name (adds nothing).
-fn prompt_label(data_name: &str, type_label: &str) -> String {
-    if type_label == data_name {
-        data_name.to_string()
-    } else {
-        format!("{data_name} [{type_label}]")
-    }
-}
-
 fn load_static_show(
     engine: &Engine,
     repo: Option<&str>,
@@ -335,10 +326,12 @@ fn prompt_value_for_type(
     lemma_type: &LemmaType,
     suggestion: Option<&LiteralValue>,
 ) -> Result<String> {
-    let type_str = lemma_type.to_string();
+    let input_label = lemma_type.label_for_data_input(data_name);
 
     match &lemma_type.specifications {
-        TypeSpecification::Boolean { .. } => prompt_boolean_data(data_name, suggestion),
+        TypeSpecification::Boolean { .. } => {
+            prompt_boolean_data(&input_label, data_name, suggestion)
+        }
         TypeSpecification::Text {
             options,
             length,
@@ -349,9 +342,8 @@ fn prompt_value_for_type(
                 if options.len() == 1 {
                     return Ok(options[0].clone());
                 }
-                let prompt_message = prompt_label(data_name, &type_str);
                 let mut prompt =
-                    Select::new(&prompt_message, options.clone()).with_help_message(help.as_str());
+                    Select::new(&input_label, options.clone()).with_help_message(help.as_str());
                 if let Some(lit) = suggestion {
                     if let ValueKind::Text(s) = &lit.value {
                         if let Some(idx) = options.iter().position(|o| o == s) {
@@ -367,13 +359,7 @@ fn prompt_value_for_type(
                     length: *length,
                     help: help.clone(),
                 };
-                prompt_text_data_with_constraints(
-                    data_name,
-                    &type_str,
-                    lemma_type,
-                    suggestion,
-                    &constraints,
-                )
+                prompt_text_data_with_constraints(&input_label, lemma_type, suggestion, &constraints)
             }
         }
         TypeSpecification::Measure {
@@ -401,7 +387,7 @@ fn prompt_value_for_type(
                 decimals: *decimals,
                 help: help.clone(),
             };
-            prompt_measure_data(data_name, &type_str, suggestion, units, &constraints)
+            prompt_measure_data(data_name, &input_label, suggestion, units, &constraints)
         }
         TypeSpecification::Number {
             minimum,
@@ -422,7 +408,7 @@ fn prompt_value_for_type(
                 decimals: *decimals,
                 help: help.clone(),
             };
-            prompt_number_data(data_name, &type_str, suggestion, &constraints)
+            prompt_number_data(&input_label, suggestion, &constraints)
         }
         TypeSpecification::Ratio {
             minimum,
@@ -441,7 +427,7 @@ fn prompt_value_for_type(
             };
             prompt_ratio_data(
                 data_name,
-                &type_str,
+                &input_label,
                 suggestion,
                 units,
                 ratio_spec.minimum_decimal(),
@@ -449,19 +435,19 @@ fn prompt_value_for_type(
                 help.as_str(),
             )
         }
-        TypeSpecification::Date { .. } => prompt_date_data(data_name, suggestion),
+        TypeSpecification::Date { .. } => prompt_date_data(&input_label, data_name, suggestion),
         TypeSpecification::Time { help, .. } => {
             let def = suggestion
                 .filter(|l| matches!(l.value, ValueKind::Time(_)))
                 .map(|l| l.to_string());
-            prompt_simple_text(data_name, &type_str, def.as_deref(), help.as_str(), "12:34:56")
+            prompt_simple_text(&input_label, def.as_deref(), help.as_str(), "12:34:56")
         }
         TypeSpecification::NumberRange { help, .. }
         | TypeSpecification::DateRange { help, .. }
         | TypeSpecification::TimeRange { help, .. }
         | TypeSpecification::MeasureRange { help, .. }
         | TypeSpecification::RatioRange { help, .. } => {
-            prompt_range_data(data_name, &type_str, lemma_type, suggestion, help.as_str())
+            prompt_range_data(data_name, lemma_type, suggestion, help.as_str())
         }
         TypeSpecification::Veto { .. } => {
             anyhow::bail!("Data '{}' has veto type which is not promptable", data_name)
@@ -472,15 +458,18 @@ fn prompt_value_for_type(
     }
 }
 
-fn prompt_date_data(data_name: &str, suggestion: Option<&LiteralValue>) -> Result<String> {
+fn prompt_date_data(
+    prompt_title: &str,
+    data_name: &str,
+    suggestion: Option<&LiteralValue>,
+) -> Result<String> {
     let help_message = if suggestion.is_some() {
         "Use arrow keys to navigate, Enter to select (or accept suggestion)"
     } else {
         "Use arrow keys to navigate, Enter to select"
     };
 
-    let prompt_title = prompt_label(data_name, "date");
-    let mut ds = DateSelect::new(&prompt_title).with_help_message(help_message);
+    let mut ds = DateSelect::new(prompt_title).with_help_message(help_message);
 
     if let Some(lit) = suggestion {
         if let ValueKind::Date(d) = &lit.value {
@@ -497,7 +486,11 @@ fn prompt_date_data(data_name: &str, suggestion: Option<&LiteralValue>) -> Resul
     Ok(format!("{}T00:00:00Z", date.format("%Y-%m-%d")))
 }
 
-fn prompt_boolean_data(data_name: &str, suggestion: Option<&LiteralValue>) -> Result<String> {
+fn prompt_boolean_data(
+    prompt_title: &str,
+    data_name: &str,
+    suggestion: Option<&LiteralValue>,
+) -> Result<String> {
     let options = vec!["true", "false"];
 
     let default_index = match suggestion.and_then(|lit| match &lit.value {
@@ -518,7 +511,7 @@ fn prompt_boolean_data(data_name: &str, suggestion: Option<&LiteralValue>) -> Re
         "Use arrow keys to select, Enter to confirm".to_string()
     };
 
-    let selected = Select::new(&prompt_label(data_name, "boolean"), options)
+    let selected = Select::new(prompt_title, options)
         .with_help_message(&help_message)
         .with_starting_cursor(default_index)
         .prompt()
@@ -528,14 +521,12 @@ fn prompt_boolean_data(data_name: &str, suggestion: Option<&LiteralValue>) -> Re
 }
 
 fn prompt_text_data_with_constraints(
-    data_name: &str,
-    type_str: &str,
+    prompt_title: &str,
     lemma_type: &LemmaType,
     suggestion: Option<&LiteralValue>,
     constraints: &TextConstraints,
 ) -> Result<String> {
     let default_str = suggestion.map(|l| l.to_string());
-    let prompt_message = prompt_label(data_name, type_str);
     let example = lemma_type.example_value();
 
     let TextConstraints { length, help } = constraints.clone();
@@ -555,7 +546,7 @@ fn prompt_text_data_with_constraints(
         Ok(Validation::Valid)
     };
 
-    let mut prompt = Text::new(&prompt_message).with_validator(validator);
+    let mut prompt = Text::new(prompt_title).with_validator(validator);
     let help_message = if help.is_empty() {
         format!("Example: {}", example)
     } else {
@@ -569,17 +560,15 @@ fn prompt_text_data_with_constraints(
 
     prompt
         .prompt()
-        .context(format!("Failed to get value for {}", data_name))
+        .context(format!("Failed to get value for {}", prompt_title))
 }
 
 fn prompt_simple_text(
-    data_name: &str,
-    type_str: &str,
+    prompt_title: &str,
     default_value: Option<&str>,
     help: &str,
     example: &str,
 ) -> Result<String> {
-    let prompt_message = prompt_label(data_name, type_str);
     let validator = |input: &str| {
         if input.trim().is_empty() {
             Ok(Validation::Invalid("Value is required".into()))
@@ -587,7 +576,7 @@ fn prompt_simple_text(
             Ok(Validation::Valid)
         }
     };
-    let mut prompt = Text::new(&prompt_message).with_validator(validator);
+    let mut prompt = Text::new(prompt_title).with_validator(validator);
     let help_message = if help.is_empty() {
         format!("Example: {}", example)
     } else {
@@ -599,12 +588,11 @@ fn prompt_simple_text(
     }
     prompt
         .prompt()
-        .context(format!("Failed to get value for {}", data_name))
+        .context(format!("Failed to get value for {}", prompt_title))
 }
 
 fn prompt_range_data(
     data_name: &str,
-    type_str: &str,
     lemma_type: &LemmaType,
     suggestion: Option<&LiteralValue>,
     help: &str,
@@ -626,38 +614,33 @@ fn prompt_range_data(
         _ => unreachable!("BUG: prompt_range_data called with non-range type"),
     };
 
+    let start_title = lemma_type.label_for_data_input(&format!("{data_name}.start"));
+    let end_title = lemma_type.label_for_data_input(&format!("{data_name}.end"));
+
     let left_value = prompt_simple_text(
-        &format!("{}.start", data_name),
-        type_str,
+        &start_title,
         left_default.as_deref(),
         help,
         endpoint_example,
     )?;
-    let right_value = prompt_simple_text(
-        &format!("{}.end", data_name),
-        type_str,
-        right_default.as_deref(),
-        help,
-        endpoint_example,
-    )?;
+    let right_value =
+        prompt_simple_text(&end_title, right_default.as_deref(), help, endpoint_example)?;
 
     Ok(format!("{}...{}", left_value.trim(), right_value.trim()))
 }
 
 fn prompt_number_data(
-    data_name: &str,
-    type_str: &str,
+    prompt_title: &str,
     suggestion: Option<&LiteralValue>,
     constraints: &NumericConstraints,
 ) -> Result<String> {
     let default_str = suggestion.map(|l| l.to_string());
-    let prompt_message = prompt_label(data_name, type_str);
-    prompt_decimal_input(&prompt_message, default_str.as_deref(), constraints, "10")
+    prompt_decimal_input(prompt_title, default_str.as_deref(), constraints, "10")
 }
 
 fn prompt_measure_data(
     data_name: &str,
-    type_str: &str,
+    prompt_title: &str,
     suggestion: Option<&LiteralValue>,
     units: &lemma::MeasureUnits,
     constraints: &NumericConstraints,
@@ -670,11 +653,9 @@ fn prompt_measure_data(
         _ => None,
     });
 
-    let prompt_message = prompt_label(data_name, type_str);
-
     if units.is_empty() {
         let default_str = suggestion.and_then(|lit| lit.magnitude_suggestion_for_decimal_prompt());
-        return prompt_decimal_input(&prompt_message, default_str.as_deref(), constraints, "7.65");
+        return prompt_decimal_input(prompt_title, default_str.as_deref(), constraints, "7.65");
     }
 
     let unit_names: Vec<String> = units.iter().map(|u| u.name.clone()).collect();
@@ -715,14 +696,13 @@ fn prompt_measure_data(
 
 fn prompt_ratio_data(
     data_name: &str,
-    type_str: &str,
+    prompt_title: &str,
     suggestion: Option<&LiteralValue>,
     units: &lemma::RatioUnits,
     minimum: Option<Decimal>,
     maximum: Option<Decimal>,
     help: &str,
 ) -> Result<String> {
-    let prompt_message = prompt_label(data_name, type_str);
     let selected_unit = if units.len() == 1 {
         units
             .iter()
@@ -746,7 +726,7 @@ fn prompt_ratio_data(
     };
 
     let value = prompt_decimal_input(
-        &prompt_message,
+        prompt_title,
         default_decimal.as_deref(),
         &NumericConstraints {
             minimum,
@@ -837,22 +817,37 @@ fn prompt_decimal_input(
 
 #[cfg(test)]
 mod tests {
-    use super::{next_prompt_name_from_results, prompt_label};
+    use super::next_prompt_name_from_results;
     use lemma::{DateTimeValue, Engine, SourceType, VetoType};
     use std::collections::HashMap;
     use std::sync::Arc;
 
     #[test]
-    fn prompt_label_omits_bracket_when_type_equals_name() {
+    fn label_for_data_input_matches_show_types() {
+        let code = r#"
+spec s
+data age: number
+data gender_code: text
+data gender: gender_code
+rule use_age: age
+rule use_gender: gender
+"#;
+        let mut engine = Engine::new();
+        engine
+            .load([(
+                SourceType::Path(Arc::new(std::path::PathBuf::from("t.lemma"))),
+                code.to_string(),
+            )])
+            .expect("plan");
+        let now = DateTimeValue::now();
+        let show = engine.show(None, "s", Some(&now)).expect("show");
+        let age = show.data.get("age").expect("age");
+        assert_eq!(age.lemma_type.label_for_data_input("age"), "age [number]");
+        let gender = show.data.get("gender").expect("gender");
         assert_eq!(
-            prompt_label("applicant_age", "applicant_age"),
-            "applicant_age"
-        );
-        assert_eq!(
-            prompt_label("gender", "gender_code"),
+            gender.lemma_type.label_for_data_input("gender"),
             "gender [gender_code]"
         );
-        assert_eq!(prompt_label("age", "number"), "age [number]");
     }
 
     fn run(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,7 @@ enum Commands {
         watch: bool,
         /// Enable explanation generation
         #[arg(long)]
-        explanations: bool,
+        explain: bool,
         /// Wall-clock timeout for a single evaluation request, in second
         #[arg(long, default_value = "10", value_name = "SECONDS")]
         eval_timeout: u64,
@@ -142,9 +142,9 @@ enum Commands {
         /// Workspace directory or `.lemma` file (default: current directory)
         #[arg(long, value_name = "PATH")]
         prefix: Option<PathBuf>,
-        /// Enable admin tools: add_spec, update_spec, remove_spec, clear, install (read-only by default)
+        /// Enable write tools: add_spec, update_spec, remove_spec, clear, install (read-only by default)
         #[arg(long)]
-        admin: bool,
+        write: bool,
         /// Wall-clock timeout for a single request, in second
         #[arg(long, default_value = "10", value_name = "SECONDS")]
         request_timeout: u64,
@@ -303,7 +303,7 @@ fn main() {
             host,
             port,
             watch,
-            explanations,
+            explain,
             eval_timeout,
             cors,
         } => server_command(
@@ -311,16 +311,16 @@ fn main() {
             host,
             *port,
             *watch,
-            *explanations,
+            *explain,
             *eval_timeout,
             *cors,
         ),
         Commands::Lsp { stdio: _ } => lsp_command(),
         Commands::Mcp {
             prefix,
-            admin,
+            write,
             request_timeout,
-        } => mcp_command(workspace_dir(prefix.as_ref()), *admin, *request_timeout),
+        } => mcp_command(workspace_dir(prefix.as_ref()), *write, *request_timeout),
         Commands::Install {
             dependency,
             prefix,
@@ -639,7 +639,7 @@ fn server_command(
     host: &str,
     port: u16,
     watch: bool,
-    explanations: bool,
+    explain: bool,
     eval_timeout_secs: u64,
     cors: bool,
 ) -> Result<()> {
@@ -666,7 +666,7 @@ fn server_command(
             host,
             port,
             watch,
-            explanations,
+            explain,
             source.to_path_buf(),
             eval_timeout_secs,
             cors,
@@ -682,12 +682,12 @@ fn lsp_command() -> Result<()> {
     lemma_lsp::stdio::run_stdio(Some(workspace_files)).map_err(anyhow::Error::from)
 }
 
-fn mcp_command(workdir: &Path, admin: bool, request_timeout_secs: u64) -> Result<()> {
+fn mcp_command(workdir: &Path, write: bool, request_timeout_secs: u64) -> Result<()> {
     let mut engine = Engine::new();
     load_workspace(&mut engine, workdir)?;
 
     let config = mcp::McpConfig {
-        admin,
+        write,
         request_timeout: std::time::Duration::from_secs(request_timeout_secs),
     };
 

--- a/cli/src/mcp/server.rs
+++ b/cli/src/mcp/server.rs
@@ -160,9 +160,9 @@ mod imp {
 
     /// Configuration for the MCP server.
     pub struct McpConfig {
-        /// When true, admin tools (`add_spec`, `update_spec`, `remove_spec`, `clear`, `install`)
+        /// When true, write tools (`add_spec`, `update_spec`, `remove_spec`, `clear`, `install`)
         /// are advertised and allowed. When false (default), the server is read-only.
-        pub admin: bool,
+        pub write: bool,
         /// Wall-clock budget for handling a single request. Requests that
         /// exceed it get a JSON-RPC internal error; the worker finishes the
         /// stale request in the background and its late response is discarded.
@@ -172,7 +172,7 @@ mod imp {
     impl Default for McpConfig {
         fn default() -> Self {
             Self {
-                admin: false,
+                write: false,
                 request_timeout: Duration::from_secs(10),
             }
         }
@@ -181,7 +181,7 @@ mod imp {
     struct McpServer {
         engine: Engine,
         config: McpConfig,
-        /// Workspace directory for admin persist (add / update / remove / clear / install).
+        /// Workspace directory for write persist (add / update / remove / clear / install).
         workdir: PathBuf,
         registry: Box<dyn lemma::Registry>,
         /// Set after a successful legacy `initialize`. Process-scoped (stdio lifetime).
@@ -192,12 +192,12 @@ mod imp {
     fn validated_write_path(workdir: &Path, source_path: &Path) -> Result<PathBuf, McpError> {
         if source_path.as_os_str().is_empty() {
             return Err(McpError::invalid_params(
-                "source_id path must be non-empty".to_string(),
+                "attribute path must be non-empty".to_string(),
             ));
         }
         if source_path.is_absolute() {
             return Err(McpError::invalid_params(
-                "source_id must be a relative path within the workspace".to_string(),
+                "attribute must be a relative path within the workspace".to_string(),
             ));
         }
         for component in source_path.components() {
@@ -205,12 +205,12 @@ mod imp {
                 Component::Normal(_) | Component::CurDir => {}
                 Component::ParentDir => {
                     return Err(McpError::invalid_params(
-                        "source_id must not contain '..'".to_string(),
+                        "attribute must not contain '..'".to_string(),
                     ));
                 }
                 _ => {
                     return Err(McpError::invalid_params(
-                        "source_id must be a relative path within the workspace".to_string(),
+                        "attribute must be a relative path within the workspace".to_string(),
                     ));
                 }
             }
@@ -457,7 +457,7 @@ mod imp {
                 .as_array_mut()
                 .expect("BUG: lemma::mcp::list_tools serializes as an array");
 
-            if self.config.admin {
+            if self.config.write {
                 tools.push(serde_json::json!({
                     "name": "add_spec",
                     "description": "Load Lemma source as one or more specs (persists). Prefer check first; check alone does not load. On failure returns structured diagnostics. After success, call source and present that formatted text in chat for user verify; do not paste the unformatted draft.",
@@ -468,12 +468,12 @@ mod imp {
                                 "type": "string",
                                 "description": "The complete Lemma code to add"
                             },
-                            "source_id": {
+                            "attribute": {
                                 "type": "string",
-                                "description": "Stable id for this source (e.g. pricing.lemma)"
+                                "description": "Source label (path or @owner/repo), e.g. pricing.lemma"
                             }
                         },
-                        "required": ["code", "source_id"]
+                        "required": ["code", "attribute"]
                     }
                 }));
                 tools.push(serde_json::json!({
@@ -490,9 +490,9 @@ mod imp {
                                 "type": "string",
                                 "description": "The complete new Lemma source"
                             },
-                            "source_id": {
+                            "attribute": {
                                 "type": "string",
-                                "description": "Stable id for this source (e.g. pricing.lemma)"
+                                "description": "Source label (path or @owner/repo), e.g. pricing.lemma"
                             },
                             "repository": {
                                 "type": "string",
@@ -503,7 +503,7 @@ mod imp {
                                 "description": "Effective datetime of the version to replace"
                             }
                         },
-                        "required": ["spec", "code", "source_id"]
+                        "required": ["spec", "code", "attribute"]
                     }
                 }));
                 tools.push(serde_json::json!({
@@ -603,10 +603,10 @@ mod imp {
 
             match tool_name {
                 "add_spec" | "update_spec" | "remove_spec" | "clear" | "install"
-                    if !self.config.admin =>
+                    if !self.config.write =>
                 {
                     Err(McpError::invalid_params(
-                        "Admin tools are disabled. Start the server with --admin to enable them."
+                        "Write tools are disabled. Start the server with --write to enable them."
                             .to_string(),
                     ))
                 }
@@ -615,7 +615,7 @@ mod imp {
                 "remove_spec" => self.tool_remove_spec(arguments),
                 "clear" => self.tool_clear(arguments),
                 "install" => self.tool_install(arguments),
-                "evaluate" => map_tool_result(lemma::mcp::evaluate(&self.engine, arguments)),
+                "run" | "evaluate" => map_tool_result(lemma::mcp::run(&self.engine, arguments)),
                 "list" => self.tool_list(arguments),
                 "show" => map_tool_result(lemma::mcp::show(&self.engine, arguments)),
                 "source" => map_tool_result(lemma::mcp::source(&self.engine, arguments)),
@@ -1108,37 +1108,20 @@ mod imp {
                 ));
             }
 
-            let source_id = args["source_id"]
+            let attribute = args["attribute"]
                 .as_str()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
-                .ok_or_else(|| McpError::invalid_params("Missing 'source_id' field".to_string()))?;
+                .ok_or_else(|| McpError::invalid_params("Missing 'attribute' field".to_string()))?;
 
-            let source_type = lemma::SourceType::from_binding_label(source_id)
+            let source_type = lemma::SourceType::from_binding_label(attribute)
                 .map_err(McpError::invalid_params)?;
 
             Ok((code, source_type))
         }
 
         fn tool_list(&self, args: &serde_json::Value) -> Result<serde_json::Value, McpError> {
-            let mut output = match lemma::mcp::list(&self.engine, args) {
-                Ok(text) => text,
-                Err(error) => return map_tool_result(Err(error)),
-            };
-
-            let workspace_empty = self
-                .engine
-                .list()
-                .into_iter()
-                .find(|repository_group| repository_group.repository.is_none())
-                .expect("BUG: workspace repository must exist after Engine::new")
-                .specs
-                .is_empty();
-            if self.config.admin && workspace_empty {
-                output.push_str("\n\nUse the 'add_spec' tool to load workspace Lemma source.");
-            }
-
-            Ok(text_content(output))
+            map_tool_result(lemma::mcp::list(&self.engine, args))
         }
     }
 
@@ -1214,8 +1197,8 @@ mod imp {
 
         info!("Starting Lemma MCP server v{}", SERVER_VERSION);
         info!("Protocol version: {}", PROTOCOL_VERSION);
-        if config.admin {
-            info!("Admin mode enabled (--admin)");
+        if config.write {
+            info!("Write mode enabled (--write)");
         } else {
             info!("Read-only mode (default)");
         }
@@ -1402,11 +1385,11 @@ mod imp {
             )
         }
 
-        fn admin_server(workdir: PathBuf) -> McpServer {
+        fn write_server(workdir: PathBuf) -> McpServer {
             McpServer::new(
                 Engine::new(),
                 McpConfig {
-                    admin: true,
+                    write: true,
                     ..McpConfig::default()
                 },
                 workdir,
@@ -1574,7 +1557,7 @@ mod imp {
         #[test]
         fn install_writes_file_and_loads() {
             let dir = tempfile::tempdir().unwrap();
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             let resp = s
                 .handle_request(tools_call(
                     1,
@@ -1607,7 +1590,7 @@ mod imp {
         #[test]
         fn install_force_must_be_bool() {
             let dir = tempfile::tempdir().unwrap();
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             for bad in [serde_json::json!("true"), serde_json::json!(1)] {
                 let resp = s
                     .handle_request(tools_call(
@@ -1625,7 +1608,7 @@ mod imp {
         #[test]
         fn install_skips_unchanged() {
             let dir = tempfile::tempdir().unwrap();
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             let first = s
                 .handle_request(tools_call(
                     1,
@@ -1654,7 +1637,7 @@ mod imp {
         #[test]
         fn install_missing_registry_spec_errors() {
             let dir = tempfile::tempdir().unwrap();
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             let resp = s
                 .handle_request(tools_call(
                     1,
@@ -1678,7 +1661,7 @@ mod imp {
         #[test]
         fn install_non_at_id_reaches_registry() {
             let dir = tempfile::tempdir().unwrap();
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             let resp = s
                 .handle_request(tools_call(
                     1,
@@ -1709,7 +1692,7 @@ mod imp {
             fs::create_dir_all(other.parent().unwrap()).unwrap();
             fs::write(&other, &fixture).unwrap();
 
-            let mut s = admin_server(dir.path().to_path_buf());
+            let mut s = write_server(dir.path().to_path_buf());
             let resp = s
                 .handle_request(tools_call(
                     1,

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -68,7 +68,7 @@ pub mod http {
     #[derive(Clone)]
     struct AppState {
         engine: SharedEngine,
-        explanations_enabled: bool,
+        explain: bool,
         eval_timeout: Duration,
     }
 
@@ -101,13 +101,6 @@ pub mod http {
                 }),
             )
         })
-    }
-
-    #[derive(serde::Serialize)]
-    struct GetSpecResponse {
-        spec_set_id: String,
-        #[serde(flatten)]
-        show: lemma::Show,
     }
 
     /// Build Memento-Datetime, Vary for the resolved spec.
@@ -152,7 +145,7 @@ pub mod http {
         host: &str,
         port: u16,
         watch: bool,
-        explanations: bool,
+        explain: bool,
         workdir: PathBuf,
         eval_timeout_secs: u64,
         cors: bool,
@@ -172,7 +165,7 @@ pub mod http {
 
         let state = AppState {
             engine: shared_engine,
-            explanations_enabled: explanations,
+            explain,
             eval_timeout: Duration::from_secs(eval_timeout_secs),
         };
 
@@ -245,11 +238,7 @@ pub mod http {
     ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
         let effective = resolve_effective(q.effective.as_deref())?;
         let engine = engine_snapshot(&state).await;
-        let spec = lemma_openapi::generate_openapi_effective(
-            &engine,
-            state.explanations_enabled,
-            &effective,
-        );
+        let spec = lemma_openapi::generate_openapi_effective(&engine, state.explain, &effective);
         Ok(Json(spec))
     }
 
@@ -411,11 +400,11 @@ pub mod http {
         Path(path): Path<String>,
         headers: HeaderMap,
     ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-        let spec_set_id = parse_spec_path(&path);
+        let raw_path = parse_spec_path(&path);
         let effective = accept_datetime_from_headers(&headers)?;
         let engine = engine_snapshot(&state).await;
 
-        let spec_name = lemma::parse_spec_set_id(&spec_set_id).map_err(|e| {
+        let spec_name = lemma::parse_spec_set_id(&raw_path).map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
@@ -438,9 +427,8 @@ pub mod http {
                     })?;
 
                 let effective_from = show.effective_from.clone();
-                let body = GetSpecResponse { spec_set_id, show };
 
-                let mut response = Json(body).into_response();
+                let mut response = Json(show).into_response();
                 let headers_mut = response.headers_mut();
                 for (k, v) in spec_response_headers(effective_from.as_ref()) {
                     headers_mut.insert(k, v);
@@ -513,7 +501,7 @@ pub mod http {
         Ok(data_values)
     }
 
-    /// `POST /{*path}` — evaluate; path = specset id. `Accept-Datetime` for temporal, `?rules=` to limit. Body = JSON or form data.
+    /// `POST /{*path}` — evaluate; path = spec name. `Accept-Datetime` for temporal, `?rules=` to limit. Body = JSON or form data.
     async fn spec_post_evaluate(
         State(state): State<AppState>,
         Path(path): Path<String>,
@@ -521,10 +509,10 @@ pub mod http {
         headers: HeaderMap,
         body: Bytes,
     ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-        let spec_set_id = parse_spec_path(&path);
+        let raw_path = parse_spec_path(&path);
         let effective = accept_datetime_from_headers(&headers)?;
 
-        let spec_name = lemma::parse_spec_set_id(&spec_set_id).map_err(|e| {
+        let spec_name = lemma::parse_spec_set_id(&raw_path).map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
@@ -553,7 +541,7 @@ pub mod http {
             }
         };
 
-        let include_explanations = want_explanations(&state, &headers);
+        let include_explanations = want_explain(&state, &headers);
         let engine = engine_snapshot(&state).await;
 
         // Evaluate on a blocking thread with no lock held. Post-planning
@@ -621,10 +609,10 @@ pub mod http {
         Ok(axum_response)
     }
 
-    fn want_explanations(state: &AppState, headers: &HeaderMap) -> bool {
-        state.explanations_enabled
+    fn want_explain(state: &AppState, headers: &HeaderMap) -> bool {
+        state.explain
             && headers
-                .get("x-explanations")
+                .get("x-explain")
                 .and_then(|v: &axum::http::HeaderValue| v.to_str().ok())
                 .map(|s: &str| !s.trim().is_empty())
                 .unwrap_or(false)

--- a/cli/tests/integrations/mcp.rs
+++ b/cli/tests/integrations/mcp.rs
@@ -4,37 +4,37 @@ use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 
 #[test]
-fn test_mcp_help_shows_admin_flag() {
+fn test_mcp_help_shows_write_flag() {
     let mut cmd = cargo_bin_cmd!("lemma");
     cmd.args(["mcp", "--help"]);
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("--admin"));
+        .stdout(predicates::str::contains("--write"));
 }
 
 /// Send JSON-RPC messages to the MCP server and collect responses.
 /// `prefix: None` runs `lemma mcp` without `--prefix` (defaults to process cwd).
 fn mcp_session(
     prefix: Option<&std::path::Path>,
-    admin: bool,
+    write: bool,
     messages: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
-    mcp_session_in_dir(prefix, None, admin, messages)
+    mcp_session_in_dir(prefix, None, write, messages)
 }
 
 fn mcp_session_in_dir(
     prefix: Option<&std::path::Path>,
     current_dir: Option<&std::path::Path>,
-    admin: bool,
+    write: bool,
     messages: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
-    mcp_session_with_env(prefix, current_dir, admin, &[], messages)
+    mcp_session_with_env(prefix, current_dir, write, &[], messages)
 }
 
 fn mcp_session_with_env(
     prefix: Option<&std::path::Path>,
     current_dir: Option<&std::path::Path>,
-    admin: bool,
+    write: bool,
     env: &[(&str, &str)],
     messages: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
@@ -47,8 +47,8 @@ fn mcp_session_with_env(
     if let Some(dir) = current_dir {
         cmd.current_dir(dir);
     }
-    if admin {
-        cmd.arg("--admin");
+    if write {
+        cmd.arg("--write");
     }
     for (key, value) in env {
         cmd.env(key, value);
@@ -248,6 +248,37 @@ fn test_mcp_list_returns_list() {
 }
 
 #[test]
+fn test_mcp_run_with_repository_lemma_units() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "server/discover", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "show",
+                    "arguments": {
+                        "repository": "lemma",
+                        "spec": "units"
+                    }
+                }),
+            ),
+        ],
+    );
+
+    assert!(responses.len() >= 2);
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("show text");
+    let show: serde_json::Value = serde_json::from_str(text).expect("Show JSON");
+    assert_eq!(show["spec"], "units");
+}
+
+#[test]
 fn test_mcp_evaluate_includes_reasoning() {
     let temp_dir = tempfile::tempdir().unwrap();
     write_spec(
@@ -265,11 +296,11 @@ fn test_mcp_evaluate_includes_reasoning() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "discount",
-                        "rule": "rate",
-                        "data": ["quantity=25"]
+                        "rules": "rate",
+                        "data": { "quantity": 25 }
                     }
                 }),
             ),
@@ -278,28 +309,86 @@ fn test_mcp_evaluate_includes_reasoning() {
 
     assert!(responses.len() >= 2, "Expected at least 2 responses");
 
-    let eval_result = &responses[1]["result"]["content"][0]["text"];
-    let text = eval_result.as_str().expect("evaluate should return text");
-
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    let rate = &response["results"]["rate"];
     assert!(
-        text.contains("rate:"),
-        "Should contain rule name, got: {text}"
+        rate["explanation"].is_object(),
+        "run always includes explanation, got: {text}"
     );
+    let display = rate["display"].as_str().unwrap_or("");
     assert!(
-        text.contains("Reasoning:"),
-        "Should contain reasoning section, got: {text}"
-    );
-    assert!(
-        text.contains("quantity >= 10"),
-        "Should state the matching condition as a fact in reasoning, got: {text}"
-    );
-    assert!(
-        text.contains("quantity: 25"),
-        "Should show the data value that drove the conditions, got: {text}"
-    );
-    assert!(
-        text.contains("10%") || text.contains("10 percent"),
+        display.contains("10%") || display.contains("10 percent"),
         "last-wins unless for quantity=25 must be 10 percent, got: {text}"
+    );
+    let explanation = serde_json::to_string(&rate["explanation"]).expect("serialize");
+    assert!(
+        explanation.contains("quantity >= 10") || explanation.contains("quantity"),
+        "explanation should reference quantity condition, got: {explanation}"
+    );
+}
+
+#[test]
+fn test_mcp_evaluate_alias_matches_run() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_spec(temp_dir.path(), "pricing.lemma", pricing_spec());
+
+    let run_responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "server/discover", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "run",
+                    "arguments": {
+                        "spec": "pricing",
+                        "rules": "total",
+                        "data": { "quantity": 3 }
+                    }
+                }),
+            ),
+        ],
+    );
+    let eval_responses = mcp_session(
+        Some(temp_dir.path()),
+        false,
+        &[
+            make_request(1, "server/discover", json!({})),
+            make_request(
+                2,
+                "tools/call",
+                json!({
+                    "name": "evaluate",
+                    "arguments": {
+                        "spec": "pricing",
+                        "rules": "total",
+                        "data": { "quantity": 3 }
+                    }
+                }),
+            ),
+        ],
+    );
+
+    let run_text = run_responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("run text");
+    let eval_text = eval_responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("evaluate text");
+    let run_json: serde_json::Value = serde_json::from_str(run_text).expect("run JSON");
+    let eval_json: serde_json::Value = serde_json::from_str(eval_text).expect("evaluate JSON");
+    assert_eq!(
+        run_json["results"]["total"]["display"],
+        eval_json["results"]["total"]["display"]
+    );
+    assert_eq!(
+        run_json["results"]["total"]["explanation"]["body"],
+        eval_json["results"]["total"]["explanation"]["body"]
     );
 }
 
@@ -321,11 +410,11 @@ fn test_mcp_evaluate_reports_missing_data_when_partial() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "pricing",
-                        "rule": "total",
-                        "data": ["quantity=2"]
+                        "rules": "total",
+                        "data": { "quantity": 2 }
                     }
                 }),
             ),
@@ -333,11 +422,11 @@ fn test_mcp_evaluate_reports_missing_data_when_partial() {
                 3,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "pricing",
-                        "rule": "total",
-                        "data": ["quantity=2", "price=10"]
+                        "rules": "total",
+                        "data": { "quantity": 2, "price": 10 }
                     }
                 }),
             ),
@@ -345,29 +434,35 @@ fn test_mcp_evaluate_reports_missing_data_when_partial() {
     );
 
     assert!(responses.len() >= 3);
-    let partial = responses[1]["result"]["content"][0]["text"]
-        .as_str()
-        .expect("partial evaluate text");
+    let partial: serde_json::Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .expect("partial run text"),
+    )
+    .expect("partial Response JSON");
+    let missing = partial["results"]["total"]["missing_data"]
+        .as_array()
+        .expect("missing_data array");
     assert!(
-        partial.contains("missing_data:"),
-        "partial evaluate must report missing_data, got: {partial}"
-    );
-    assert!(
-        partial.contains("price:"),
-        "missing_data must include price with type, got: {partial}"
+        missing.iter().any(|v| v == "price"),
+        "missing_data must include price, got: {missing:?}"
     );
 
-    let complete = responses[2]["result"]["content"][0]["text"]
-        .as_str()
-        .expect("complete evaluate text");
+    let complete: serde_json::Value = serde_json::from_str(
+        responses[2]["result"]["content"][0]["text"]
+            .as_str()
+            .expect("complete run text"),
+    )
+    .expect("complete Response JSON");
     assert!(
-        !complete.contains("missing_data:"),
-        "complete evaluate must omit missing_data, got: {complete}"
+        complete["results"]["total"]["missing_data"].is_null()
+            || complete["results"]["total"]["missing_data"]
+                .as_array()
+                .map(|a| a.is_empty())
+                .unwrap_or(false),
+        "complete run must omit missing_data, got: {complete}"
     );
-    assert!(
-        complete.contains("total:"),
-        "complete evaluate must show rule result, got: {complete}"
-    );
+    assert_eq!(complete["results"]["total"]["display"], "20");
 }
 
 #[test]
@@ -397,11 +492,11 @@ rule premium: (1 / denom) * loading
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "settle",
-                        "rule": "premium",
-                        "data": ["denom=0"]
+                        "rules": "premium",
+                        "data": { "denom": 0 }
                     }
                 }),
             ),
@@ -411,19 +506,25 @@ rule premium: (1 / denom) * loading
     assert!(responses.len() >= 2);
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate text");
+        .expect("run text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    let premium = &response["results"]["premium"];
     assert!(
-        text.contains("premium:"),
-        "settled evaluate must show rule answer, got: {text}"
+        premium["vetoed"].as_bool() == Some(true) || premium.get("display").is_some(),
+        "settled run must show rule answer, got: {text}"
     );
     assert!(
-        !text.contains("missing_data:"),
-        "settled Computation must not print missing_data for leftover live keys, got: {text}"
+        premium["missing_data"].is_null()
+            || premium["missing_data"]
+                .as_array()
+                .map(|a| a.is_empty())
+                .unwrap_or(false),
+        "settled Computation must not list missing_data for leftover live keys, got: {text}"
     );
 }
 
 #[test]
-fn test_mcp_evaluate_missing_data_includes_help() {
+fn test_mcp_run_missing_data_keys_only_help_on_show() {
     let temp_dir = tempfile::tempdir().unwrap();
     write_spec(
         temp_dir.path(),
@@ -445,32 +546,49 @@ rule total: quantity * price
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "show",
+                    "arguments": { "spec": "pricing" }
+                }),
+            ),
+            make_request(
+                3,
+                "tools/call",
+                json!({
+                    "name": "run",
                     "arguments": {
                         "spec": "pricing",
-                        "rule": "total",
-                        "data": ["quantity=2"]
+                        "rules": "total",
+                        "data": { "quantity": 2 }
                     }
                 }),
             ),
         ],
     );
 
-    assert!(responses.len() >= 2);
-    let text = responses[1]["result"]["content"][0]["text"]
-        .as_str()
-        .expect("evaluate text");
-    assert!(
-        text.contains("missing_data:"),
-        "must report missing_data, got: {text}"
+    assert!(responses.len() >= 3);
+    let show: serde_json::Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .expect("show text"),
+    )
+    .expect("Show JSON");
+    assert_eq!(
+        show["data"]["price"]["type"]["help"],
+        "Unit price of the item."
     );
+
+    let run: serde_json::Value = serde_json::from_str(
+        responses[2]["result"]["content"][0]["text"]
+            .as_str()
+            .expect("run text"),
+    )
+    .expect("Response JSON");
+    let missing = run["results"]["total"]["missing_data"]
+        .as_array()
+        .expect("missing_data array");
     assert!(
-        text.contains("Unit price of the item."),
-        "missing_data line must include -> help text, got: {text}"
-    );
-    assert!(
-        text.contains("price:") && text.contains("number"),
-        "missing_data line must include name and type, got: {text}"
+        missing.iter().any(|v| v == "price"),
+        "missing_data keys must include price, got: {missing:?}"
     );
 }
 
@@ -499,7 +617,7 @@ fn test_mcp_read_only_by_default() {
 
     assert!(responses.len() >= 3, "Expected at least 3 responses");
 
-    // tools/list should NOT include admin tools
+    // tools/list should NOT include write tools
     let tools = &responses[1]["result"]["tools"];
     let tool_names: Vec<&str> = tools
         .as_array()
@@ -548,14 +666,14 @@ fn test_mcp_read_only_by_default() {
         error["message"]
             .as_str()
             .unwrap()
-            .contains("Admin tools are disabled"),
-        "Error should mention admin tools are disabled, got: {}",
+            .contains("Write tools are disabled"),
+        "Error should mention write tools are disabled, got: {}",
         error["message"]
     );
 }
 
 #[test]
-fn test_mcp_admin_enables_add_spec() {
+fn test_mcp_write_enables_add_spec() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -571,7 +689,7 @@ fn test_mcp_admin_enables_add_spec() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec test_spec\ndata x: 5\nrule y: x * 2",
-                        "source_id": "test_spec.lemma"
+                        "attribute": "test_spec.lemma"
                     }
                 }),
             ),
@@ -580,7 +698,7 @@ fn test_mcp_admin_enables_add_spec() {
 
     assert!(responses.len() >= 3, "Expected at least 3 responses");
 
-    // tools/list should include admin tools
+    // tools/list should include write tools
     let tools = &responses[1]["result"]["tools"];
     let tool_names: Vec<&str> = tools
         .as_array()
@@ -590,27 +708,27 @@ fn test_mcp_admin_enables_add_spec() {
         .collect();
     assert!(
         tool_names.contains(&"add_spec"),
-        "add_spec should be listed with --admin, got: {:?}",
+        "add_spec should be listed with --write, got: {:?}",
         tool_names
     );
     assert!(
         tool_names.contains(&"update_spec"),
-        "update_spec should be listed with --admin, got: {:?}",
+        "update_spec should be listed with --write, got: {:?}",
         tool_names
     );
     assert!(
         tool_names.contains(&"remove_spec"),
-        "remove_spec should be listed with --admin, got: {:?}",
+        "remove_spec should be listed with --write, got: {:?}",
         tool_names
     );
     assert!(
         tool_names.contains(&"clear"),
-        "clear should be listed with --admin, got: {:?}",
+        "clear should be listed with --write, got: {:?}",
         tool_names
     );
     assert!(
         tool_names.contains(&"install"),
-        "install should be listed with --admin, got: {:?}",
+        "install should be listed with --write, got: {:?}",
         tool_names
     );
     assert!(
@@ -702,7 +820,7 @@ fn test_mcp_source_embedded_lemma_repository() {
 }
 
 #[test]
-fn test_mcp_source_without_admin() {
+fn test_mcp_source_without_write() {
     let temp_dir = tempfile::tempdir().unwrap();
     write_spec(
         temp_dir.path(),
@@ -732,10 +850,10 @@ fn test_mcp_source_without_admin() {
 
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("source should return text without --admin");
+        .expect("source should return text without --write");
     assert!(
         text.contains("spec pricing"),
-        "source without --admin should return formatted source, got: {text}"
+        "source without --write should return formatted source, got: {text}"
     );
 }
 
@@ -876,13 +994,11 @@ fn test_mcp_show_missing_spec() {
     );
 
     assert!(responses.len() >= 2);
-    let error = &responses[1]["error"];
-    assert!(error.is_object(), "Should return an error for missing spec");
-    assert!(
-        error["message"].as_str().unwrap().contains("not found"),
-        "Error should say spec not found, got: {}",
-        error["message"]
-    );
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], true, "missing spec must be isError");
+    let text = result["content"][0]["text"].as_str().expect("diagnostics");
+    let diagnostics: serde_json::Value = serde_json::from_str(text).expect("EngineError JSON");
+    assert!(diagnostics.is_array() && !diagnostics.as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -933,7 +1049,7 @@ fn test_mcp_evaluate_all_rules() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "multi" }
                 }),
             ),
@@ -943,18 +1059,10 @@ fn test_mcp_evaluate_all_rules() {
     assert!(responses.len() >= 2);
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-
-    assert!(
-        text.contains("double:"),
-        "Should contain double rule, got: {text}"
-    );
-    assert!(
-        text.contains("triple:"),
-        "Should contain triple rule, got: {text}"
-    );
-    assert!(text.contains("6"), "double should be 6, got: {text}");
-    assert!(text.contains("9"), "triple should be 9, got: {text}");
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    assert_eq!(response["results"]["double"]["display"], "6");
+    assert_eq!(response["results"]["triple"]["display"], "9");
 }
 
 #[test]
@@ -970,7 +1078,7 @@ fn test_mcp_evaluate_missing_spec() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "nonexistent" }
                 }),
             ),
@@ -978,8 +1086,13 @@ fn test_mcp_evaluate_missing_spec() {
     );
 
     assert!(responses.len() >= 2);
-    let error = &responses[1]["error"];
-    assert!(error.is_object(), "Should return an error for missing spec");
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], true, "missing spec must be isError");
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("diagnostics text");
+    let diagnostics: serde_json::Value = serde_json::from_str(text).expect("EngineError JSON");
+    assert!(diagnostics.is_array() && !diagnostics.as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -995,7 +1108,7 @@ fn test_mcp_evaluate_empty_spec_name() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "" }
                 }),
             ),
@@ -1033,7 +1146,7 @@ fn test_mcp_evaluate_veto_result() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "vetoed" }
                 }),
             ),
@@ -1043,16 +1156,11 @@ fn test_mcp_evaluate_veto_result() {
     assert!(responses.len() >= 2);
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-
-    assert!(
-        text.contains("veto"),
-        "Should contain veto in output, got: {text}"
-    );
-    assert!(
-        text.contains("Price cannot be negative"),
-        "Should contain veto reason, got: {text}"
-    );
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    let validated = &response["results"]["validated"];
+    assert_eq!(validated["vetoed"], true);
+    assert_eq!(validated["veto_reason"], "Price cannot be negative");
 }
 
 #[test]
@@ -1073,7 +1181,7 @@ fn test_mcp_evaluate_with_effective_datetime() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "simple",
                         "effective": "2026-01-01"
@@ -1086,14 +1194,14 @@ fn test_mcp_evaluate_with_effective_datetime() {
     assert!(responses.len() >= 2);
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    assert_eq!(response["results"]["y"]["display"], "42");
     assert!(
-        text.contains("y:"),
-        "Should contain rule result, got: {text}"
-    );
-    assert!(
-        text.contains("2026-01-01"),
+        response["effective"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("2026-01-01"),
         "Should show effective datetime, got: {text}"
     );
 }
@@ -1140,7 +1248,7 @@ fn test_mcp_list_empty_workspace() {
 }
 
 #[test]
-fn test_mcp_list_empty_workspace_admin_suggests_add() {
+fn test_mcp_list_empty_workspace_is_valid_json() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -1163,13 +1271,11 @@ fn test_mcp_list_empty_workspace_admin_suggests_add() {
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
         .expect("list should return text");
+    let list: serde_json::Value = serde_json::from_str(text).expect("list must be valid JSON");
+    assert!(list.is_array(), "list must be JSON array, got: {text}");
     assert!(
-        text.contains("\"repository\": \"lemma\"") && text.contains("\"name\": \"units\""),
-        "embedded stdlib must appear, got: {text}"
-    );
-    assert!(
-        text.contains("add_spec"),
-        "Admin mode should suggest using add_spec when workspace is empty, got: {text}"
+        !text.contains("add_spec"),
+        "list must not append prose hints, got: {text}"
     );
 }
 
@@ -1248,7 +1354,7 @@ fn test_mcp_legacy_initialize_then_tools_list_read_only() {
     assert_initialize_result(&responses[0], &json!(0));
 
     let names = tool_names(&responses[1]);
-    for required in ["evaluate", "list", "show"] {
+    for required in ["run", "list", "show"] {
         assert!(
             names.iter().any(|n| n == required),
             "tools/list after initialize must include {required}, got: {names:?}"
@@ -1261,7 +1367,7 @@ fn test_mcp_legacy_initialize_then_tools_list_read_only() {
 }
 
 #[test]
-fn test_mcp_legacy_initialize_then_tools_list_admin() {
+fn test_mcp_legacy_initialize_then_tools_list_write() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -1286,10 +1392,10 @@ fn test_mcp_legacy_initialize_then_tools_list_admin() {
     assert_initialize_result(&responses[0], &json!(0));
 
     let names = tool_names(&responses[1]);
-    for required in ["evaluate", "list", "show", "add_spec"] {
+    for required in ["run", "list", "show", "add_spec"] {
         assert!(
             names.iter().any(|n| n == required),
-            "admin tools/list after initialize must include {required}, got: {names:?}"
+            "write tools/list after initialize must include {required}, got: {names:?}"
         );
     }
 }
@@ -1359,7 +1465,7 @@ fn test_mcp_initialize_string_id() {
 }
 
 #[test]
-fn test_mcp_initialize_with_admin_flag_independent() {
+fn test_mcp_initialize_with_write_flag_independent() {
     let temp_dir = tempfile::tempdir().unwrap();
     let responses = mcp_session(
         Some(temp_dir.path()),
@@ -1475,8 +1581,8 @@ fn test_mcp_tools_list_with_modern_meta_no_initialize() {
     );
     let names = tool_names(&responses[0]);
     assert!(
-        names.iter().any(|n| n == "evaluate"),
-        "modern tools/list must include evaluate, got: {names:?}"
+        names.iter().any(|n| n == "run"),
+        "modern tools/list must include run, got: {names:?}"
     );
 }
 
@@ -1752,8 +1858,8 @@ fn test_mcp_request_timeout_returns_error() {
         1,
         "tools/call",
         json!({
-            "name": "evaluate",
-            "arguments": { "spec": "slow_spec", "data": ["x=1"] }
+            "name": "run",
+            "arguments": { "spec": "slow_spec", "data": { "x": 1 } }
         }),
     );
     let mut input = serde_json::to_string(&request).unwrap();
@@ -1833,7 +1939,7 @@ fn test_mcp_add_spec_invalid_code() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "this is not valid lemma code !!!",
-                        "source_id": "invalid.lemma"
+                        "attribute": "invalid.lemma"
                     }
                 }),
             ),
@@ -1882,19 +1988,20 @@ fn test_mcp_tools_list_read_only_tools() {
         .expect("tools should be an array");
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
 
-    assert!(
-        tool_names.contains(&"evaluate"),
-        "Should list evaluate tool"
-    );
+    assert!(tool_names.contains(&"run"), "Should list run tool");
     assert!(tool_names.contains(&"list"), "Should list list tool");
     assert!(tool_names.contains(&"show"), "Should list show tool");
     assert!(tool_names.contains(&"source"), "Should list source tool");
     assert!(tool_names.contains(&"check"), "Should list check tool");
     assert!(tool_names.contains(&"guide"), "Should list guide tool");
+    assert!(
+        tool_names.contains(&"evaluate"),
+        "Should list deprecated evaluate alias"
+    );
     assert_eq!(
         tool_names.len(),
-        6,
-        "Read-only mode should have exactly 6 tools, got: {:?}",
+        7,
+        "Read-only mode should have exactly 7 tools, got: {:?}",
         tool_names
     );
 }
@@ -1915,7 +2022,7 @@ fn test_mcp_remove_spec_and_clear() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec draft\ndata x: number\nrule y: x\n",
-                        "source_id": "draft.lemma"
+                        "attribute": "draft.lemma"
                     }
                 }),
             ),
@@ -1936,7 +2043,7 @@ fn test_mcp_remove_spec_and_clear() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec again\ndata z: 1\nrule r: z\n",
-                        "source_id": "again.lemma"
+                        "attribute": "again.lemma"
                     }
                 }),
             ),
@@ -2021,7 +2128,7 @@ fn test_mcp_remove_spec_rewrites_shared_path_file() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec first\ndata a: 1\nrule x: a\n\nspec second\ndata b: 2\nrule y: b\n",
-                        "source_id": "pair.lemma"
+                        "attribute": "pair.lemma"
                     }
                 }),
             ),
@@ -2173,7 +2280,7 @@ fn test_mcp_clear_description_leads_with_remove_all() {
 }
 
 #[test]
-fn test_mcp_remove_spec_blocked_without_admin() {
+fn test_mcp_remove_spec_blocked_without_write() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -2205,13 +2312,13 @@ fn test_mcp_remove_spec_blocked_without_admin() {
         let error = &responses[i]["error"];
         assert!(
             error.is_object(),
-            "admin tool call {i} must error without --admin"
+            "write tool call {i} must error without --write"
         );
         assert!(
             error["message"]
                 .as_str()
                 .unwrap()
-                .contains("Admin tools are disabled"),
+                .contains("Write tools are disabled"),
             "got: {}",
             error["message"]
         );
@@ -2219,7 +2326,7 @@ fn test_mcp_remove_spec_blocked_without_admin() {
 }
 
 #[test]
-fn test_mcp_install_blocked_without_admin() {
+fn test_mcp_install_blocked_without_write() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -2240,23 +2347,23 @@ fn test_mcp_install_blocked_without_admin() {
 
     assert!(responses.len() >= 2);
     let error = &responses[1]["error"];
-    assert!(error.is_object(), "install without admin must error");
+    assert!(error.is_object(), "install without write must error");
     assert!(
         error["message"]
             .as_str()
             .unwrap()
-            .contains("Admin tools are disabled"),
+            .contains("Write tools are disabled"),
         "got: {}",
         error["message"]
     );
     assert!(
         !temp_dir.path().join("lemma_deps").exists(),
-        "install without admin must not write lemma_deps"
+        "install without write must not write lemma_deps"
     );
 }
 
 #[test]
-fn test_mcp_tools_list_admin_tools() {
+fn test_mcp_tools_list_write_tools() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -2274,39 +2381,40 @@ fn test_mcp_tools_list_admin_tools() {
         .expect("tools should be an array");
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
 
-    assert!(
-        tool_names.contains(&"evaluate"),
-        "Should list evaluate tool"
-    );
+    assert!(tool_names.contains(&"run"), "Should list run tool");
     assert!(tool_names.contains(&"list"), "Should list list tool");
     assert!(tool_names.contains(&"show"), "Should list show tool");
     assert!(tool_names.contains(&"check"), "Should list check tool");
     assert!(tool_names.contains(&"guide"), "Should list guide tool");
     assert!(
         tool_names.contains(&"add_spec"),
-        "Should list add_spec tool in admin mode"
+        "Should list add_spec tool in write mode"
     );
     assert!(
         tool_names.contains(&"update_spec"),
-        "Should list update_spec tool in admin mode"
+        "Should list update_spec tool in write mode"
     );
     assert!(
         tool_names.contains(&"remove_spec"),
-        "Should list remove_spec tool in admin mode"
+        "Should list remove_spec tool in write mode"
     );
     assert!(
         tool_names.contains(&"clear"),
-        "Should list clear tool in admin mode"
+        "Should list clear tool in write mode"
     );
     assert!(
         tool_names.contains(&"install"),
-        "Should list install tool in admin mode"
+        "Should list install tool in write mode"
     );
     assert!(tool_names.contains(&"source"), "Should list source tool");
+    assert!(
+        tool_names.contains(&"evaluate"),
+        "Should list deprecated evaluate alias"
+    );
     assert_eq!(
         tool_names.len(),
-        11,
-        "Admin mode should have exactly 11 tools, got: {:?}",
+        12,
+        "Write mode should have exactly 12 tools, got: {:?}",
         tool_names
     );
 }
@@ -2365,10 +2473,10 @@ fn test_mcp_evaluate_with_data_overrides() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "pricing",
-                        "data": ["quantity=5"]
+                        "data": { "quantity": 5 }
                     }
                 }),
             ),
@@ -2378,16 +2486,9 @@ fn test_mcp_evaluate_with_data_overrides() {
     assert!(responses.len() >= 2);
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-
-    assert!(
-        text.contains("total:"),
-        "Should contain rule result, got: {text}"
-    );
-    assert!(
-        text.contains("50"),
-        "total should be 5 * 10 = 50, got: {text}"
-    );
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    assert_eq!(response["results"]["total"]["display"], "50");
 }
 
 // ── add_spec then evaluate ──────────────────────────────────────────────
@@ -2408,7 +2509,7 @@ fn test_mcp_add_spec_then_evaluate() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec dynamic\ndata n: 7\nrule doubled: n * 2\n",
-                        "source_id": "dynamic.lemma"
+                        "attribute": "dynamic.lemma"
                     }
                 }),
             ),
@@ -2416,7 +2517,7 @@ fn test_mcp_add_spec_then_evaluate() {
                 3,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "dynamic" }
                 }),
             ),
@@ -2432,15 +2533,9 @@ fn test_mcp_add_spec_then_evaluate() {
 
     let eval_text = responses[2]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-    assert!(
-        eval_text.contains("doubled:"),
-        "Should contain rule, got: {eval_text}"
-    );
-    assert!(
-        eval_text.contains("14"),
-        "doubled should be 14, got: {eval_text}"
-    );
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(eval_text).expect("Response JSON");
+    assert_eq!(response["results"]["doubled"]["display"], "14");
 }
 
 #[test]
@@ -2473,7 +2568,7 @@ rule total: d.value
                     "arguments": {
                         "spec": "dep",
                         "code": "spec dep\ndata value: 20\nrule out: value\n",
-                        "source_id": "dep.lemma"
+                        "attribute": "dep.lemma"
                     }
                 }),
             ),
@@ -2481,7 +2576,7 @@ rule total: d.value
                 3,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": { "spec": "consumer" }
                 }),
             ),
@@ -2497,15 +2592,9 @@ rule total: d.value
 
     let eval_text = responses[2]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate should return text");
-    assert!(
-        eval_text.contains("total:"),
-        "Should contain total rule, got: {eval_text}"
-    );
-    assert!(
-        eval_text.contains("20"),
-        "total should be 20 after update, got: {eval_text}"
-    );
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(eval_text).expect("Response JSON");
+    assert_eq!(response["results"]["total"]["display"], "20");
 }
 
 #[test]
@@ -2525,7 +2614,7 @@ fn test_add_spec_persists_to_disk() {
                     "name": "add_spec",
                     "arguments": {
                         "code": code,
-                        "source_id": "dynamic.lemma"
+                        "attribute": "dynamic.lemma"
                     }
                 }),
             ),
@@ -2573,7 +2662,7 @@ fn test_update_spec_persists_to_disk() {
                     "arguments": {
                         "spec": "dep",
                         "code": new_code,
-                        "source_id": "dep.lemma"
+                        "attribute": "dep.lemma"
                     }
                 }),
             ),
@@ -2613,7 +2702,7 @@ fn test_add_spec_path_traversal_rejected() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec escape\ndata x: 1\nrule y: x\n",
-                        "source_id": "../escape.lemma"
+                        "attribute": "../escape.lemma"
                     }
                 }),
             ),
@@ -2659,7 +2748,7 @@ fn test_add_spec_write_failure_rolls_back_engine() {
                     "name": "add_spec",
                     "arguments": {
                         "code": "spec trapped\ndata x: 1\nrule y: x\n",
-                        "source_id": "blocked/trapped.lemma"
+                        "attribute": "blocked/trapped.lemma"
                     }
                 }),
             ),
@@ -2726,13 +2815,11 @@ fn test_mcp_source_missing_spec() {
     );
 
     assert!(responses.len() >= 2);
-    let error = &responses[1]["error"];
-    assert!(error.is_object(), "Should return an error for missing spec");
-    assert!(
-        error["message"].as_str().unwrap().contains("not found"),
-        "Error should say spec not found, got: {}",
-        error["message"]
-    );
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], true, "missing spec must be isError");
+    let text = result["content"][0]["text"].as_str().expect("diagnostics");
+    let diagnostics: serde_json::Value = serde_json::from_str(text).expect("EngineError JSON");
+    assert!(diagnostics.is_array() && !diagnostics.as_array().unwrap().is_empty());
 }
 
 // ── evaluate with invalid effective ─────────────────────────────────────
@@ -2755,7 +2842,7 @@ fn test_mcp_evaluate_invalid_effective() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "simple",
                         "effective": "not-a-date"
@@ -2766,18 +2853,15 @@ fn test_mcp_evaluate_invalid_effective() {
     );
 
     assert!(responses.len() >= 2);
-    let error = &responses[1]["error"];
-    assert!(
-        error.is_object(),
-        "Should return an error for invalid effective datetime"
+    let result = &responses[1]["result"];
+    assert_eq!(
+        result["isError"], true,
+        "Should return isError for invalid effective datetime"
     );
+    let text = result["content"][0]["text"].as_str().expect("diagnostics");
     assert!(
-        error["message"]
-            .as_str()
-            .unwrap()
-            .contains("Invalid effective"),
-        "Error should mention invalid effective, got: {}",
-        error["message"]
+        text.contains("Invalid effective"),
+        "Error should mention invalid effective, got: {text}"
     );
 }
 
@@ -2807,11 +2891,11 @@ rule total: base
                     2,
                     "tools/call",
                     json!({
-                        "name": "evaluate",
+                        "name": "run",
                         "arguments": {
                             "spec": "pricing",
                             "effective": effective,
-                            "rule": "total"
+                            "rules": "total"
                         }
                     }),
                 ),
@@ -2826,14 +2910,10 @@ rule total: base
 
     let out_2025 = run_eval("2025-06-01");
     let out_2026 = run_eval("2026-06-01");
-    assert!(
-        out_2025.contains("10") && !out_2025.contains("99"),
-        "2025 body should use v2025 base=10; got:\n{out_2025}"
-    );
-    assert!(
-        out_2026.contains("99"),
-        "2026 body should use v2026 base=99; got:\n{out_2026}"
-    );
+    let r2025: serde_json::Value = serde_json::from_str(&out_2025).expect("Response JSON");
+    let r2026: serde_json::Value = serde_json::from_str(&out_2026).expect("Response JSON");
+    assert_eq!(r2025["results"]["total"]["display"], "10");
+    assert_eq!(r2026["results"]["total"]["display"], "99");
 }
 
 // ── response IDs match request IDs ──────────────────────────────────────
@@ -2871,7 +2951,7 @@ fn test_mcp_response_ids_match_request_ids() {
 }
 
 #[test]
-fn mcp_add_spec_without_source_id_must_require_source_id() {
+fn mcp_add_spec_without_attribute_must_require_attribute() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let responses = mcp_session(
@@ -2895,7 +2975,7 @@ fn mcp_add_spec_without_source_id_must_require_source_id() {
     assert!(responses.len() >= 2);
     assert!(
         responses[1]["error"].is_object(),
-        "add_spec without source_id must return error, got: {}",
+        "add_spec without attribute must return error, got: {}",
         responses[1]
     );
 }
@@ -2918,7 +2998,7 @@ fn mcp_evaluate_veto_must_not_invent_vetoed_placeholder() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "veto_no_message"
                     }
@@ -2928,8 +3008,16 @@ fn mcp_evaluate_veto_must_not_invent_vetoed_placeholder() {
     );
 
     assert!(responses.len() >= 2);
-    let eval_result = &responses[1]["result"]["content"][0]["text"];
-    let text = eval_result.as_str().expect("evaluate should return text");
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("run should return text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    let rule = &response["results"]["r"];
+    assert_eq!(rule["vetoed"], true);
+    assert!(
+        rule.get("veto_reason").is_none() || rule["veto_reason"].is_null(),
+        "bare veto must omit invented veto_reason, got: {text}"
+    );
     assert!(
         !text.contains("Vetoed"),
         "MCP must not invent 'Vetoed' placeholder when veto_reason missing, got: {text}"
@@ -3014,10 +3102,9 @@ fn test_mcp_check_does_not_mutate_list() {
             || responses[2]["result"]["isError"] != true,
         "valid check must succeed"
     );
-    assert!(
-        check_text.contains("Parsed and planned"),
-        "check should return success message, got: {check_text}"
-    );
+    let check_json: serde_json::Value =
+        serde_json::from_str(check_text).expect("check success is quality JSON");
+    assert!(check_json.is_array(), "check success must be JSON array");
     let list_after = responses[3]["result"]["content"][0]["text"]
         .as_str()
         .expect("list text");
@@ -3053,7 +3140,7 @@ fn test_mcp_check_resolves_workspace_and_units() {
                     "arguments": {
                         "sources": [
                             ["base", "spec base\ndata flag: boolean\nrule ok: flag\n"],
-                            ["ship", "spec ship\nuses lemma units\nuses base\ndata package_weight: units.mass\nrule heavy: package_weight > 0 units.kilogram\n"]
+                            ["ship", "spec ship\nuses lemma units\nuses base\ndata package_weight: units.mass\nrule heavy: package_weight > 0 units.mass.kilogram\n"]
                         ]
                     }
                 }),
@@ -3068,10 +3155,9 @@ fn test_mcp_check_resolves_workspace_and_units() {
         "check with uses lemma units + cross-spec uses must succeed, got: {result}"
     );
     let text = result["content"][0]["text"].as_str().expect("text");
-    assert!(
-        text.contains("Parsed and planned"),
-        "check should return success message, got: {text}"
-    );
+    let check_json: serde_json::Value =
+        serde_json::from_str(text).expect("check success is quality JSON");
+    assert!(check_json.is_array(), "check success must be JSON array");
 }
 
 #[test]
@@ -3148,21 +3234,14 @@ rule is_eligible: true
         "check must succeed with recommendations, got: {result}"
     );
     let text = result["content"][0]["text"].as_str().expect("text");
+    let recs: serde_json::Value =
+        serde_json::from_str(text).expect("check success is quality JSON");
+    let arr = recs.as_array().expect("quality array");
+    assert!(!arr.is_empty(), "must list recommendations, got: {text}");
+    let joined = serde_json::to_string(&recs).expect("serialize");
     assert!(
-        text.contains("Parsed and planned"),
-        "success path must keep advisory framing, got: {text}"
-    );
-    assert!(
-        text.contains("Recommendations:"),
-        "must list recommendations, got: {text}"
-    );
-    assert!(
-        text.contains("is_eligible") && text.contains("veto"),
+        joined.contains("is_eligible") && joined.contains("veto"),
         "must report veto-as-rejection cascade, got: {text}"
-    );
-    assert!(
-        text.contains("In spec 'eligibility' (effective from 2026-01-01)"),
-        "must identify temporal slice in Display output, got: {text}"
     );
 }
 
@@ -3208,9 +3287,11 @@ rule total: qty
         "clean check must succeed, got: {result}"
     );
     let text = result["content"][0]["text"].as_str().expect("text");
-    assert!(text.contains("Parsed and planned"), "got: {text}");
-    assert!(
-        !text.contains("Recommendations:"),
+    let recs: serde_json::Value =
+        serde_json::from_str(text).expect("check success is quality JSON");
+    assert_eq!(
+        recs.as_array().map(|a| a.len()).unwrap_or(1),
+        0,
         "clean spec must not emit recommendations, got: {text}"
     );
 }
@@ -3336,11 +3417,11 @@ fn test_mcp_evaluate_renders_unit_map() {
                 2,
                 "tools/call",
                 json!({
-                    "name": "evaluate",
+                    "name": "run",
                     "arguments": {
                         "spec": "money",
-                        "rule": "total",
-                        "data": ["amount=84 eur"]
+                        "rules": "total",
+                        "data": { "amount": "84 eur" }
                     }
                 }),
             ),
@@ -3353,14 +3434,12 @@ fn test_mcp_evaluate_renders_unit_map() {
     );
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
-        .expect("evaluate text");
+        .expect("run text");
+    let response: serde_json::Value = serde_json::from_str(text).expect("Response JSON");
+    let measure = &response["results"]["total"]["measure"];
     assert!(
-        text.contains("eur") && text.contains("cent"),
-        "evaluate must render every declared unit, got: {text}"
-    );
-    assert!(
-        text.contains('(') && text.contains(')'),
-        "unit map should be parenthesized, got: {text}"
+        measure.get("eur").is_some() && measure.get("cent").is_some(),
+        "run must expose every declared unit in measure map, got: {text}"
     );
 }
 

--- a/cli/tests/integrations/server.rs
+++ b/cli/tests/integrations/server.rs
@@ -59,7 +59,7 @@ rule result: x
 }
 
 #[test]
-fn test_get_with_x_explanations_header_returns_explanation_when_explanations_enabled() {
+fn test_post_with_x_explain_header_returns_explanation_when_explain_enabled() {
     let temp_dir = tempfile::tempdir().unwrap();
     let lemma_file = temp_dir.path().join("single.lemma");
     std::fs::write(
@@ -79,7 +79,7 @@ rule result: x
         .arg(temp_dir.path())
         .arg("--port")
         .arg(port.to_string())
-        .arg("--explanations")
+        .arg("--explain")
         .spawn()
         .unwrap();
 
@@ -94,7 +94,7 @@ rule result: x
     let url = format!("http://127.0.0.1:{}/single_spec", port);
     let resp = client
         .post(&url)
-        .header("x-explanations", "true")
+        .header("x-explain", "true")
         .header("Content-Type", "application/json")
         .body(r#"{"x":"42"}"#)
         .send()
@@ -107,7 +107,7 @@ rule result: x
 
     assert!(
         status.is_success(),
-        "POST with x-explanations should return 2xx, got {}",
+        "POST with x-explain should return 2xx, got {}",
         status
     );
     let results = body
@@ -118,7 +118,7 @@ rule result: x
         .expect("results should have 'result' rule");
     assert!(
         rule_result.get("explanation").is_some(),
-        "response should include explanation when x-explanations header sent: {:?}",
+        "response should include explanation when x-explain header sent: {:?}",
         body
     );
     assert_eq!(rule_result["number"].as_str(), Some("42"));
@@ -560,6 +560,16 @@ rule total: base
     let body: serde_json::Value = serde_json::from_str(&body_text)
         .unwrap_or_else(|e| panic!("invalid JSON: {e}; {body_text}"));
 
+    assert_eq!(
+        body["spec"].as_str(),
+        Some("pricing"),
+        "GET show body must be Show: {body}"
+    );
+    assert!(
+        body.get("spec_set_id").is_none(),
+        "GET show body must not include spec_set_id: {body}"
+    );
+
     let versions = body["versions"]
         .as_array()
         .unwrap_or_else(|| panic!("'versions' must be an array: {body}"));
@@ -728,7 +738,7 @@ rule r: n
     let rule = body["results"]["r"].as_object().expect("rule r in results");
     assert!(
         rule.get("explanation").is_none(),
-        "explanation must stay omitted without x-explanations: {rule:?}"
+        "explanation must stay omitted without x-explain: {rule:?}"
     );
     let missing = rule["missing_data"]
         .as_array()

--- a/engine/README.md
+++ b/engine/README.md
@@ -22,7 +22,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-lemma-engine = "0.9.7"
+lemma-engine = "0.9.8"
 ```
 
 ### Minimal example
@@ -235,7 +235,7 @@ Build: `node build.js` (from `engine/packages/npm/`). See [packages/npm/README.m
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
 </dependency>
 ```
 

--- a/engine/documentation/evaluate_guide.md
+++ b/engine/documentation/evaluate_guide.md
@@ -15,12 +15,12 @@ Never present your interpretation as the truth ("that counts as…", "that's fin
 **Setup**
 
 1. **`list`**: learn available specs. Never invent spec names.
-2. **`show`** the chosen spec once. Do not call show again between asks. Never turn show into a questionnaire.
-3. **`evaluate`** one target `rule`. Read `missing_data` (name, type, help, suggest). `missing_data` is inputs still needed, not a queue order and not a script.
+2. **`show`** the chosen spec once. Do not call show again between asks. Never turn show into a questionnaire. Keep that Show for type/help/suggest lookups.
+3. **`run`** one target via `rules` (string or array). Response is Engine JSON (`results`, always with `explanation`). Per-rule `missing_data` is unbound input **keys** only — look up type, help, and suggest on the Show from step 2. Prefer tool `run` (deprecated alias `evaluate` still works).
 
 **After every user turn (primary loop)**
 
-4. Bind every `missing_data` field that utterance decides, including clear entailments across fields. Supply bindings and re-evaluate.
+4. Bind every `missing_data` field that utterance decides, including clear entailments across fields. Supply bindings in `data` (JSON object) and re-`run`.
 5. Do not ask again about a topic the user already settled with a broader claim. Synonym probes of the same claim are forbidden.
 6. **Ambiguous polarity** → do not bind; re-ask that one input clearly.
 7. **Broad / over-answer** that covers a topic → bind all fields that claim settles; do not keep grilling that topic.
@@ -29,13 +29,13 @@ Never present your interpretation as the truth ("that counts as…", "that's fin
 **When inputs remain (fallback)**
 
 9. Ask **one** natural question aimed at the next undecided *topic* (or the single blocking input). Prefer what a consultant would ask. At most one unanswered question in flight. Help may inform meaning; ask normally.
-10. If the missing list is huge, you may evaluate the next undecided intermediate gate to learn which topic to ask, still without dumping the schema.
+10. If the missing list is huge, you may `run` the next undecided intermediate gate to learn which topic to ask, still without dumping the schema.
 
 **When the rule answers (verify before done)**
 
 11. Do not treat the first complete evaluation as final. Present a short table the user can check:
     - **Details**: each input in readable wording (help label or plain language), with the value you used.
     - **Answer**: the outcome for their question and any other derived answers you relied on.
-12. Close with a statement, not a question: e.g. tell the user to say if anything requires adjustment. If they correct something, update the data, re-evaluate, and verify again. Only then treat the outcome as final.
+12. Close with a statement, not a question: e.g. tell the user to say if anything requires adjustment. If they correct something, update the data, re-`run`, and verify again. Only then treat the outcome as final.
 
 Repeat the intake loop until the rule answers, then verify, then stop.

--- a/engine/documentation/guide/00_intro.md
+++ b/engine/documentation/guide/00_intro.md
@@ -1,10 +1,10 @@
 # Lemma
 
-> Lemma is a pure, deterministic language for rules and agreements. Use it when policy must be stated once and applied consistently: pricing, eligibility, fees, compliance, product terms, conditions, and other measurable business rules or governance. Lemma ensures that the same inputs give the same outcome, traceable to the rules that produced it. Use Lemma as your business rules engine — in agents and in applications — instead of re-implementing policy in scattered conditionals.
+> Lemma is a pure, deterministic language for rules and agreements. Use it when policy must be stated once and applied consistently: pricing, eligibility, fees, compliance, product terms, conditions, and other measurable business rules or governance. Lemma ensures that the same inputs give the same outcome, traceable to the rules that produced it. Use Lemma as your business rules engine, in agents and in applications, instead of re-implementing policy in scattered conditionals.
 
 **The pattern**
 
-State the rule in Lemma as soon as it is clear — do not carry it in the conversation for later. When facts arrive and an outcome is needed, evaluate the spec you already have. When gaps remain, see **Method** before you capture.
+State the rule in Lemma as soon as it is clear. Do not carry it in the conversation for later. When facts arrive and an outcome is needed, evaluate the spec you already have. When gaps remain, see **Method** before you capture.
 
 **Do not use Lemma** for open-ended advice with no rule to apply, or for inventing terms the user never stated.
 

--- a/engine/documentation/guide/05_method.md
+++ b/engine/documentation/guide/05_method.md
@@ -1,56 +1,134 @@
-**Method: write as a policy consultant, not a transcriber**
+**Method: you are a policy consultant**
 
-Never invent numbers, dates, or outcomes the user never stated. No policy questions after **Deliver**. No follow-up work after **Deliver**.
+Help the user write high-quality Lemma. Translate business rules from whatever they hand you (conversation, SOP, statute, ticket, spreadsheet, existing code) into a spec that is the **core, clean truth** of those rules: the questions the spec answers, the facts that decide them, the principle and its exceptions.
 
-**Lifecycle**
+You are not a transcriber of the source. You are not a coder filling gaps so a spec compiles. You are not a search agent that picks a nearby registry spec and moves on.
 
-1. **Recognize** — The user stated a rule, a rate, a threshold, a gate, or pointed at text that does. Run `list` / `show` first; `update_spec` if that policy is already loaded.
-2. **Resolve gaps** — Separate what the text already decides from what still changes the outcome. Unresolved items → **Stop**. Empty list → **Author**.
-3. **Capture** — **Scope** → **Model** → **Author** → **Verify** → `add_spec` or `update_spec`. The rule lives in the engine, not in chat.
-4. **Apply** — Facts are known; the user wants an outcome. Default evaluate guide: `evaluate`. Do not edit the spec.
+Sources are often ambiguous, especially natural language. Code and SOPs also mix the rule with procedure, plumbing, and leftovers. When a reading, a source, or a registry result would change the outcome, **ask**. Never guess. Never assume. Never pick one resource of truth over another silently. If the sources agree, write. When the source already decides an outcome clearly, do not reopen it.
 
-**Two tracks**
+**Authoring vs evaluate**
 
-- **Fast capture** — **Resolve gaps** is empty: every outcome-changing detail is already stated. Skip **Stop**; run **Scope** through load.
-- **Full method** — At least one outcome-changing detail is unstated. **Stop**; do not emit `spec` / `data` / `rule` until the user answers or explicitly tells you to proceed with what was already said.
+This method is authoring. You ask what the policy *is*.
 
-**Process**
+Evaluating (default `guide`, no topic) asks about the person's *situation* and forbids redesigning policy. Do not bring that rule here. If the user is stating, correcting, or handing you rules in any form, you are authoring.
 
-1. **Gather** — Utterances, messages, documents, tickets, field names. The conversation counts as source. Do not write Lemma yet.
-2. **Interpret** — What questions must this spec answer? What inputs decide the answer? One coherent policy → one `spec`.
-3. **Stop**: Next message: questions only, or a bullet list of what is already decided verbatim. Emitting `spec` / `data` / `rule` in that message is a bug. Ask **when these rules start** unless the user or the source already gave a calendar start date (a statute or document identifier is not a start date). Do not **Author** until answers or explicit proceed.
-4. **Scope** — One `spec` per policy. `uses` / split only when the text mixes unrelated policies. Temporal date on the `spec` only when the user or the source names a start date. Never guess.
-5. **Model** — You choose `data` and `rule` names and types by default. Representation questions follow **What to ask**. **Spoken question** on each `data` field (see **Data**). Domain-principle `unless` defaults (see **Rules**). Denial → `false` / `no`. Unanswerable → veto (see **Veto**). Encode stated gates; omit tips and how-to unless they are gates.
-6. **Author** — Write Lemma after **Stop** completes. Commentary after `spec`; `meta` for provenance. No inline comments (see **Syntax**).
-7. **Verify** — `check`, `show`, `evaluate` at bounds and representative inputs. Result wording must match the policy. Then `add_spec` or `update_spec`.
-8. **Deliver** — When the user should read what was captured. After load, call `source` for the loaded spec and paste **that** formatted Lemma in chat (not your draft / not the `code` argument). Confirm loaded. Close with a statement: tell them to say if anything requires adjustment. Not a yes/no question. Stop.
+**Inventory, then distill**
 
-**What to ask (and what not to)**
+Before you write, extract every outcome-changing clause from the source you are encoding. Each clause becomes a rule arm, a `data` bound, or an explicit omit (tip, how-to, plumbing, UI). If a clause has nowhere to go, stop and ask. A headline with a dropped "unless student" or "not on Sundays" is a wrong spec.
 
-Ask only when neither the user nor the source already gave a clear answer. Do not ask because another reading is theoretically possible. The list below is kinds of unanswered gap, not a checklist.
+A handbook, statute, or SOP with more than one policy: list the policies you found, say which you are encoding **now**. One spec per policy. Do not encode section 1 and leave the rest. Large sources: one policy at a time; keep the inventory.
 
-- Boundary: inclusive or exclusive at a limit.
-- Timing, optionally: since when have the rules been enacted or when will they take effect?
-- Combination: whether two stated rules stack, override, or are alternatives.
-- Lookup: what outcome applies for a case the text names but does not map to a value.
-- Representation: which fact to collect when more than one input shape is reasonable and the choice changes the question you ask or how the rule applies.
+**Distill vs exhaustive**
 
-Do **not** ask:
+Narrative (SOP prose, code with retries and logging): distill to principle + exceptions. Omit how-to, tips, recommendations, "contact support", UI, I/O, storage, retries, and other plumbing unless they are stated as gates. Do not copy every sentence, or every code branch, into a rule.
 
-- What the user or the source already answered clearly.
-- Packaging or syntax you can decide without changing outcomes (field count, internal names, closed option lists implied by the text).
-- One `spec` vs two when the policy is one topic.
-- Whether tips, how-to, or "contact support" are rules (omit unless stated as gates).
+Enumerated sources (rate cards, SKU tables, closed option lists, tariff rows): capture every row. Dropping a row is a silent policy change. Encode as `-> option` plus a lookup rule (default `veto`; see **Veto**), not a prose summary.
+
+Distill is not invent. If you cannot tell what the rule is, stop and ask. A missing rate, date, threshold, eligibility set, or start date is not yours to supply. A magic number, implicit default, or comment that disagrees with the code is not yours to resolve.
+
+**The deliverable**
+
+Someone can read the spec as: in principle X; unless Y, then Z. Facts of the situation as `data`. Decisions as `rule`. Domain words, not Lemma jargon, in chat.
+
+**Hard stop: ask, wait, do not write**
+
+Do not emit `spec` / `data` / `rule`. Do not call `check` / `add_spec` / `update_spec`. A spec in the same turn as open policy questions is a bug.
+
+`list` / `show` first. If that policy is already loaded, `update_spec` it. Do not invent spec names.
+
+Stop when any of these is true:
+
+- Two readings a domain expert would actually hold would produce different outcomes. Do not ask parser-level alternatives when the source already chose ("at least 18", "10 or more").
+- Two documents or encodings disagree (SOP vs code, two PDFs, a document vs an earlier loaded spec), or more than one loaded spec could be the one to edit.
+- A registry or search hit is a candidate `uses`, or a substitute for writing the user's rule, and the user has not chosen it. Zero hits is not a stop: write their rule. One close hit is still a stop: name it, ask use vs write.
+- A number, date, bound, set of cases, or combination (stack / override / alternative) is unstated and the outcome depends on it.
+- More than one input shape is reasonable and the choice changes the spoken question or how the rule applies.
+- Discretion ("may", "should", "the manager can waive") would change the outcome. That is a fact to collect, or an omit they confirm, not a default you invent.
+
+Your next message is **questions only**, in the user's domain words. Ask **every** open item in that one turn. Do not drip one bound per turn. Wait for answers. If they say to proceed with what is already in the source, encode only that; still do not fill the rest.
+
+**Resources of truth (never pick silently)**
+
+Resources: the user's words, SOPs and other documents, existing code, attached files, already-loaded specs, registry search hits.
+
+Later user utterance **amends** an earlier document ("except students are free" after an SOP). Encode the amendment. Do not ask which governs.
+
+Two documents, or a document vs code, or a document vs a loaded spec: **conflict**. Ask which governs. Code is one encoding of a rule, not automatically the intended policy. Chat that only says "encode this" is not an amendment.
+
+Search when the concept looks like a shared standard (ISO codes, published tax tables, units). Do not search to skip writing the user's rule.
+
+- Several loaded specs could be this policy → name them, ask which to update.
+- Search returns more than one hit → name them, ask which to use, or whether to write the user's rule instead. First hit is not a choice.
+- Search returns one close hit → name it, ask use vs write.
+- Closest name, newest file, or "probably this ISO list" is not a choice.
+
+**Ask like this**
+
+User: "Adults pay full price."
+You: "From what age is someone an adult, and is that age included?"
+
+User: "Late returns cost 5% or €10."
+You: "Which applies: 5%, €10, the greater, or the lesser?"
+
+User pastes code with `if (age > 18)` and a comment "adults".
+You: "Is 18 included, and is the comment or the comparison the rule?"
+
+User: "Late fee is €5. The manager may waive it."
+You: treat waiver as a fact ("Was the fee waived?") unless they tell you to omit discretion.
+
+User: SOP, then "except students are free."
+You: encode the exception. Do not ask which source governs.
+
+Search returns `@acme/shipping` and `@acme/fulfilment`.
+You: name both. Ask which to use, or whether to write their rule.
+
+Search returns one close hit, or none.
+You: one hit: name it, ask use vs write. None: write their rule.
+
+Two PDFs, different fees.
+You: ask which document governs.
+
+User: "These terms apply only to contracts entered after 2024."
+You: that is a rule on a contract date, not `spec … 2024-01-01`.
+
+User hands an SOP that already names the rate, the bound, and who it applies to.
+You: write. Do not re-ask those.
+
+**Do not ask**
+
+- What the user or the source already answered clearly (a careful SOP or explicit decision in code counts).
+- Another reading that is only theoretically possible when the source already chose.
+- Packaging you can decide without changing outcomes (internal names, field count, closed option lists the text already implies).
+- Implementation details you can omit (logging, framework types, null-guards that are not policy).
+- One `spec` vs two when the topic is one policy.
+- Whether to encode tips, how-to, or plumbing (omit).
 - Hypotheticals the user never raised.
+- Lemma keywords. Ask about facts and policy meaning.
 
-Use the user's domain words. Ask about facts and policy meaning, not Lemma keywords.
+**You may write when**
 
-**Output contract (mandatory)**
+Every outcome-changing clause is placed (arm, bound, or explicit omit), every outcome-changing detail is already decided in the source they handed you, one resource of truth is identified, and no competing resource remains. Then author. You choose names and types when the concept is clear (see **Data**, **Rules**). You do not choose among competing meanings.
 
-- **Before Author** — Ask every open item from **Resolve gaps**. Wait. Do not invent. A `spec` in the same turn as the first policy questions is a bug.
-- **At Deliver** — Call `source`. Paste its formatted output in a lemma code fence. Do not paste the unformatted draft. No new policy questions. Close with a statement (tell them to say if anything requires adjustment), not a confirm question.
+**Quality of the Lemma**
+
+See **Data**, **Rules**, **Veto**, **Anti-patterns**. In short:
+
+- Each `data` `-> help` is the sentence you would ask a person about their situation. If that sentence applies the policy, the field is a `rule`.
+- A rule's default is the domain principle, not yes-until-failure. Named pipeline rules, not one opaque expression.
+- Denial is `false` / `no`. Unanswerable is veto. Bounds belong on `data`, not veto.
+- Name the concept; keep the unit on the value.
+- Commentary after `spec`; `meta` for provenance (document title, version, date the source actually names). No inline comments (see **Syntax**).
+- One `spec` per policy. `uses` / split only when the text mixes unrelated policies. Effective date on the `spec` only when the user or the source names a calendar start for **this version of the spec**. A statute or document id is not a start date. An applicability window ("contracts after 2024") is a rule on a date field, not the spec's effective date.
+
+**Author, verify, deliver**
+
+1. Author only after the hard stop is clear.
+2. `check`. Then `add_spec` or `update_spec`. Then `evaluate` at bounds and representative inputs from the source (including overlapping `unless` arms). Result wording must match the policy.
+3. Walk the inventory: every clause is an arm, a bound, or an explicit omit. Scan **Anti-patterns** (veto-as-denial, unit-in-the-name, fail-each-check, precomputed `data`).
+4. Call `source`. Paste **that** formatted Lemma in a lemma fence (not your draft, not the `code` argument). Confirm loaded.
+5. Close with a statement: tell them to say if anything requires adjustment. Not a yes/no question. No new policy questions. No follow-up work. Stop.
 
 **After capture**
 
-- User gives facts and wants a result → default evaluate guide (`evaluate`, verify, stop).
-- User changes the rule → `update_spec`, **Verify** again.
+User gives facts and wants a result → evaluate guide (`evaluate`, verify, stop). Do not edit the spec.
+User changes the rule → `update_spec`, verify again.

--- a/engine/lsp/Cargo.toml
+++ b/engine/lsp/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 default = []
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.7", path = "..", features = ["registry"] }
+lemma = { package = "lemma-engine", version = "=0.9.8", path = "..", features = ["registry"] }
 serde_json.workspace = true
 
 # Native: tokio (multi-threaded) + tower-lsp with stdio transport

--- a/engine/lsp/editors/vscode/package-lock.json
+++ b/engine/lsp/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-language",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-language",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/engine/lsp/editors/vscode/package.json
+++ b/engine/lsp/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lemma-language",
   "displayName": "Lemma Language",
   "description": "Language support for Lemma: syntax highlighting, inline diagnostics, and clickable Registry references",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "publisher": "lemma",
   "license": "Apache-2.0",
   "icon": "lemma_128.png",

--- a/engine/packages/hex/lib/lemma/mcp.ex
+++ b/engine/packages/hex/lib/lemma/mcp.ex
@@ -1,6 +1,14 @@
 defmodule Lemma.Mcp do
   @moduledoc """
-  Pure Lemma MCP tools: engine + arguments in, catalog or text out.
+  Pure Lemma MCP tools: engine + JSON args in, catalog or tool result text out.
+
+  Read tools mirror the engine catalog: `run`, `list`, `show`, `source`,
+  `check`, `guide`. Admin/write tools stay in the CLI MCP server only.
+
+  `run/2` always includes explanations and returns Engine `Response` JSON
+  (same shape as `Lemma.run/3` with `explain: true`). Args match SDK `run`:
+  `spec`, optional `repository`, `rules`, `data` (object), `effective`.
+  Do not pass `explain`.
   """
 
   @type engine :: Lemma.engine()
@@ -27,11 +35,21 @@ defmodule Lemma.Mcp do
     Lemma.Native.mcp_read_resource(uri)
   end
 
+  @spec run(engine(), args()) ::
+          {:ok, String.t()}
+          | {:error, :invalid_arguments | :not_found | :diagnostics, String.t()}
+  def run(engine, args) when is_map(args) do
+    Lemma.Native.mcp_run(engine, Jason.encode!(args))
+  end
+
+  @doc """
+  Deprecated alias of `run/2`. Prefer `Lemma.Mcp.run/2`.
+  """
   @spec evaluate(engine(), args()) ::
           {:ok, String.t()}
           | {:error, :invalid_arguments | :not_found | :diagnostics, String.t()}
   def evaluate(engine, args) when is_map(args) do
-    Lemma.Native.mcp_evaluate(engine, Jason.encode!(args))
+    run(engine, args)
   end
 
   @spec list(engine(), args()) ::

--- a/engine/packages/hex/lib/lemma/native.ex
+++ b/engine/packages/hex/lib/lemma/native.ex
@@ -41,7 +41,7 @@ defmodule Lemma.Native do
 
   def lemma_format(_code), do: :erlang.nif_error(:nif_not_loaded)
 
-  def lemma_generate_openapi(_resource, _explanations_enabled, _effective_opt),
+  def lemma_generate_openapi(_resource, _explain, _effective_opt),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def lemma_temporal_api_sources(_resource), do: :erlang.nif_error(:nif_not_loaded)
@@ -49,6 +49,7 @@ defmodule Lemma.Native do
   def mcp_list_tools, do: :erlang.nif_error(:nif_not_loaded)
   def mcp_list_resources, do: :erlang.nif_error(:nif_not_loaded)
   def mcp_read_resource(_uri), do: :erlang.nif_error(:nif_not_loaded)
+  def mcp_run(_resource, _args_json), do: :erlang.nif_error(:nif_not_loaded)
   def mcp_evaluate(_resource, _args_json), do: :erlang.nif_error(:nif_not_loaded)
   def mcp_list(_resource, _args_json), do: :erlang.nif_error(:nif_not_loaded)
   def mcp_show(_resource, _args_json), do: :erlang.nif_error(:nif_not_loaded)

--- a/engine/packages/hex/lib/lemma/openapi.ex
+++ b/engine/packages/hex/lib/lemma/openapi.ex
@@ -20,14 +20,14 @@ defmodule Lemma.OpenAPI do
   @doc """
   Generates an OpenAPI 3.1 JSON document for the loaded specs (Lemma HTTP API shape).
 
-  Options: `:explanations` (boolean, default false), `:effective` (datetime string or nil for "now").
+  Options: `:explain` (boolean, default false), `:effective` (datetime string or nil for "now").
   """
   @spec generate_openapi(Lemma.engine(), keyword()) :: {:ok, map()} | {:error, term()}
   def generate_openapi(engine, opts \\ []) do
-    explanations = Keyword.get(opts, :explanations, false)
+    explain = Keyword.get(opts, :explain, false)
     effective = Keyword.get(opts, :effective)
 
-    case Lemma.Native.lemma_generate_openapi(engine, explanations, effective) do
+    case Lemma.Native.lemma_generate_openapi(engine, explain, effective) do
       {:ok, binary} -> {:ok, Jason.decode!(binary)}
       err -> err
     end

--- a/engine/packages/hex/mix.exs
+++ b/engine/packages/hex/mix.exs
@@ -1,7 +1,7 @@
 defmodule Lemma.MixProject do
   use Mix.Project
 
-  @version "0.9.7"
+  @version "0.9.8"
   @source_url "https://github.com/lemma/lemma"
 
   def project do

--- a/engine/packages/hex/native/lemma_hex/src/lib.rs
+++ b/engine/packages/hex/native/lemma_hex/src/lib.rs
@@ -399,7 +399,7 @@ fn lemma_format<'a>(env: Env<'a>, code: String) -> NifResult<Term<'a>> {
 fn lemma_generate_openapi<'a>(
     env: Env<'a>,
     resource: ResourceArc<LemmaEngineResource>,
-    explanations_enabled: bool,
+    explain: bool,
     effective_opt: Option<String>,
 ) -> NifResult<Term<'a>> {
     let engine = resource
@@ -414,7 +414,7 @@ fn lemma_generate_openapi<'a>(
         })?,
     };
 
-    let spec = lemma_openapi::generate_openapi_effective(&engine, explanations_enabled, &effective);
+    let spec = lemma_openapi::generate_openapi_effective(&engine, explain, &effective);
     let json = serde_json::to_vec(&spec).map_err(|e| {
         rustler::Error::RaiseTerm(Box::new(format!(
             "OpenAPI JSON serialization failed: {}",
@@ -672,8 +672,7 @@ fn mcp_read_resource<'a>(env: Env<'a>, uri: String) -> NifResult<Term<'a>> {
     }
 }
 
-#[rustler::nif(schedule = "DirtyCpu")]
-fn mcp_evaluate<'a>(
+fn mcp_run_impl<'a>(
     env: Env<'a>,
     resource: ResourceArc<LemmaEngineResource>,
     args_json: String,
@@ -683,7 +682,25 @@ fn mcp_evaluate<'a>(
         .0
         .lock()
         .map_err(|_| rustler::Error::RaiseTerm(Box::new("Engine lock poisoned".to_string())))?;
-    mcp_tool_result(env, lemma::mcp::evaluate(&engine, &args))
+    mcp_tool_result(env, lemma::mcp::run(&engine, &args))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn mcp_run<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<LemmaEngineResource>,
+    args_json: String,
+) -> NifResult<Term<'a>> {
+    mcp_run_impl(env, resource, args_json)
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn mcp_evaluate<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<LemmaEngineResource>,
+    args_json: String,
+) -> NifResult<Term<'a>> {
+    mcp_run_impl(env, resource, args_json)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/engine/packages/hex/test/lemma_test.exs
+++ b/engine/packages/hex/test/lemma_test.exs
@@ -626,30 +626,59 @@ defmodule LemmaTest do
   end
 
   describe "mcp" do
-    test "list_tools includes evaluate list show source check guide" do
+    test "list_tools includes run evaluate list show source check guide" do
       assert {:ok, tools} = Lemma.Mcp.list_tools()
       names = Enum.map(tools, & &1["name"])
 
-      assert names == ["evaluate", "list", "show", "source", "check", "guide"]
+      assert names == ["run", "evaluate", "list", "show", "source", "check", "guide"]
       refute "add_spec" in names
       assert hd(tools)["inputSchema"]["required"] == ["spec"]
+      assert Enum.at(tools, 1)["name"] == "evaluate"
+      assert Enum.at(tools, 1)["description"] =~ "Deprecated"
     end
 
-    test "evaluate and list on a loaded engine" do
+    test "run and list on a loaded engine" do
       {:ok, engine} = Lemma.new()
       :ok = Lemma.load(engine, @simple_spec)
 
       assert {:ok, text} =
-               Lemma.Mcp.evaluate(engine, %{
+               Lemma.Mcp.run(engine, %{
                  "spec" => "pricing",
-                 "rule" => "total",
-                 "data" => ["quantity=3"]
+                 "rules" => "total",
+                 "data" => %{"quantity" => 3}
                })
 
-      assert text =~ "total:"
-      assert text =~ "30"
+      response = Jason.decode!(text)
+      assert response["results"]["total"]["display"] == "30"
+      assert is_map(response["results"]["total"]["explanation"])
+
+      assert {:ok, alias_text} =
+               Lemma.Mcp.evaluate(engine, %{
+                 "spec" => "pricing",
+                 "rules" => "total",
+                 "data" => %{"quantity" => 3}
+               })
+
+      alias_response = Jason.decode!(alias_text)
+
+      assert alias_response["results"]["total"]["display"] ==
+               response["results"]["total"]["display"]
+
+      assert alias_response["results"]["total"]["explanation"]["body"] ==
+               response["results"]["total"]["explanation"]["body"]
+
       assert {:ok, list} = Lemma.Mcp.list(engine, %{})
       assert list =~ "pricing"
+    end
+
+    test "check success returns quality JSON array" do
+      assert {:ok, text} =
+               Lemma.Mcp.check(%{
+                 "sources" => [["ok.lemma", "spec ok\nrule r: 1\n"]]
+               })
+
+      recs = Jason.decode!(text)
+      assert is_list(recs)
     end
 
     test "check diagnostics for invalid source" do
@@ -662,6 +691,7 @@ defmodule LemmaTest do
     test "guide default is evaluate guide" do
       assert {:ok, text} = Lemma.Mcp.guide(%{})
       assert text =~ "Talk like a consultant"
+      assert text =~ "`run`"
     end
   end
 end

--- a/engine/packages/maven/README.md
+++ b/engine/packages/maven/README.md
@@ -6,7 +6,7 @@ JVM binding for the Lemma rules engine. Coordinates: `com.lemmabase:lemma-engine
 <dependency>
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
 </dependency>
 ```
 

--- a/engine/packages/maven/pom.xml
+++ b/engine/packages/maven/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.lemmabase</groupId>
   <artifactId>lemma-engine</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
   <packaging>jar</packaging>
 
   <name>Lemma Engine</name>

--- a/engine/src/documentation/mod.rs
+++ b/engine/src/documentation/mod.rs
@@ -177,7 +177,9 @@ mod tests {
             .filter_map(|entry| {
                 let entry = entry.ok()?;
                 let path = entry.path();
-                if path.extension()?.to_str()? == "md" {
+                if path.extension()?.to_str()? == "md"
+                    && !path.file_stem()?.to_str()?.ends_with("_improved")
+                {
                     Some(path)
                 } else {
                     None

--- a/engine/src/evaluation/run_data.rs
+++ b/engine/src/evaluation/run_data.rs
@@ -25,6 +25,126 @@ impl RunDataValue {
     pub fn string(value: impl Into<String>) -> Self {
         Self::String(value.into())
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self::String(s) => s.trim().is_empty(),
+            Self::MeasureMap(map) | Self::RatioMap(map) => map.is_empty(),
+            Self::Boolean(_) => false,
+        }
+    }
+}
+
+/// Parse one JSON value into a [`RunDataValue`] (SDK / MCP / WASM wire shape).
+pub fn run_data_value_from_json_value(value: serde_json::Value) -> Result<RunDataValue, String> {
+    match value {
+        serde_json::Value::String(s) => Ok(RunDataValue::String(s)),
+        serde_json::Value::Bool(b) => Ok(RunDataValue::Boolean(b)),
+        serde_json::Value::Number(n) => {
+            if n.is_i64() || n.is_u64() {
+                Ok(RunDataValue::String(n.to_string()))
+            } else {
+                Err("decimal values must be passed as strings to preserve exactness".to_string())
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            if obj.is_empty() {
+                return Err("data value object must not be empty".to_string());
+            }
+            if obj.len() == 2 && obj.contains_key("value") && obj.contains_key("unit") {
+                return Err(
+                    "the {value, unit} object shape is not supported; use a unit map like {\"eur\": \"84\"}"
+                        .to_string(),
+                );
+            }
+            if obj.values().all(|v| v.is_string()) {
+                let map: BTreeMap<String, String> = obj
+                    .into_iter()
+                    .map(|(k, v)| {
+                        (
+                            k,
+                            v.as_str()
+                                .expect("BUG: object values checked as strings")
+                                .to_string(),
+                        )
+                    })
+                    .collect();
+                return Ok(RunDataValue::MeasureMap(map));
+            }
+            Err("data value object must be a unit map with string magnitudes".to_string())
+        }
+        serde_json::Value::Null => Err("data value must not be null".to_string()),
+        serde_json::Value::Array(_) => Err("data value must not be an array".to_string()),
+    }
+}
+
+/// Convert SDK/MCP/WASM `data` object to string map for [`crate::Engine::run`].
+///
+/// Single-entry unit maps become convenience strings (`"84 eur"`). Multi-key maps
+/// are rejected until `Engine::run` accepts typed [`RunDataValue`] directly.
+pub fn parse_run_data_object(
+    data: &Option<serde_json::Value>,
+) -> Result<HashMap<String, String>, String> {
+    let Some(value) = data else {
+        return Ok(HashMap::new());
+    };
+    if value.is_null() {
+        return Ok(HashMap::new());
+    }
+    let map: HashMap<String, serde_json::Value> = serde_json::from_value(value.clone())
+        .map_err(|e| format!("data must be a plain object: {e}"))?;
+    map.into_iter()
+        .filter(|(_, v)| !v.is_null())
+        .map(|(k, v)| {
+            let input = run_data_value_from_json_value(v)?;
+            match input {
+                RunDataValue::String(s) => Ok((k, s)),
+                RunDataValue::Boolean(b) => Ok((k, b.to_string())),
+                RunDataValue::MeasureMap(m) | RunDataValue::RatioMap(m) => {
+                    if m.len() == 1 {
+                        let (unit, mag) = m.into_iter().next().expect("BUG: single entry map");
+                        Ok((k, format!("{mag} {unit}")))
+                    } else {
+                        Err(format!(
+                            "data value '{k}' must be a convenience string for run"
+                        ))
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+/// Resolve SDK/MCP/WASM `rules` (string or string array) for [`crate::Engine::run`].
+pub fn resolve_run_rules(rules: &Option<serde_json::Value>) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = rules else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    if let Some(s) = value.as_str() {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err("rules must not be empty".to_string());
+        }
+        return Ok(Some(vec![trimmed.to_string()]));
+    }
+    if let Some(arr) = value.as_array() {
+        if arr.is_empty() {
+            return Err("rules must not be empty".to_string());
+        }
+        let names: Vec<String> = arr
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| "rules must be an array of strings".to_string())
+            })
+            .collect::<Result<_, _>>()?;
+        return Ok(Some(names));
+    }
+    Err("rules must be a string or array of strings".to_string())
 }
 
 pub fn parse_data_value(
@@ -229,12 +349,26 @@ impl RunData {
                 }
             };
 
+            let input_key = data_path.input_key();
+
+            if raw_value.is_empty() && type_arc.empty_runtime_input_vetoes() {
+                run_data.bindings.insert(
+                    data_path,
+                    OperationResult::Veto(VetoType::computation(
+                        type_arc.data_veto_message(&input_key, "cannot be empty."),
+                    )),
+                );
+                continue;
+            }
+
             let literal_value = match parse_data_value(&raw_value, &type_arc, &data_source) {
                 Ok(value) => value,
                 Err(error) => {
                     run_data.bindings.insert(
                         data_path,
-                        OperationResult::Veto(VetoType::computation(error.message().to_string())),
+                        OperationResult::Veto(VetoType::computation(
+                            type_arc.data_veto_message(&input_key, error.message()),
+                        )),
                     );
                     continue;
                 }
@@ -244,10 +378,9 @@ impl RunData {
             if size > limits.max_data_value_bytes {
                 run_data.bindings.insert(
                     data_path,
-                    OperationResult::Veto(VetoType::computation(format!(
-                        "max_data_value_bytes (limit: {}, actual: {})",
-                        limits.max_data_value_bytes, size
-                    ))),
+                    OperationResult::Veto(VetoType::computation(
+                        type_arc.data_veto_message(&input_key, "exceeds the size limit."),
+                    )),
                 );
                 continue;
             }
@@ -259,7 +392,9 @@ impl RunData {
             ) {
                 run_data.bindings.insert(
                     data_path,
-                    OperationResult::Veto(VetoType::computation(message)),
+                    OperationResult::Veto(VetoType::computation(
+                        type_arc.data_veto_message(&input_key, &message),
+                    )),
                 );
                 continue;
             }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -40,7 +40,9 @@ pub use engine::{
 pub use error::{EngineError, EngineErrorSource, Error, ErrorDetails, ErrorKind, RequestErrorKind};
 pub use evaluation::explanations::{format_explanation, Cause, Explanation, ExplanationNode};
 pub use evaluation::response::{Response, RuleResult};
-pub use evaluation::run_data::RunDataValue;
+pub use evaluation::run_data::{
+    parse_run_data_object, resolve_run_rules, run_data_value_from_json_value, RunDataValue,
+};
 pub use formatting::{format_parse_result, format_source, format_specs};
 pub use limits::{
     ResourceLimits, MAX_DATA_NAME_LENGTH, MAX_RULE_NAME_LENGTH, MAX_SPEC_NAME_LENGTH,

--- a/engine/src/mcp/catalog.rs
+++ b/engine/src/mcp/catalog.rs
@@ -20,39 +20,54 @@ pub struct ResourceDefinition {
     pub description: String,
 }
 
+fn run_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "spec": {
+                "type": "string",
+                "description": "Spec set id, e.g. pricing"
+            },
+            "repository": {
+                "type": "string",
+                "description": "Optional repository qualifier (e.g. lemma, @org/repo). Omit for workspace."
+            },
+            "rules": {
+                "description": "Optional: one rule name (string) or several (string array). Omit for all rules.",
+                "oneOf": [
+                    { "type": "string" },
+                    { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+                ]
+            },
+            "data": {
+                "type": "object",
+                "description": "Optional input bindings. Integers as numbers; decimals as strings; unit maps as {\"eur\": \"84\"}. Partial is fine.",
+                "additionalProperties": true
+            },
+            "effective": {
+                "type": "string",
+                "description": "Optional: evaluate at a specific effective datetime (e.g. '2026', '2026-03', '2026-03-04', '2026-03-04T10:30:00Z')"
+            }
+        },
+        "required": ["spec"]
+    })
+}
+
 pub fn list_tools() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
+            name: "run",
+            description: "Evaluate rules (Engine Response JSON, same as SDK run / lemma run --json -x). Always includes explanation trees. Pass `rules` to target one or more rules; omit for all. For human intake: call guide (default = evaluate guide; not topic full), then list, show once, run. missing_data is unbound input keys only — look up type/help/suggest on the Show already fetched. Primary loop: after each user turn, bind every field that utterance decides (entailments), re-run; ask at most one open topic-question when something remains. Never ask the user what the policy means. Never dispose interpretation as truth; use “should” when a judgment call cannot be answered. When the rule answers, present details+answer in domain language for user verify (no tooling jargon to the user) before treating as done. No questionnaire dumps. No re-call show between asks. Do not dump every show data field into run.",
+            input_schema: run_input_schema(),
+        },
+        ToolDefinition {
             name: "evaluate",
-            description: "Evaluate rules. Pass `rule` to target one rule; omit for all. For human intake: call guide (default = evaluate guide; not topic full), then list, show once, evaluate. missing_data lines include name, type, and help. Primary loop: after each user turn, bind every field that utterance decides (entailments), re-evaluate; ask at most one open topic-question when something remains. Never ask the user what the policy means. Never dispose interpretation as truth; use “should” when a judgment call cannot be answered. When the rule answers, present details+answer in domain language for user verify (no tooling jargon to the user) before treating as done. No questionnaire dumps. No re-call show between asks. Do not dump every show data field into evaluate. Returns display values, unit maps, reasoning, and missing_data when inputs are still needed.",
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "spec": {
-                        "type": "string",
-                        "description": "Spec set id, e.g. pricing"
-                    },
-                    "rule": {
-                        "type": "string",
-                        "description": "Optional: name of a specific rule to evaluate. Omit to evaluate all rules."
-                    },
-                    "data": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Optional data values as 'name=value' (e.g. ['price=100', 'measure=5']). Partial is fine.",
-                        "default": []
-                    },
-                    "effective": {
-                        "type": "string",
-                        "description": "Optional: evaluate at a specific effective datetime (e.g. '2026', '2026-03', '2026-03-04', '2026-03-04T10:30:00Z')"
-                    }
-                },
-                "required": ["spec"]
-            }),
+            description: "Deprecated alias of `run`. Same arguments and Response JSON. Prefer `run`.",
+            input_schema: run_input_schema(),
         },
         ToolDefinition {
             name: "list",
-            description: "List loaded specs by repository (name, effective_from, effective_to). Call this first when you do not already know the exact spec name. Do not invent or guess spec names. For human intake call guide (default evaluate guide), then show once and evaluate.",
+            description: "List loaded specs by repository (name, effective_from, effective_to). Call this first when you do not already know the exact spec name. Do not invent or guess spec names. For human intake call guide (default evaluate guide), then show once and run. When the workspace is empty and write mode is enabled, use add_spec to load Lemma source.",
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {}
@@ -60,13 +75,17 @@ pub fn list_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "show",
-            description: "Return JSON Show for a spec: data catalog (types, constraints, suggestions, units, help) and rule output types. Call once after list. Static interface — not a required-input list, not a questionnaire, not something to re-call between evaluate/ask turns. Human intake: call guide (default = evaluate guide).",
+            description: "Return JSON Show for a spec: data catalog (types, constraints, suggestions, units, help) and rule output types. Call once after list. Static interface — not a required-input list, not a questionnaire, not something to re-call between run/ask turns. Human intake: call guide (default = evaluate guide).",
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "spec": {
                         "type": "string",
                         "description": "Spec set id, e.g. pricing"
+                    },
+                    "repository": {
+                        "type": "string",
+                        "description": "Optional repository qualifier (e.g. lemma, @org/repo). Omit for workspace."
                     },
                     "effective": {
                         "type": "string",
@@ -78,17 +97,17 @@ pub fn list_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "source",
-            description: "Return formatted Lemma source. Pass `repository` (e.g. `lemma` for embedded units stdlib) for the whole repo, or `spec` for a workspace spec. After add_spec / update_spec, call this and paste the result in chat for user verify; do not present the draft you authored.",
+            description: "Return formatted Lemma source. Pass `repository` (e.g. `lemma` for embedded units stdlib) for the whole repo, or `spec` for a workspace or repository spec. After add_spec / update_spec, call this and paste the result in chat for user verify; do not present the draft you authored.",
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "repository": {
                         "type": "string",
-                        "description": "Repository qualifier (e.g. lemma). When set, returns formatted source for the entire repository."
+                        "description": "Repository qualifier (e.g. lemma). Alone: whole repository. With `spec`: that repo's spec."
                     },
                     "spec": {
                         "type": "string",
-                        "description": "Workspace spec set id (when repository is omitted)"
+                        "description": "Spec set id (workspace when repository omitted)"
                     },
                     "effective": {
                         "type": "string",
@@ -99,7 +118,7 @@ pub fn list_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "check",
-            description: "Validate Lemma sources (does not load). On success confirms syntax is valid. Call add_spec to load after check passes. On failure returns structured diagnostics (kind, message, suggestion, source line/column). Sources resolve cross-file `uses` within the batch. A leading `@` label loads as a dependency. Lemma has no `#` or `//` comments; commentary is valid only as a docstring immediately after the `spec` line. Before drafting new specs, call guide with topic full (or method then data). Finish Interrogate first: do not call check or add_spec in the same turn as the first policy questions; wait for answers or an explicit acceptance that the source already states the gaps.",
+            description: "Validate Lemma sources (does not load). On success returns JSON quality recommendations array (empty if none). Call add_spec to load after check passes. On failure returns structured diagnostics (kind, message, suggestion, source line/column). Sources resolve cross-file `uses` within the batch. A leading `@` label loads as a dependency. Lemma has no `#` or `//` comments; commentary is valid only as a docstring immediately after the `spec` line. Before drafting new specs, call guide with topic full (or method then data). Finish Interrogate first: do not call check or add_spec in the same turn as the first policy questions; wait for answers or an explicit acceptance that the source already states the gaps.",
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/engine/src/mcp/error.rs
+++ b/engine/src/mcp/error.rs
@@ -1,4 +1,4 @@
-use crate::error::{EngineError, Error, ErrorKind, RequestErrorKind};
+use crate::error::{EngineError, Error};
 
 /// Expected MCP tool failure. Unexpected engine invariants still panic at the call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,23 +46,5 @@ impl std::fmt::Display for ResourceError {
         match self {
             Self::UnknownUri(message) => f.write_str(message),
         }
-    }
-}
-
-pub fn map_engine_error(error: Error) -> ToolError {
-    match error.request_kind() {
-        Some(RequestErrorKind::SpecNotFound) => ToolError::not_found(error.message()),
-        Some(RequestErrorKind::RuleNotFound) | Some(RequestErrorKind::InvalidRequest) => {
-            ToolError::invalid_arguments(error.message())
-        }
-        None => match error.kind() {
-            ErrorKind::MissingRepository => ToolError::not_found(error.message()),
-            ErrorKind::Request => ToolError::not_found(error.message()),
-            ErrorKind::Parsing
-            | ErrorKind::Validation
-            | ErrorKind::Inversion
-            | ErrorKind::Registry
-            | ErrorKind::ResourceLimit => ToolError::invalid_arguments(error.message()),
-        },
     }
 }

--- a/engine/src/mcp/mod.rs
+++ b/engine/src/mcp/mod.rs
@@ -8,4 +8,4 @@ mod tools;
 
 pub use catalog::{list_resources, list_tools, read_resource, ResourceDefinition, ToolDefinition};
 pub use error::{ResourceError, ToolError};
-pub use tools::{check, evaluate, guide, list, show, source};
+pub use tools::{check, evaluate, guide, list, run, show, source};

--- a/engine/src/mcp/tools.rs
+++ b/engine/src/mcp/tools.rs
@@ -1,108 +1,48 @@
-use std::collections::HashMap;
-
 use serde_json::Value;
 
 use crate::documentation::{GuideTopic, EVALUATE_GUIDE};
 use crate::engine::{resolve_effective as resolve_effective_datetime, Engine};
-use crate::format_explanation;
-use crate::mcp::error::{map_engine_error, ToolError};
+use crate::mcp::error::ToolError;
+use crate::parse_run_data_object;
 use crate::parsing::ast::DateTimeValue;
 use crate::parsing::source::SourceType;
+use crate::resolve_run_rules;
 use crate::spec_set_id::parse_spec_set_id;
 
-pub fn evaluate(engine: &Engine, args: &Value) -> Result<String, ToolError> {
+/// Evaluate a spec. Always explains (`Engine::run(..., true)`). No `explain` arg.
+pub fn run(engine: &Engine, args: &Value) -> Result<String, ToolError> {
+    require_object(args)?;
+    reject_explain_arg(args)?;
+    if args.get("rule").is_some() {
+        return Err(ToolError::invalid_arguments(
+            "Unknown field 'rule'. Use 'rules' (string or string array).",
+        ));
+    }
+
     let spec_set_id = required_string(args, "spec")?;
     if spec_set_id.is_empty() {
         return Err(ToolError::invalid_arguments("Spec set id cannot be empty"));
     }
-    let spec_name = parse_spec_set_id(spec_set_id).map_err(map_engine_error)?;
-    let rule_names = optional_rule_names(args)?;
-    let data_values = parse_data(args)?;
+    let spec_name = parse_spec_set_id(spec_set_id).map_err(engine_error_to_diagnostics)?;
+    let repository = optional_nonempty_string(args, "repository")?;
     let now = resolve_effective(args)?;
-    let rules = if rule_names.is_empty() {
-        None
-    } else {
-        Some(rule_names.as_slice())
-    };
+    let data_values =
+        parse_run_data_object(&args.get("data").cloned()).map_err(ToolError::invalid_arguments)?;
+    let rule_names =
+        resolve_run_rules(&args.get("rules").cloned()).map_err(ToolError::invalid_arguments)?;
+    let rules = rule_names.as_deref();
+
     let response = engine
-        .run(None, &spec_name, Some(&now), data_values, rules, true)
-        .map_err(map_engine_error)?;
+        .run(repository, &spec_name, Some(&now), data_values, rules, true)
+        .map_err(engine_error_to_diagnostics)?;
 
-    let show_for_missing = if response
-        .results
-        .values()
-        .any(|result| result.awaits_missing_data())
-    {
-        Some(
-            engine
-                .show(None, &spec_name, Some(&now))
-                .unwrap_or_else(|error| {
-                    panic!("BUG: show must succeed after evaluate for '{spec_set_id}': {error}")
-                }),
-        )
-    } else {
-        None
-    };
+    Ok(serde_json::to_string_pretty(&response)
+        .unwrap_or_else(|error| panic!("BUG: Response must serialize: {error}")))
+}
 
-    let mut output = String::new();
-    output.push_str(&format!("spec: {spec_set_id}\n"));
-    output.push_str(&format!("effective: {now}\n"));
-    output.push('\n');
-
-    for result in response.results.values() {
-        output.push_str(&format!("{}: ", result.rule.name));
-        if result.vetoed {
-            if let Some(reason) = result.veto_reason.as_deref() {
-                output.push_str(reason);
-            }
-        } else {
-            let display = result.display().unwrap_or_else(|| {
-                panic!(
-                    "BUG: rule '{}' evaluated without display after evaluation",
-                    result.rule.name
-                )
-            });
-            output.push_str(display);
-            if let Some(value) = &result.value {
-                if let Some(measure) = &value.measure {
-                    append_unit_map(&mut output, measure);
-                } else if let Some(ratio) = &value.ratio {
-                    append_unit_map(&mut output, ratio);
-                }
-            }
-        }
-        output.push('\n');
-
-        if result.awaits_missing_data() {
-            let show = show_for_missing
-                .as_ref()
-                .expect("BUG: any awaiting rule requires show_for_missing after evaluate");
-            output.push_str("missing_data:\n");
-            for name in result.missing_data() {
-                let entry = show.data.get(name).unwrap_or_else(|| {
-                    panic!("BUG: missing_data key {name:?} must exist in show.data after evaluate")
-                });
-                let type_name = entry.lemma_type.specifications.to_string();
-                let help = entry.lemma_type.specifications.help();
-                if help.is_empty() {
-                    output.push_str(&format!("  {name}: {type_name}\n"));
-                } else {
-                    output.push_str(&format!("  {name}: {type_name} — {help}\n"));
-                }
-            }
-        }
-
-        if let Some(explanation) = &result.explanation {
-            let steps = format_explanation(explanation);
-            if !steps.is_empty() {
-                output.push_str("\nReasoning:\n");
-                output.push_str(&steps);
-                output.push('\n');
-            }
-        }
-    }
-
-    Ok(output)
+/// Deprecated alias of [`run`]. Same args and Response JSON.
+pub fn evaluate(engine: &Engine, args: &Value) -> Result<String, ToolError> {
+    run(engine, args)
 }
 
 pub fn list(engine: &Engine, args: &Value) -> Result<String, ToolError> {
@@ -113,33 +53,39 @@ pub fn list(engine: &Engine, args: &Value) -> Result<String, ToolError> {
 }
 
 pub fn show(engine: &Engine, args: &Value) -> Result<String, ToolError> {
+    let repository = optional_nonempty_string(args, "repository")?;
     let spec_set_id = required_string(args, "spec")?;
     if spec_set_id.is_empty() {
         return Err(ToolError::invalid_arguments("Spec set id cannot be empty"));
     }
-    let spec_name = parse_spec_set_id(spec_set_id).map_err(map_engine_error)?;
+    let spec_name = parse_spec_set_id(spec_set_id).map_err(engine_error_to_diagnostics)?;
     let now = resolve_effective(args)?;
     let show = engine
-        .show(None, &spec_name, Some(&now))
-        .map_err(map_engine_error)?;
+        .show(repository, &spec_name, Some(&now))
+        .map_err(engine_error_to_diagnostics)?;
     Ok(serde_json::to_string_pretty(&show)
         .unwrap_or_else(|error| panic!("BUG: show response must serialize: {error}")))
 }
 
 pub fn source(engine: &Engine, args: &Value) -> Result<String, ToolError> {
     require_object(args)?;
-    if let Some(repository) = optional_nonempty_string(args, "repository")? {
-        return engine
-            .source(Some(repository), None, None)
-            .map_err(map_engine_error);
+    let repository = optional_nonempty_string(args, "repository")?;
+    let spec = optional_nonempty_string(args, "spec")?;
+    match (repository, spec) {
+        (Some(repo), None) => engine
+            .source(Some(repo), None, None)
+            .map_err(engine_error_to_diagnostics),
+        (repo, Some(spec_set_id)) => {
+            let spec_name = parse_spec_set_id(spec_set_id).map_err(engine_error_to_diagnostics)?;
+            let now = resolve_effective(args)?;
+            engine
+                .source(repo, Some(&spec_name), Some(&now))
+                .map_err(engine_error_to_diagnostics)
+        }
+        (None, None) => Err(ToolError::invalid_arguments(
+            "Missing 'spec' or 'repository' field",
+        )),
     }
-    let spec_set_id = required_string(args, "spec")
-        .map_err(|_| ToolError::invalid_arguments("Missing 'spec' or 'repository' field"))?;
-    let spec_name = parse_spec_set_id(spec_set_id).map_err(map_engine_error)?;
-    let now = resolve_effective(args)?;
-    engine
-        .source(None, Some(&spec_name), Some(&now))
-        .map_err(map_engine_error)
 }
 
 pub fn check(args: &Value) -> Result<String, ToolError> {
@@ -182,21 +128,8 @@ pub fn check(args: &Value) -> Result<String, ToolError> {
     }
 
     let recommendations = engine.quality();
-    let mut text = String::from(
-        "Parsed and planned. Syntax is valid; this does not verify the policy is correct.",
-    );
-    const MAX_RECOMMENDATIONS: usize = 20;
-    if !recommendations.is_empty() {
-        text.push_str("\n\nRecommendations:");
-        for (i, rec) in recommendations.iter().take(MAX_RECOMMENDATIONS).enumerate() {
-            text.push_str(&format!("\n{}. {}", i + 1, rec));
-        }
-        let omitted = recommendations.len().saturating_sub(MAX_RECOMMENDATIONS);
-        if omitted > 0 {
-            text.push_str(&format!("\n… and {omitted} more"));
-        }
-    }
-    Ok(text)
+    Ok(serde_json::to_string_pretty(&recommendations)
+        .unwrap_or_else(|error| panic!("BUG: quality recommendations must serialize: {error}")))
 }
 
 pub fn guide(args: &Value) -> Result<String, ToolError> {
@@ -216,6 +149,19 @@ pub fn guide(args: &Value) -> Result<String, ToolError> {
             Ok(topic.section_text().to_string())
         }
     }
+}
+
+fn engine_error_to_diagnostics(error: crate::Error) -> ToolError {
+    ToolError::diagnostics(std::slice::from_ref(&error))
+}
+
+fn reject_explain_arg(args: &Value) -> Result<(), ToolError> {
+    if args.get("explain").is_some() {
+        return Err(ToolError::invalid_arguments(
+            "MCP run always includes explanations; do not pass 'explain'",
+        ));
+    }
+    Ok(())
 }
 
 fn require_object(args: &Value) -> Result<(), ToolError> {
@@ -259,61 +205,164 @@ fn optional_nonempty_string<'a>(
     }
 }
 
-fn optional_rule_names(args: &Value) -> Result<Vec<String>, ToolError> {
-    match args.get("rule") {
-        None | Some(Value::Null) => Ok(Vec::new()),
-        Some(Value::String(rule)) => {
-            let trimmed = rule.trim();
-            if trimmed.is_empty() {
-                Ok(Vec::new())
-            } else {
-                Ok(vec![trimmed.to_string()])
-            }
-        }
-        Some(_) => Err(ToolError::invalid_arguments("'rule' must be a string")),
-    }
-}
-
-fn parse_data(args: &Value) -> Result<HashMap<String, String>, ToolError> {
-    match args.get("data") {
-        None | Some(Value::Null) => Ok(HashMap::new()),
-        Some(Value::Array(entries)) => {
-            let mut data = HashMap::new();
-            for (i, entry) in entries.iter().enumerate() {
-                let Some(raw) = entry.as_str() else {
-                    return Err(ToolError::invalid_arguments(format!(
-                        "data[{i}] must be a string 'name=value'"
-                    )));
-                };
-                let Some((name, value)) = raw.split_once('=') else {
-                    return Err(ToolError::invalid_arguments(format!(
-                        "data[{i}] must be 'name=value', got '{raw}'"
-                    )));
-                };
-                data.insert(name.to_string(), value.to_string());
-            }
-            Ok(data)
-        }
-        Some(_) => Err(ToolError::invalid_arguments(
-            "'data' must be an array of 'name=value' strings",
-        )),
-    }
-}
-
 fn resolve_effective(args: &Value) -> Result<DateTimeValue, ToolError> {
     match args.get("effective") {
-        None | Some(Value::Null) => resolve_effective_datetime(None).map_err(map_engine_error),
-        Some(Value::String(raw)) => resolve_effective_datetime(Some(raw)).map_err(map_engine_error),
+        None | Some(Value::Null) => {
+            resolve_effective_datetime(None).map_err(engine_error_to_diagnostics)
+        }
+        Some(Value::String(raw)) => {
+            resolve_effective_datetime(Some(raw)).map_err(engine_error_to_diagnostics)
+        }
         Some(_) => Err(ToolError::invalid_arguments("'effective' must be a string")),
     }
 }
 
-fn append_unit_map(output: &mut String, map: &std::collections::BTreeMap<String, String>) {
-    let parts: Vec<String> = map
-        .iter()
-        .map(|(unit, magnitude)| format!("{unit} {magnitude}"))
-        .collect();
-    output.push_str(" (");
-    output.push_str(&parts.join(", "));
-    output.push(')');
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    fn load_pricing() -> Engine {
+        let mut engine = Engine::new();
+        engine
+            .load([(
+                SourceType::Path(Arc::new(PathBuf::from("pricing.lemma"))),
+                "spec pricing\ndata quantity: number\nrule total: quantity * 10\n".to_string(),
+            )])
+            .expect("load");
+        engine
+    }
+
+    #[test]
+    fn run_returns_response_json_with_explanation() {
+        let engine = load_pricing();
+        let text = run(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "rules": "total",
+                "data": { "quantity": 3 }
+            }),
+        )
+        .expect("run");
+        let value: Value = serde_json::from_str(&text).expect("Response JSON");
+        assert_eq!(value["results"]["total"]["display"], "30");
+        assert!(value["results"]["total"]["explanation"].is_object());
+    }
+
+    #[test]
+    fn run_rejects_explain_arg() {
+        let engine = load_pricing();
+        let err = run(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "explain": false
+            }),
+        )
+        .expect_err("explain forbidden");
+        assert!(matches!(err, ToolError::InvalidArguments(_)));
+    }
+
+    #[test]
+    fn run_rejects_legacy_rule_field() {
+        let engine = load_pricing();
+        let err = run(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "rule": "total"
+            }),
+        )
+        .expect_err("rule forbidden");
+        assert!(matches!(err, ToolError::InvalidArguments(_)));
+    }
+
+    #[test]
+    fn run_rules_array() {
+        let engine = load_pricing();
+        let text = run(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "rules": ["total"],
+                "data": { "quantity": 2 }
+            }),
+        )
+        .expect("run");
+        let value: Value = serde_json::from_str(&text).expect("Response JSON");
+        assert_eq!(value["results"]["total"]["display"], "20");
+    }
+
+    #[test]
+    fn show_accepts_repository() {
+        let engine = Engine::new();
+        let text = show(
+            &engine,
+            &serde_json::json!({
+                "repository": "lemma",
+                "spec": "units"
+            }),
+        )
+        .expect("show lemma units");
+        let value: Value = serde_json::from_str(&text).expect("Show JSON");
+        assert_eq!(value["spec"], "units");
+    }
+
+    #[test]
+    fn missing_spec_is_diagnostics() {
+        let engine = Engine::new();
+        let err =
+            run(&engine, &serde_json::json!({ "spec": "nonexistent" })).expect_err("missing spec");
+        match err {
+            ToolError::Diagnostics(text) => {
+                let value: Value = serde_json::from_str(&text).expect("EngineError JSON");
+                assert!(value.is_array());
+                assert!(!value.as_array().expect("array").is_empty());
+            }
+            other => panic!("expected Diagnostics, got {other}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_aliases_run() {
+        let engine = load_pricing();
+        let a = run(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "data": { "quantity": 1 }
+            }),
+        )
+        .expect("run");
+        let b = evaluate(
+            &engine,
+            &serde_json::json!({
+                "spec": "pricing",
+                "data": { "quantity": 1 }
+            }),
+        )
+        .expect("evaluate");
+        let va: Value = serde_json::from_str(&a).expect("run JSON");
+        let vb: Value = serde_json::from_str(&b).expect("evaluate JSON");
+        assert_eq!(
+            va["results"]["total"]["display"],
+            vb["results"]["total"]["display"]
+        );
+        assert_eq!(
+            va["results"]["total"]["explanation"]["body"],
+            vb["results"]["total"]["explanation"]["body"]
+        );
+    }
+
+    #[test]
+    fn check_success_is_quality_json() {
+        let text = check(&serde_json::json!({
+            "sources": [["ok.lemma", "spec ok\nrule r: 1\n"]]
+        }))
+        .expect("check");
+        let value: Value = serde_json::from_str(&text).expect("quality JSON");
+        assert!(value.is_array());
+    }
 }

--- a/engine/src/planning/graph.rs
+++ b/engine/src/planning/graph.rs
@@ -1545,22 +1545,20 @@ impl<'a> GraphBuilder<'a> {
         )
     }
 
-    fn unit_index_for_spec(&self, current_spec: &LemmaSpec) -> Option<&UnitIndex> {
-        self.local_types
-            .iter()
-            .find(|(_, s, _)| discovery::same_loaded_spec(s, current_spec))
-            .map(|(_, _, t)| &t.unit_index)
-    }
-
     fn resolve_unit_ref(
         &self,
         current_spec: &LemmaSpec,
         unit_ref: &str,
     ) -> Result<(String, Arc<LemmaType>), String> {
-        let index = self
-            .unit_index_for_spec(current_spec)
-            .ok_or_else(|| format!("Unknown unit '{unit_ref}' is not in scope for this spec"))?;
-        index.resolve(unit_ref)
+        let resolved = find_types_by_spec(&self.local_types, current_spec)
+            .ok_or_else(|| {
+                format!(
+                    "Unknown unit '{unit_ref}'. Declare it on a measure or ratio type, or import it with uses."
+                )
+            })?;
+        resolved
+            .unit_index
+            .resolve_with_named_types(unit_ref, &resolved.resolved)
     }
 
     fn process_meta_fields(&mut self, spec: &LemmaSpec) {
@@ -2863,28 +2861,29 @@ impl<'a> GraphBuilder<'a> {
                     .find(|(_, s, _)| discovery::same_loaded_spec(s, ctx.spec))
                     .map(|(_, _, t)| t);
                 let unit_index = resolved_spec_types.map(|dt| &dt.unit_index);
-                let semantic_target = match conversion_target_to_semantic(target, unit_index) {
-                    Ok(t) => t,
-                    Err(msg) => {
-                        // When there is no unit index (e.g. primitive context), surface the
-                        // conversion error without a "valid units" list.
-                        let full_msg = unit_index
-                            .map(|idx| {
-                                let mut valid: Vec<&str> = idx.keys().map(String::as_str).collect();
-                                valid.sort_unstable();
-                                format!("{} Valid units: {}", msg, valid.join(", "))
-                            })
-                            .unwrap_or(msg);
-                        self.errors.push(Error::validation_with_context(
-                            full_msg,
-                            expr.source_location.clone(),
-                            None::<String>,
-                            Some(self.main_spec),
-                            None,
-                        ));
-                        return None;
-                    }
-                };
+                let resolved_map = resolved_spec_types.map(|dt| &dt.resolved);
+                let semantic_target =
+                    match conversion_target_to_semantic(target, unit_index, resolved_map) {
+                        Ok(t) => t,
+                        Err(msg) => {
+                            let full_msg = unit_index
+                                .map(|idx| {
+                                    let mut valid: Vec<&str> =
+                                        idx.keys().map(String::as_str).collect();
+                                    valid.sort_unstable();
+                                    format!("{} Valid units: {}", msg, valid.join(", "))
+                                })
+                                .unwrap_or(msg);
+                            self.errors.push(Error::validation_with_context(
+                                full_msg,
+                                expr.source_location.clone(),
+                                None::<String>,
+                                Some(self.main_spec),
+                                None,
+                            ));
+                            return None;
+                        }
+                    };
 
                 Some(Expression::with_source(
                     ExpressionKind::UnitConversion(Arc::new(converted_value), semantic_target),
@@ -8242,8 +8241,8 @@ rule r: i.x
             let usd_type = resolved.unit_index.unique_owner("usd").unwrap();
             assert_eq!(
                 eur_type.name.as_deref(),
-                Some("money2"),
-                "more derived type (money2) should own inherited eur"
+                Some("money"),
+                "declarer money must own inherited eur, not extension"
             );
             assert_eq!(
                 usd_type.name.as_deref(),
@@ -8363,6 +8362,11 @@ rule r: i.x
             let resolved = resolver
                 .resolve_and_validate(spec, &EffectiveDate::Origin, &Vec::new())
                 .expect("additive extension unit must resolve");
+            let money = resolved
+                .resolved
+                .get("money")
+                .expect("money resolved")
+                .clone();
             let money2 = resolved
                 .resolved
                 .get("money2")
@@ -8380,15 +8384,15 @@ rule r: i.x
             let usd_owner = resolved.unit_index.unique_owner("usd").expect("usd owner");
             assert_eq!(
                 eur_owner.name.as_deref(),
-                Some("money2"),
-                "most-derived type must own inherited eur"
+                Some("money"),
+                "declarer money must own eur, not extension money2"
             );
             assert_eq!(
                 usd_owner.name.as_deref(),
                 Some("money2"),
-                "most-derived type must own new usd"
+                "money2 must own new unit usd"
             );
-            assert_eq!(eur_owner.as_ref(), money2.as_ref());
+            assert_eq!(eur_owner.as_ref(), money.as_ref());
             assert_eq!(usd_owner.as_ref(), money2.as_ref());
         }
 
@@ -8684,13 +8688,15 @@ rule r: i.x
                 .collect::<Vec<_>>()
                 .join("; ");
             assert!(
-                error_msg.contains("hour") && error_msg.contains("conflicting factors"),
+                error_msg.contains("hour")
+                    && (error_msg.contains("different values")
+                        || error_msg.contains("conflicting factors")),
                 "expected conflicting factor error for hour, got: {error_msg}"
             );
         }
 
         #[test]
-        fn test_spec_level_duplicate_unit_names_allowed_at_index() {
+        fn test_spec_level_duplicate_unit_names_rejected() {
             let (resolver, spec) = resolver_single_spec(
                 r#"spec test
     data money_a: measure
@@ -8708,19 +8714,23 @@ rule r: i.x
       -> unit meter: 1.0"#,
             );
 
-            let resolved = resolver
-                .resolve_and_validate(spec, &EffectiveDate::Origin, &Vec::new())
-                .expect("duplicate bare unit names across types must load");
-            assert!(resolved.unit_index.unique_owner("eur").is_none());
-            assert!(resolved.unit_index.unique_owner("meter").is_none());
-            resolved
-                .unit_index
-                .resolve("money_a.eur")
-                .expect("qualify money_a");
-            resolved
-                .unit_index
-                .resolve("money_b.eur")
-                .expect("qualify money_b");
+            let result = resolver.resolve_and_validate(spec, &EffectiveDate::Origin, &Vec::new());
+            assert!(
+                result.is_err(),
+                "second independent declarer of same unit name must Error"
+            );
+            let error_msg = result
+                .unwrap_err()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            assert!(
+                error_msg.contains("eur")
+                    || error_msg.contains("meter")
+                    || error_msg.contains("usd"),
+                "expected duplicate unit name Error, got: {error_msg}"
+            );
         }
 
         #[test]
@@ -8753,7 +8763,7 @@ rule r: i.x
         }
 
         #[test]
-        fn test_same_ratio_unit_same_factor_across_types_allowed() {
+        fn test_same_ratio_unit_across_types_rejected() {
             let (resolver, spec) = resolver_single_spec(
                 r#"spec test
     data spread_a: ratio
@@ -8763,9 +8773,21 @@ rule r: i.x
       -> unit basis_points: 10000"#,
             );
 
-            resolver
-                .resolve_and_validate(spec, &EffectiveDate::Origin, &Vec::new())
-                .expect("same unit name and factor across ratio types must be allowed");
+            let result = resolver.resolve_and_validate(spec, &EffectiveDate::Origin, &Vec::new());
+            assert!(
+                result.is_err(),
+                "second independent declarer of same ratio unit must Error"
+            );
+            let error_msg = result
+                .unwrap_err()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            assert!(
+                error_msg.contains("basis_points"),
+                "expected duplicate ratio unit Error, got: {error_msg}"
+            );
         }
 
         #[test]
@@ -9971,7 +9993,7 @@ pub struct ResolvedSpecTypes {
     /// Raw defaults retained after [`value_kind_from_raw_suggestion`] for cross-spec parent lookup during later specs.
     pub(crate) source_defaults: HashMap<String, RawSuggestion>,
 
-    /// Expression-scope units. Bare names may have multiple owners; qualify when ambiguous.
+    /// Expression-scope units. One declarer per bare unit name; qualify with Type.unit or alias.Type.unit.
     /// Binding aliases never appear as index keys.
     pub unit_index: crate::planning::unit_index::UnitIndex,
 }
@@ -10854,8 +10876,27 @@ impl<'a> TypeResolver<'a> {
                 .get(type_name.as_str())
                 .expect("BUG: type was resolved but not in registry");
             let merge_result = if type_arc.is_measure() {
-                if matches!(data_type_def.parent, ParentType::Qualified { .. }) {
-                    Ok(())
+                if let ParentType::Qualified { spec_alias, inner } = &data_type_def.parent {
+                    match Self::parent_units_for_qualified_extension(
+                        self,
+                        spec,
+                        data_type_def,
+                        already_resolved,
+                        at,
+                        spec_alias,
+                        inner,
+                    ) {
+                        Ok(None) => Ok(()),
+                        Ok(Some(parent_units)) => Self::merge_additive_measure_units(
+                            spec,
+                            &mut unit_index,
+                            type_arc,
+                            data_type_def,
+                            None,
+                            &parent_units,
+                        ),
+                        Err(error) => Err(error),
+                    }
                 } else {
                     Self::add_measure_units_to_index(
                         spec,
@@ -11007,12 +11048,81 @@ impl<'a> TypeResolver<'a> {
         import_alias: Option<String>,
     ) -> Result<(), Error> {
         if matches!(defined_by.parent, ParentType::Qualified { .. }) {
-            unreachable!("BUG: qualified import alias rows must not register units");
+            unreachable!(
+                "BUG: Qualified parents must use parent_units_for_qualified_extension + merge_additive_measure_units"
+            );
         }
         let measure_family = resolved_type
             .measure_family_name()
             .expect("BUG: add_measure_units_to_index requires measure type with family");
         for unit in Self::extract_units_from_type(&resolved_type.specifications) {
+            unit_index
+                .merge_measure_unit(
+                    unit,
+                    resolved_type,
+                    &defined_by.name,
+                    import_alias.clone(),
+                    measure_family,
+                )
+                .map_err(|conflict| {
+                    Self::unit_merge_conflict_to_error(conflict, defined_by, spec)
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Parent unit names for a Qualified extension; `None` if parent not resolved yet.
+    fn parent_units_for_qualified_extension(
+        resolver: &TypeResolver<'_>,
+        spec: &LemmaSpec,
+        defined_by: &DataTypeDef,
+        already_resolved: &ResolvedTypesMap<'_>,
+        at: &EffectiveDate,
+        spec_alias: &str,
+        inner: &ParentType,
+    ) -> Result<Option<BTreeSet<String>>, Error> {
+        let ParentType::Custom {
+            name: parent_type_name,
+        } = inner
+        else {
+            return Ok(None);
+        };
+        let spec_ref = ast::SpecRef::same_repository(spec_alias.to_string());
+        let (_, target_spec) =
+            resolver.resolve_spec_for_import(spec, &spec_ref, &defined_by.source, at)?;
+        let Some(imported_resolved) = already_resolved
+            .iter()
+            .find(|(_, imported, _)| discovery::same_loaded_spec(imported, target_spec))
+            .map(|(_, _, types)| types)
+        else {
+            return Ok(None);
+        };
+        let Some(parent_type) = imported_resolved.resolved.get(parent_type_name.as_str()) else {
+            return Ok(None);
+        };
+        Ok(Some(
+            Self::extract_units_from_type(&parent_type.specifications)
+                .into_iter()
+                .collect(),
+        ))
+    }
+
+    /// Register only units the Qualified extension newly declares (not inherited from parent).
+    fn merge_additive_measure_units(
+        spec: &LemmaSpec,
+        unit_index: &mut UnitIndex,
+        resolved_type: &Arc<LemmaType>,
+        defined_by: &DataTypeDef,
+        import_alias: Option<String>,
+        parent_units: &BTreeSet<String>,
+    ) -> Result<(), Error> {
+        let measure_family = resolved_type
+            .measure_family_name()
+            .expect("BUG: additive measure registration requires family");
+        for unit in Self::extract_units_from_type(&resolved_type.specifications) {
+            if parent_units.contains(&unit) {
+                continue;
+            }
             unit_index
                 .merge_measure_unit(
                     unit,
@@ -11063,20 +11173,20 @@ impl<'a> TypeResolver<'a> {
                 existing_name,
                 new_name,
             } => format!(
-                "Ambiguous unit '{}'. Defined in multiple types: '{}' and '{}'",
-                unit, existing_name, new_name
+                "Unit '{unit}' is defined on both '{existing_name}' and '{new_name}'. \
+                 Each unit name may be declared only once."
             ),
             UnitMergeConflict::ConflictingFactors { unit, family } => format!(
-                "Unit '{}' in measure family '{}' is defined with conflicting factors",
-                unit, family
+                "Unit '{unit}' has different values on related measure types in '{family}'. \
+                 Use the same unit value on each type, or use different unit names."
             ),
             UnitMergeConflict::AmbiguousRatio {
                 unit,
                 existing_name,
                 new_name,
             } => format!(
-                "Ambiguous unit '{}'. Defined in multiple ratio types: '{}' and '{}'",
-                unit, existing_name, new_name
+                "Unit '{unit}' is defined on both '{existing_name}' and '{new_name}'. \
+                 Each unit name may be declared only once."
             ),
         };
         Error::validation_with_context(

--- a/engine/src/planning/semantics.rs
+++ b/engine/src/planning/semantics.rs
@@ -50,7 +50,7 @@ use crate::parsing::ast::{
 use crate::Error;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
@@ -3992,6 +3992,38 @@ impl LemmaType {
         }
     }
 
+    /// `age [number]` or `gender [gender_code]` — brackets omitted when type adds nothing.
+    #[must_use]
+    pub fn label_for_data_input(&self, input_key: &str) -> String {
+        let type_label = if let Some(parent) = self.extends.parent_name() {
+            parent.to_string()
+        } else {
+            let type_name = self.name();
+            if type_name == input_key {
+                self.specifications.to_string()
+            } else {
+                type_name
+            }
+        };
+        if type_label == input_key {
+            input_key.to_string()
+        } else {
+            format!("{input_key} [{type_label}]")
+        }
+    }
+
+    /// `Data age [number]: {detail}` for runtime data override vetoes.
+    #[must_use]
+    pub fn data_veto_message(&self, input_key: &str, detail: &str) -> String {
+        format!("Data {}: {}", self.label_for_data_input(input_key), detail)
+    }
+
+    /// Whether an empty [`RunDataValue`] should veto before parse (text may accept `""`).
+    #[must_use]
+    pub fn empty_runtime_input_vetoes(&self) -> bool {
+        !matches!(self.specifications, TypeSpecification::Text { .. })
+    }
+
     /// Return the conversion factor for a declared unit name on this measure type.
     pub fn measure_unit_factor(
         &self,
@@ -4909,12 +4941,16 @@ pub(crate) fn compare_semantic_times(
 pub fn conversion_target_to_semantic(
     ct: &ConversionTarget,
     unit_index: Option<&crate::planning::unit_index::UnitIndex>,
+    resolved_types: Option<&HashMap<String, Arc<LemmaType>>>,
 ) -> Result<SemanticConversionTarget, String> {
     match ct {
         ConversionTarget::Type(kind) => Ok(SemanticConversionTarget::Type(*kind)),
         ConversionTarget::Unit { unit_name } => {
             let index = unit_index.ok_or_else(|| format!("Unknown unit '{unit_name}'."))?;
-            let (bare, owning_type) = index.resolve(unit_name)?;
+            let (bare, owning_type) = match resolved_types {
+                Some(resolved) => index.resolve_with_named_types(unit_name, resolved)?,
+                None => index.resolve(unit_name)?,
+            };
             Ok(SemanticConversionTarget::Unit {
                 unit_name: bare,
                 owning_type,

--- a/engine/src/planning/unit_index.rs
+++ b/engine/src/planning/unit_index.rs
@@ -1,5 +1,5 @@
-//! Expression-scope unit index: bare names may have multiple owners.
-//! Optionally qualify; must qualify when ambiguous.
+//! Expression-scope unit index: one declarer per bare unit name.
+//! Qualify with Type.unit or alias.Type.unit (not alias.unit).
 
 use crate::planning::semantics::{LemmaType, TypeSpecification};
 use std::collections::{BTreeSet, HashMap};
@@ -114,7 +114,8 @@ impl UnitIndex {
 
     /// Merge one measure unit name from `resolved_type` into the index.
     ///
-    /// Applies replace-by-extends, same-family factor checks, and cross-kind ambiguity.
+    /// Keeps the declarer as bare owner when a child extends a parent. Rejects a second
+    /// independent declarer of the same unit name. Same-family factor checks unchanged.
     pub fn merge_measure_unit(
         &mut self,
         unit: String,
@@ -132,8 +133,8 @@ impl UnitIndex {
         }
 
         let resolved_ref = resolved_type.as_ref();
-        let mut replace_indices = Vec::new();
         let mut skip_insert = false;
+        let mut reclaim_indices = Vec::new();
         for (index, owner) in owners.iter().enumerate() {
             let existing_type = owner.owning_type.as_ref();
             let existing_name = owner.type_name.as_str();
@@ -151,9 +152,11 @@ impl UnitIndex {
             if existing_type.is_measure() && (current_extends_existing || existing_extends_current)
             {
                 if current_extends_existing {
-                    replace_indices.push(index);
-                } else {
+                    // Child registering inherited unit; declarer already owns bare name.
                     skip_insert = true;
+                } else {
+                    // Parent declarer arrived after child claimed inherited unit (HashMap order).
+                    reclaim_indices.push(index);
                 }
                 continue;
             }
@@ -194,12 +197,20 @@ impl UnitIndex {
                     });
                 }
             }
-            // Cross-type measure name clash: keep both owners (qualify at use).
+
+            if existing_type.is_measure() {
+                return Err(UnitMergeConflict::Ambiguous {
+                    unit,
+                    existing_name: existing_name.to_string(),
+                    new_name: type_name.to_string(),
+                });
+            }
         }
 
-        for index in replace_indices.into_iter().rev() {
+        for index in reclaim_indices.into_iter().rev() {
             owners.remove(index);
         }
+
         if !skip_insert {
             owners.push(UnitOwner {
                 owning_type: Arc::clone(resolved_type),
@@ -265,24 +276,30 @@ impl UnitIndex {
             if existing_type.name() == resolved_ref.name() {
                 continue;
             }
-            if let (
-                TypeSpecification::Ratio {
-                    units: existing_units,
-                    ..
-                },
-                TypeSpecification::Ratio {
-                    units: new_units, ..
-                },
-            ) = (&existing_type.specifications, &resolved_ref.specifications)
-            {
-                let same_factor = existing_units
-                    .iter()
-                    .find(|existing_unit| existing_unit.name == unit)
-                    .zip(new_units.iter().find(|new_unit| new_unit.name == unit))
-                    .is_some_and(|(existing_unit, new_unit)| existing_unit.value == new_unit.value);
-                if same_factor {
-                    skip_insert = true;
-                    continue;
+            // Builtin percent/permille are shared across named ratio types (same factors).
+            // Custom ratio unit names still have one independent declarer.
+            if matches!(unit.as_str(), "percent" | "permille") {
+                if let (
+                    TypeSpecification::Ratio {
+                        units: existing_units,
+                        ..
+                    },
+                    TypeSpecification::Ratio {
+                        units: new_units, ..
+                    },
+                ) = (&existing_type.specifications, &resolved_ref.specifications)
+                {
+                    let same_factor = existing_units
+                        .iter()
+                        .find(|existing_unit| existing_unit.name == unit)
+                        .zip(new_units.iter().find(|new_unit| new_unit.name == unit))
+                        .is_some_and(|(existing_unit, new_unit)| {
+                            existing_unit.value == new_unit.value
+                        });
+                    if same_factor {
+                        skip_insert = true;
+                        continue;
+                    }
                 }
             }
             return Err(UnitMergeConflict::AmbiguousRatio {
@@ -329,33 +346,30 @@ impl UnitIndex {
         match segments.len() {
             1 => match owners {
                 [] => Err(format!(
-                    "Unknown unit '{bare}' is not in scope for this spec"
+                    "Unknown unit '{bare}'. Declare it on a measure or ratio type, or import it with uses."
                 )),
                 [only] => Ok((bare, Arc::clone(&only.owning_type))),
                 many => Err(format!(
-                    "Unit '{bare}' is ambiguous. Qualify as one of: {}",
+                    "Unit '{bare}' matches more than one type. Write one of: {}",
                     format_qualifier_list(many, &bare)
                 )),
             },
             2 => {
-                let first = &segments[0];
-                let mut matches: Vec<&UnitOwner> = Vec::new();
-                for owner in owners {
-                    let type_name_match = owner.type_name == *first;
-                    let alias_sugar = owner.import_alias.as_deref() == Some(first.as_str())
-                        && owners_unique_under_alias(owners, first);
-                    if type_name_match || alias_sugar {
-                        matches.push(owner);
-                    }
-                }
+                // Type.unit only. Import-alias sugar (alias.unit) is rejected: use alias.Type.unit.
+                let type_name = &segments[0];
+                let mut matches: Vec<&UnitOwner> = owners
+                    .iter()
+                    .filter(|owner| owner.type_name == *type_name)
+                    .collect();
                 dedupe_owner_matches(&mut matches);
                 match matches.as_slice() {
                     [only] => Ok((bare, Arc::clone(&only.owning_type))),
                     [] => Err(format!(
-                        "Unknown unit '{unit_ref}' is not in scope for this spec"
+                        "Unknown unit '{unit_ref}'. Use Type.unit or alias.Type.unit \
+                         (for example units.mass.kilogram), not alias.unit."
                     )),
                     _ => Err(format!(
-                        "Unit '{unit_ref}' is ambiguous. Qualify as one of: {}",
+                        "Unit '{unit_ref}' matches more than one type. Write one of: {}",
                         format_qualifier_list(owners, &bare)
                     )),
                 }
@@ -373,14 +387,55 @@ impl UnitIndex {
                 match matches.as_slice() {
                     [only] => Ok((bare, Arc::clone(&only.owning_type))),
                     [] => Err(format!(
-                        "Unknown unit '{unit_ref}' is not in scope for this spec"
+                        "Unknown unit '{unit_ref}'. Declare it on a measure or ratio type, or import it with uses."
                     )),
-                    _ => Err(format!("Unit '{unit_ref}' matched multiple owners")),
+                    _ => Err(format!("Unit '{unit_ref}' matches more than one type.")),
                 }
             }
             _ => Err(format!(
-                "Invalid unit path '{unit_ref}'. Use unit, Type.unit, alias.unit, or alias.Type.unit"
+                "Invalid unit path '{unit_ref}'. Use unit, Type.unit, or alias.Type.unit"
             )),
+        }
+    }
+
+    /// Type.unit / alias.Type.unit when the named measure inherits the unit but is not the bare owner.
+    #[must_use]
+    pub fn resolve_via_named_measure_type(
+        unit_ref: &str,
+        resolved: &HashMap<String, Arc<LemmaType>>,
+    ) -> Option<(String, Arc<LemmaType>)> {
+        let segments: Vec<String> = unit_ref
+            .split('.')
+            .map(|segment| crate::parsing::ast::ascii_lowercase_logical_name(segment.to_string()))
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        let (type_name, bare) = match segments.as_slice() {
+            [type_name, bare] => (type_name.as_str(), bare.as_str()),
+            [_, type_name, bare] => (type_name.as_str(), bare.as_str()),
+            _ => return None,
+        };
+        let lemma_type = resolved.get(type_name)?;
+        if !lemma_type.is_measure() {
+            return None;
+        }
+        let names = lemma_type.measure_unit_names()?;
+        if !names.contains(&bare) {
+            return None;
+        }
+        Some((bare.to_string(), Arc::clone(lemma_type)))
+    }
+
+    /// Index resolve, then named-measure Type.unit fallback for extension binding.
+    pub fn resolve_with_named_types(
+        &self,
+        unit_ref: &str,
+        resolved: &HashMap<String, Arc<LemmaType>>,
+    ) -> Result<(String, Arc<LemmaType>), String> {
+        match self.resolve(unit_ref) {
+            Ok(hit) => Ok(hit),
+            Err(index_err) => {
+                Self::resolve_via_named_measure_type(unit_ref, resolved).ok_or(index_err)
+            }
         }
     }
 
@@ -418,14 +473,6 @@ fn type_declares_unit(lemma_type: &LemmaType, unit_name: &str) -> bool {
     }
 }
 
-fn owners_unique_under_alias(owners: &[UnitOwner], alias: &str) -> bool {
-    owners
-        .iter()
-        .filter(|owner| owner.import_alias.as_deref() == Some(alias))
-        .count()
-        == 1
-}
-
 fn dedupe_owner_matches(matches: &mut Vec<&UnitOwner>) {
     let mut seen = BTreeSet::new();
     matches.retain(|owner| {
@@ -443,9 +490,6 @@ fn format_qualifier_list(owners: &[UnitOwner], bare: &str) -> String {
         paths.insert(format!("{}.{}", owner.type_name, bare));
         if let Some(alias) = &owner.import_alias {
             paths.insert(format!("{}.{}.{}", alias, owner.type_name, bare));
-            if owners_unique_under_alias(owners, alias) {
-                paths.insert(format!("{alias}.{bare}"));
-            }
         }
     }
     paths.into_iter().collect::<Vec<_>>().join(", ")
@@ -485,6 +529,32 @@ mod tests {
     }
 
     #[test]
+    fn merge_parent_reclaims_inherited_unit_from_child() {
+        let mut index = UnitIndex::new();
+        let money = measure_type("money", "eur");
+        let money2 = Arc::new(LemmaType::new(
+            "money2".to_string(),
+            money.specifications.clone(),
+            TypeExtends::custom_local("money".to_string(), "money".to_string()),
+        ));
+        index
+            .merge_measure_unit("eur".into(), &money2, "money2", None, "money")
+            .expect("child first");
+        assert_eq!(
+            index.unique_owner("eur").map(|t| t.name()),
+            Some("money2".into())
+        );
+        index
+            .merge_measure_unit("eur".into(), &money, "money", None, "money")
+            .expect("parent reclaim");
+        assert_eq!(
+            index.unique_owner("eur").map(|t| t.name()),
+            Some("money".into()),
+            "declarer must reclaim bare ownership"
+        );
+    }
+
+    #[test]
     fn bare_unique_resolves() {
         let mut index = UnitIndex::new();
         let mass = measure_type("mass", "kilogram");
@@ -499,43 +569,72 @@ mod tests {
         let (bare, owner) = index.resolve("kilogram").expect("unique");
         assert_eq!(bare, "kilogram");
         assert_eq!(owner.name(), "mass");
-        let (bare, owner) = index.resolve("units.kilogram").expect("sugar");
+        let sugar_err = index
+            .resolve("units.kilogram")
+            .expect_err("import-alias sugar must be rejected");
+        assert!(
+            sugar_err.contains("Unknown") || sugar_err.contains("alias.Type.unit"),
+            "got: {sugar_err}"
+        );
+        let (bare, owner) = index.resolve("units.mass.kilogram").expect("full");
         assert_eq!(bare, "kilogram");
         assert_eq!(owner.name(), "mass");
-        let (bare, owner) = index.resolve("units.mass.kilogram").expect("full");
+        let (bare, owner) = index.resolve("mass.kilogram").expect("type.unit");
         assert_eq!(bare, "kilogram");
         assert_eq!(owner.name(), "mass");
     }
 
     #[test]
-    fn bare_ambiguous_requires_qualify() {
+    fn two_segment_import_alias_unit_rejected() {
+        let mut index = UnitIndex::new();
+        let mass = measure_type("mass", "kilogram");
+        index.insert_owner(
+            "kilogram".into(),
+            UnitOwner {
+                owning_type: Arc::clone(&mass),
+                type_name: "mass".into(),
+                import_alias: Some("units".into()),
+            },
+        );
+        assert!(
+            index.resolve("units.kilogram").is_err(),
+            "alias.unit sugar rejected even when unique under alias"
+        );
+        index
+            .resolve("units.mass.kilogram")
+            .expect("alias.Type.unit must resolve");
+    }
+
+    #[test]
+    fn merge_second_measure_declarer_rejected() {
         let mut index = UnitIndex::new();
         let a = measure_type("money_a", "eur");
         let b = measure_type("money_b", "eur");
-        index.insert_owner(
-            "eur".into(),
-            UnitOwner {
-                owning_type: a,
-                type_name: "money_a".into(),
-                import_alias: None,
-            },
+        index
+            .merge_measure_unit("eur".into(), &a, "money_a", None, "money_a")
+            .expect("first declarer");
+        let err = index
+            .merge_measure_unit("eur".into(), &b, "money_b", None, "money_b")
+            .expect_err("second independent eur declarer must Err");
+        match err {
+            UnitMergeConflict::Ambiguous {
+                unit,
+                existing_name,
+                new_name,
+            } => {
+                assert_eq!(unit, "eur");
+                assert!(
+                    (existing_name == "money_a" && new_name == "money_b")
+                        || (existing_name == "money_b" && new_name == "money_a"),
+                    "got {existing_name} / {new_name}"
+                );
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+        assert!(
+            index.has_unique_owner("eur"),
+            "index must keep sole first declarer after rejected merge"
         );
-        index.insert_owner(
-            "eur".into(),
-            UnitOwner {
-                owning_type: b,
-                type_name: "money_b".into(),
-                import_alias: None,
-            },
-        );
-        assert!(index.unique_owner("eur").is_none());
-        assert!(!index.has_unique_owner("eur"));
-        let msg = index.resolve("eur").expect_err("ambiguous");
-        assert!(msg.contains("ambiguous") || msg.contains("Ambiguous") || msg.contains("Qualify"));
-        assert!(msg.contains("money_a.eur"));
-        assert!(msg.contains("money_b.eur"));
-        index.resolve("money_a.eur").expect("qualified a");
-        index.resolve("money_b.eur").expect("qualified b");
     }
 
     #[test]
@@ -582,7 +681,24 @@ mod tests {
             )
             .expect("second alias");
         assert_eq!(index.owners_for("percent").len(), 2);
-        index.resolve("alpha.percent").expect("alpha sugar");
-        index.resolve("beta.percent").expect("beta sugar");
+        assert!(
+            index.resolve("alpha.percent").is_err(),
+            "alias.unit sugar rejected for ratio units"
+        );
+        assert!(index.resolve("beta.percent").is_err());
+        index
+            .resolve("alpha.rate.percent")
+            .expect("alpha.Type.unit");
+        index.resolve("beta.rate.percent").expect("beta.Type.unit");
+        let type_unit_err = index
+            .resolve("rate.percent")
+            .expect_err("Type.unit ambiguous when same type_name appears under two aliases");
+        assert!(
+            type_unit_err.contains("more than one type")
+                || type_unit_err.contains("Write one of")
+                || type_unit_err.contains("ambiguous")
+                || type_unit_err.contains("Qualify"),
+            "got: {type_unit_err}"
+        );
     }
 }

--- a/engine/src/wasm.rs
+++ b/engine/src/wasm.rs
@@ -1,5 +1,4 @@
 use crate::error::EngineError;
-use crate::evaluation::RunDataValue;
 use crate::{Engine, Error, Source, SourceType};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -116,7 +115,7 @@ impl WasmEngine {
             .map(str::trim)
             .filter(|s| !s.is_empty());
 
-        let response_rules = resolve_run_rules(&opts.rules).map_err(js_err)?;
+        let response_rules = crate::resolve_run_rules(&opts.rules).map_err(js_err)?;
 
         let response = self
             .engine
@@ -289,75 +288,7 @@ struct RunOptions {
 }
 
 fn parse_run_data(data: &Option<serde_json::Value>) -> Result<HashMap<String, String>, String> {
-    let Some(value) = data else {
-        return Ok(HashMap::new());
-    };
-    if value.is_null() {
-        return Ok(HashMap::new());
-    }
-    let map: HashMap<String, serde_json::Value> = serde_json::from_value(value.clone())
-        .map_err(|e| format!("data must be a plain object: {e}"))?;
-    map.into_iter()
-        .filter(|(_, v)| !v.is_null())
-        .map(|(k, v)| {
-            let input = run_data_value_from_json_value(v)?;
-            match input {
-                RunDataValue::String(s) => Ok((k, s)),
-                RunDataValue::Boolean(b) => Ok((k, b.to_string())),
-                RunDataValue::MeasureMap(m) => {
-                    if m.len() == 1 {
-                        let (unit, mag) = m.into_iter().next().expect("BUG: single entry map");
-                        Ok((k, format!("{mag} {unit}")))
-                    } else {
-                        Err(format!(
-                            "data value '{k}' must be a convenience string for WASM run"
-                        ))
-                    }
-                }
-                RunDataValue::RatioMap(m) => {
-                    if m.len() == 1 {
-                        let (unit, mag) = m.into_iter().next().expect("BUG: single entry map");
-                        Ok((k, format!("{mag} {unit}")))
-                    } else {
-                        Err(format!(
-                            "data value '{k}' must be a convenience string for WASM run"
-                        ))
-                    }
-                }
-            }
-        })
-        .collect()
-}
-
-fn resolve_run_rules(rules: &Option<serde_json::Value>) -> Result<Option<Vec<String>>, String> {
-    let Some(value) = rules else {
-        return Ok(None);
-    };
-    if value.is_null() {
-        return Ok(None);
-    }
-    if let Some(s) = value.as_str() {
-        let trimmed = s.trim();
-        if trimmed.is_empty() {
-            return Err("rules must not be empty".to_string());
-        }
-        return Ok(Some(vec![trimmed.to_string()]));
-    }
-    if let Some(arr) = value.as_array() {
-        if arr.is_empty() {
-            return Err("rules must not be empty".to_string());
-        }
-        let names: Vec<String> = arr
-            .iter()
-            .map(|v| {
-                v.as_str()
-                    .map(|s| s.to_string())
-                    .ok_or_else(|| "rules must be an array of strings".to_string())
-            })
-            .collect::<Result<_, _>>()?;
-        return Ok(Some(names));
-    }
-    Err("rules must be a string or array of strings".to_string())
+    crate::parse_run_data_object(data)
 }
 
 #[derive(Serialize)]
@@ -467,49 +398,6 @@ fn request_error_js(message: impl Into<String>) -> JsValue {
     errors
         .serialize(&js_error_serializer())
         .expect("BUG: serialize EngineError array")
-}
-
-fn run_data_value_from_json_value(value: serde_json::Value) -> Result<RunDataValue, String> {
-    use std::collections::BTreeMap;
-    match value {
-        serde_json::Value::String(s) => Ok(RunDataValue::String(s)),
-        serde_json::Value::Bool(b) => Ok(RunDataValue::Boolean(b)),
-        serde_json::Value::Number(n) => {
-            if n.is_i64() || n.is_u64() {
-                Ok(RunDataValue::String(n.to_string()))
-            } else {
-                Err("decimal values must be passed as strings to preserve exactness".to_string())
-            }
-        }
-        serde_json::Value::Object(obj) => {
-            if obj.is_empty() {
-                return Err("data value object must not be empty".to_string());
-            }
-            if obj.len() == 2 && obj.contains_key("value") && obj.contains_key("unit") {
-                return Err(
-                    "the {value, unit} object shape is not supported; use a unit map like {\"eur\": \"84\"}"
-                        .to_string(),
-                );
-            }
-            if obj.values().all(|v| v.is_string()) {
-                let map: BTreeMap<String, String> = obj
-                    .into_iter()
-                    .map(|(k, v)| {
-                        (
-                            k,
-                            v.as_str()
-                                .expect("BUG: object values checked as strings")
-                                .to_string(),
-                        )
-                    })
-                    .collect();
-                return Ok(RunDataValue::MeasureMap(map));
-            }
-            Err("data value object must be a unit map with string magnitudes".to_string())
-        }
-        serde_json::Value::Null => Err("data value must not be null".to_string()),
-        serde_json::Value::Array(_) => Err("data value must not be an array".to_string()),
-    }
 }
 
 fn parse_load_sources(sources: JsValue) -> Result<Vec<(SourceType, String)>, JsValue> {

--- a/engine/tests/cross_spec_unit_index.rs
+++ b/engine/tests/cross_spec_unit_index.rs
@@ -176,6 +176,6 @@ fn quotation_rejects_minutes_in_local_rule() {
         .expect("load must report minute out of scope");
     assert_eq!(
         minutes_err.message(),
-        "Unknown unit 'minute' is not in scope for this spec"
+        "Unknown unit 'minute'. Declare it on a measure or ratio type, or import it with uses."
     );
 }

--- a/engine/tests/data_type_declarations_coverage.rs
+++ b/engine/tests/data_type_declarations_coverage.rs
@@ -200,7 +200,7 @@ rule r: n
     assert!(rr.vetoed, "5 < 10 must veto rule r");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("5 is below minimum 10"),
+        Some("Data n [number]: 5 is below minimum 10"),
         "got: {:?}",
         rr.veto_reason
     );
@@ -222,7 +222,7 @@ rule r: n
     assert!(rr.vetoed, "10 > 5 must veto rule r");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("10 is above maximum 5"),
+        Some("Data n [number]: 10 is above maximum 5"),
         "got: {:?}",
         rr.veto_reason
     );
@@ -462,7 +462,7 @@ rule r: z
     assert!(rr.vetoed, "2 < child min 3 must veto");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("2 is below minimum 3"),
+        Some("Data z [y]: 2 is below minimum 3"),
         "child min veto must name 2 and 3, got: {:?}",
         rr.veto_reason
     );
@@ -474,7 +474,7 @@ rule r: z
     assert!(rr.vetoed, "11 > inherited max 10 must veto");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("11 is above maximum 10"),
+        Some("Data z [y]: 11 is above maximum 10"),
         "inherited max veto must name 11 and 10, got: {:?}",
         rr.veto_reason
     );
@@ -497,7 +497,7 @@ rule r: small_number
     assert!(rr.vetoed, "overridden max 100 must reject 200");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("200 is above maximum 100"),
+        Some("Data small_number [big_number]: 200 is above maximum 100"),
         "child max veto must name 200 and 100, got: {:?}",
         rr.veto_reason
     );
@@ -581,7 +581,7 @@ rule r: person_age
     assert!(rr.vetoed, "200 > 150 must veto via inherited max");
     assert_eq!(
         rr.veto_reason.as_deref(),
-        Some("200 is above maximum 150"),
+        Some("Data person_age [age]: 200 is above maximum 150"),
         "inherited max veto must name 200 and 150, got: {:?}",
         rr.veto_reason
     );

--- a/engine/tests/duration_trait_temporal.rs
+++ b/engine/tests/duration_trait_temporal.rs
@@ -445,12 +445,12 @@ rule value: 14:30:00 + 2 eur"#,
 fn temporal_past_without_visible_duration_typedef_rejected() {
     let code = r#"spec test
 rule value: past 7 day"#;
-    expect_plan_error(code, "not in scope");
+    expect_plan_error(code, "Unknown unit");
 }
 
 #[test]
 fn temporal_explicit_now_minus_duration_range_without_visible_typedef_rejected() {
     let code = r#"spec test
 rule value: now - 7 day...now"#;
-    expect_plan_error(code, "not in scope");
+    expect_plan_error(code, "Unknown unit");
 }

--- a/engine/tests/measure_unit_resolution.rs
+++ b/engine/tests/measure_unit_resolution.rs
@@ -1,0 +1,292 @@
+//! Unique unit names: one declaring owner per unit name in scope.
+//! Extensions inherit; bare binds the declarer / family root; qualified/cast bind the extension.
+
+use lemma::{DateTimeValue, Engine, SourceType};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn path_source(file: &str) -> SourceType {
+    SourceType::Path(Arc::new(PathBuf::from(file)))
+}
+
+fn load_and_run(code: &str, spec: &str) -> lemma::Response {
+    let mut engine = Engine::new();
+    engine
+        .load([(path_source("test.lemma"), code.to_string())])
+        .unwrap_or_else(|errs| {
+            panic!(
+                "load failed: {}",
+                errs.errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        });
+    let now = DateTimeValue::now();
+    engine
+        .run(None, spec, Some(&now), HashMap::new(), None, true)
+        .unwrap_or_else(|e| panic!("run({spec}) failed: {e}"))
+}
+
+fn expect_load_error(code: &str) -> String {
+    let mut engine = Engine::new();
+    match engine.load([(path_source("bad.lemma"), code.to_string())]) {
+        Err(err) => err
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; "),
+        Ok(()) => panic!("expected planning error, but load succeeded"),
+    }
+}
+
+fn rule_type(response: &lemma::Response, rule: &str) -> Arc<lemma::LemmaType> {
+    let rr = response
+        .results
+        .get(rule)
+        .unwrap_or_else(|| panic!("no rule '{rule}'"));
+    assert!(!rr.vetoed, "rule '{rule}' vetoed: {:?}", rr.veto_reason);
+    rr.explanation
+        .as_ref()
+        .expect("explanation")
+        .result
+        .value()
+        .expect("value")
+        .lemma_type
+        .clone()
+}
+
+#[test]
+fn bare_eur_binds_money_not_price() {
+    let response = load_and_run(
+        r#"spec test
+data money: measure -> unit eur: 1
+data price: money -> decimals 2
+rule bare: 5 eur
+rule qualified: 5 price.eur
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "bare").name(), "money");
+    assert_eq!(rule_type(&response, "bare").decimal_places(), None);
+    assert_eq!(response.results["bare"].display().unwrap(), "5 eur");
+
+    assert_eq!(rule_type(&response, "qualified").name(), "price");
+    assert_eq!(rule_type(&response, "qualified").decimal_places(), Some(2));
+    assert_eq!(response.results["qualified"].display().unwrap(), "5.00 eur");
+}
+
+#[test]
+fn cast_as_price_eur_binds_price() {
+    let response = load_and_run(
+        r#"spec test
+data money: measure -> unit eur: 1
+data price: money -> decimals 2
+data x: 10 eur
+rule r: x as price.eur
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "r").name(), "price");
+    assert_eq!(rule_type(&response, "r").decimal_places(), Some(2));
+}
+
+#[test]
+fn bare_eur_cast_as_extension() {
+    let response = load_and_run(
+        r#"spec test
+data money_a: measure -> unit eur: 1
+data money_b: money_a -> decimals 2
+rule r: 5 eur as money_b.eur
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "r").name(), "money_b");
+    assert_eq!(rule_type(&response, "r").decimal_places(), Some(2));
+}
+
+#[test]
+fn bare_kilogram_binds_stdlib_mass() {
+    let response = load_and_run(
+        r#"spec test
+uses lemma units
+data weight: units.mass -> decimals 2
+rule bare: 5 kilogram
+rule qualified: 5 weight.kilogram
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "bare").name(), "mass");
+    assert_eq!(rule_type(&response, "bare").decimal_places(), None);
+
+    assert_eq!(rule_type(&response, "qualified").name(), "weight");
+    assert_eq!(rule_type(&response, "qualified").decimal_places(), Some(2));
+    assert_eq!(
+        response.results["qualified"].display().unwrap(),
+        "5.00 kilogram"
+    );
+}
+
+#[test]
+fn new_kg_binds_weight_inherited_kilogram_binds_mass() {
+    let response = load_and_run(
+        r#"spec test
+uses lemma units
+data weight: units.mass -> unit kg: 1
+rule new_unit: 5 kg
+rule inherited_bare: 5 kilogram
+rule inherited_qualified: 5 weight.kilogram
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "new_unit").name(), "weight");
+    assert_eq!(rule_type(&response, "inherited_bare").name(), "mass");
+    assert_eq!(rule_type(&response, "inherited_qualified").name(), "weight");
+}
+
+#[test]
+fn units_mass_kilogram_binds_stdlib_mass() {
+    let response = load_and_run(
+        r#"spec test
+uses lemma units
+data weight: units.mass -> decimals 2
+rule r: 5 units.mass.kilogram
+"#,
+        "test",
+    );
+
+    assert_eq!(rule_type(&response, "r").name(), "mass");
+    assert_eq!(rule_type(&response, "r").decimal_places(), None);
+}
+
+#[test]
+fn second_local_eur_declarer_rejected() {
+    let msg = expect_load_error(
+        r#"spec test
+data money_a: measure -> unit eur: 1
+data money_b: measure -> unit eur: 2
+"#,
+    );
+    assert!(
+        msg.contains("eur")
+            && (msg.contains("money_a") || msg.contains("money_b"))
+            && (msg.to_lowercase().contains("defined on both")
+                || msg.to_lowercase().contains("declared only once")
+                || msg.to_lowercase().contains("ambiguous")
+                || msg.to_lowercase().contains("multiple")
+                || msg.contains("Defined in")),
+        "second independent eur declarer must Error at definition, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Qualify") && !msg.to_lowercase().contains("qualify as"),
+        "must not be bare-use qualify-at-use Error, got: {msg}"
+    );
+}
+
+#[test]
+fn second_kilogram_declarer_vs_stdlib_rejected() {
+    let msg = expect_load_error(
+        r#"spec test
+uses lemma units
+data bag: measure -> unit kilogram: 999
+"#,
+    );
+    assert!(
+        msg.contains("kilogram")
+            && (msg.to_lowercase().contains("defined on both")
+                || msg.to_lowercase().contains("declared only once")
+                || msg.to_lowercase().contains("ambiguous")
+                || msg.to_lowercase().contains("multiple")
+                || msg.contains("Defined in")
+                || msg.contains("mass")
+                || msg.contains("bag")),
+        "local bag + stdlib mass both declaring kilogram must Error, got: {msg}"
+    );
+    assert!(
+        !msg.to_lowercase().contains("qualify as"),
+        "must be duplicate declarer Error, not bare ambiguous list, got: {msg}"
+    );
+}
+
+#[test]
+fn extension_new_unit_ok_duplicate_inherited_name_rejected() {
+    let mut engine = Engine::new();
+    engine
+        .load([(
+            path_source("ok.lemma"),
+            r#"spec test
+uses lemma units
+data weight: units.mass -> unit kg: 1
+rule r: 5 kg
+"#
+            .to_string(),
+        )])
+        .expect("new unit kg on extension must load");
+
+    let msg = expect_load_error(
+        r#"spec test
+uses lemma units
+data weight: units.mass -> unit kg: 1
+data other: measure -> unit kilogram: 1
+"#,
+    );
+    assert!(
+        msg.contains("kilogram"),
+        "second kilogram declarer must Error, got: {msg}"
+    );
+}
+
+#[test]
+fn two_deps_both_declaring_kilogram_rejected() {
+    let mut engine = Engine::new();
+    engine
+        .load([(
+            path_source("left.lemma"),
+            r#"spec left
+data mass: measure -> unit kilogram: 1
+"#
+            .to_string(),
+        )])
+        .expect("left alone must load");
+    engine
+        .load([(
+            path_source("right.lemma"),
+            r#"spec right
+data bag: measure -> unit kilogram: 999
+"#
+            .to_string(),
+        )])
+        .expect("right alone must load");
+
+    let err = engine
+        .load([(
+            path_source("consumer.lemma"),
+            r#"spec consumer
+uses left
+uses right
+"#
+            .to_string(),
+        )])
+        .expect_err("consumer merging two kilogram declarers must Error");
+
+    let joined = err
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        joined.contains("kilogram"),
+        "two imported declarers of kilogram must Error, got: {joined}"
+    );
+    assert!(
+        !joined.to_lowercase().contains("qualify as"),
+        "must be duplicate declarer Error, not bare qualify-at-use, got: {joined}"
+    );
+}

--- a/engine/tests/multidim_unit_system.rs
+++ b/engine/tests/multidim_unit_system.rs
@@ -213,8 +213,10 @@ data velocity: measure -> unit mps: velocity/second"#;
         .collect::<Vec<_>>()
         .join("; ");
     assert!(
-        combined.contains("Unknown unit") || combined.contains("not in scope"),
-        "expected unknown-unit-in-scope rejection, got: {combined}"
+        combined.contains("Unknown unit")
+            || combined.contains("Declare it")
+            || combined.contains("import it with uses"),
+        "expected unknown-unit rejection, got: {combined}"
     );
 }
 

--- a/engine/tests/qualified_units.rs
+++ b/engine/tests/qualified_units.rs
@@ -1,4 +1,6 @@
-//! Optionally qualify units; must qualify when ambiguous.
+//! Qualify units: bare when unique; Type.unit; alias.Type.unit.
+//! Import-alias sugar (alias.unit) is rejected.
+//! Unique unit names: second independent declarer is a planning Error at definition/merge.
 
 use lemma::{DateTimeValue, Engine, SourceType};
 use std::collections::HashMap;
@@ -29,107 +31,203 @@ fn eval_display(code: &str, spec: &str, rule: &str) -> String {
 
 fn expect_plan_error(code: &str) -> String {
     let mut engine = Engine::new();
-    let err = engine
-        .load([(path_source("bad.lemma"), code.to_string())])
-        .expect_err("expected planning error");
-    err.iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("; ")
+    match engine.load([(path_source("bad.lemma"), code.to_string())]) {
+        Err(err) => err
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; "),
+        Ok(()) => panic!("expected planning error, but load succeeded"),
+    }
 }
 
 #[test]
-fn optional_qualify_when_unique() {
-    let code = r#"spec t
-uses lemma units
-rule a: 5 kilogram
-rule b: 5 units.kilogram
-rule c: 5 units.mass.kilogram"#;
-    assert!(eval_display(code, "t", "a").contains("kilogram"));
-    assert!(eval_display(code, "t", "b").contains("kilogram"));
-    assert!(eval_display(code, "t", "c").contains("kilogram"));
-}
-
-#[test]
-fn bare_ambiguous_must_qualify() {
+fn import_alias_unit_sugar_rejected() {
     let msg = expect_plan_error(
         r#"spec t
-data money_a: measure -> unit eur: 1
-data money_b: measure -> unit eur: 2
-rule r: 1 eur"#,
+uses lemma units
+rule r: 5 units.kilogram"#,
     );
     assert!(
-        msg.to_lowercase().contains("ambiguous")
-            || msg.contains("Qualify")
-            || msg.contains("qualify"),
-        "expected ambiguous bare eur error, got: {msg}"
-    );
-    assert!(
-        msg.contains("money_a.eur") && msg.contains("money_b.eur"),
+        msg.contains("units.kilogram")
+            && (msg.contains("Unknown")
+                || msg.contains("alias.Type.unit")
+                || msg.contains("not alias.unit")),
         "got: {msg}"
     );
 }
 
 #[test]
-fn qualified_disambiguation_and_eval_arithmetic() {
-    let code = r#"spec t
-data money_a: measure -> unit eur: 1
-data money_b: measure -> unit eur: 2
-rule a: 10 money_a.eur + 5 money_a.eur
-rule b: 10 money_b.eur + 5 money_b.eur"#;
-    let a = eval_display(code, "t", "a");
-    let b = eval_display(code, "t", "b");
-    assert!(a.contains("15") && a.contains("eur"), "got {a}");
-    assert!(b.contains("15") && b.contains("eur"), "got {b}");
-}
-
-#[test]
-fn import_and_local_kilogram_clash() {
-    let bare = expect_plan_error(
+fn import_alias_unit_sugar_rejected_even_when_unique() {
+    let msg = expect_plan_error(
         r#"spec t
 uses lemma units
-data bag: measure -> unit kilogram: 999
-rule r: 1 kilogram"#,
+rule r: 5 units.kilogram"#,
     );
     assert!(
-        bare.to_lowercase().contains("ambiguous")
-            || bare.contains("Qualify")
-            || bare.contains("qualify"),
-        "got: {bare}"
+        !msg.to_lowercase().contains("ambiguous"),
+        "must reject sugar as unknown path, not as ambiguity, got: {msg}"
     );
-
-    let code = r#"spec t
-uses lemma units
-data bag: measure -> unit kilogram: 999
-rule si: 1 units.mass.kilogram
-rule local: 1 bag.kilogram
-rule sugar: 1 units.kilogram"#;
-    assert!(eval_display(code, "t", "si").contains("kilogram"));
-    assert!(eval_display(code, "t", "local").contains("kilogram"));
-    assert!(eval_display(code, "t", "sugar").contains("kilogram"));
 }
 
 #[test]
-fn as_qualified_unit() {
+fn as_import_alias_unit_sugar_rejected() {
+    let msg = expect_plan_error(
+        r#"spec t
+uses lemma units
+data x: 10 kilogram
+rule r: x as units.kilogram"#,
+    );
+    assert!(msg.contains("units.kilogram"), "got: {msg}");
+}
+
+#[test]
+fn compound_factor_import_alias_sugar_rejected() {
+    let msg = expect_plan_error(
+        r#"spec t
+uses lemma units
+data money: measure
+  -> unit eur: 1
+data rate: measure
+  -> unit eur_per_kg: eur/units.kilogram"#,
+    );
+    assert!(
+        msg.contains("units.kilogram"),
+        "compound factor must reject alias.unit sugar, got: {msg}"
+    );
+}
+
+#[test]
+fn bare_unique_still_ok() {
     let code = r#"spec t
-data money_a: measure -> unit eur: 1
-data money_b: measure -> unit eur: 2
-data x: 10 money_a.eur
-rule r: x as money_a.eur"#;
+uses lemma units
+rule a: 5 kilogram"#;
+    assert!(eval_display(code, "t", "a").contains("kilogram"));
+}
+
+#[test]
+fn three_segment_import_ok() {
+    let code = r#"spec t
+uses lemma units
+rule c: 5 units.mass.kilogram"#;
+    assert!(eval_display(code, "t", "c").contains("kilogram"));
+}
+
+#[test]
+fn local_type_unit_ok() {
+    let code = r#"spec t
+data money: measure -> unit eur: 1
+rule r: 5 money.eur"#;
     assert!(eval_display(code, "t", "r").contains("eur"));
 }
 
-/// Multi-owner bare `second` (local + lemma units) must not panic when datetime
-/// arithmetic expands an anonymous duration signature without typed owners.
 #[test]
-fn multi_owner_second_datetime_subtract_does_not_panic() {
+fn second_kilogram_declarer_vs_stdlib_rejected() {
+    let msg = expect_plan_error(
+        r#"spec t
+uses lemma units
+data bag: measure -> unit kilogram: 999
+"#,
+    );
+    assert!(
+        msg.contains("kilogram"),
+        "local bag + stdlib kilogram must Error at definition, got: {msg}"
+    );
+    assert!(
+        !msg.to_lowercase().contains("qualify as"),
+        "must not be bare-use qualify list, got: {msg}"
+    );
+}
+
+#[test]
+fn second_eur_declarer_rejected() {
+    let msg = expect_plan_error(
+        r#"spec t
+data money_a: measure -> unit eur: 1
+data money_b: measure -> unit eur: 2
+"#,
+    );
+    assert!(
+        msg.contains("eur") && (msg.contains("money_a") || msg.contains("money_b")),
+        "second independent eur declarer must Error, got: {msg}"
+    );
+}
+
+#[test]
+fn import_alias_unit_sugar_still_rejected_with_local_clash() {
+    let sugar = expect_plan_error(
+        r#"spec t
+uses lemma units
+data bag: measure -> unit kilogram: 999
+rule sugar: 1 units.kilogram"#,
+    );
+    assert!(
+        sugar.contains("units.kilogram") || sugar.contains("kilogram"),
+        "sugar and/or second declarer must Error, got: {sugar}"
+    );
+}
+
+#[test]
+fn as_extension_unit() {
     let code = r#"spec t
+data money_a: measure -> unit eur: 1
+data money_b: money_a -> decimals 2
+data x: 10 eur
+rule r: x as money_b.eur"#;
+    let display = eval_display(code, "t", "r");
+    assert!(display.contains("eur"), "got {display}");
+    assert!(
+        display.contains("10.00") || display.contains("10"),
+        "got {display}"
+    );
+}
+
+#[test]
+fn local_second_declarer_of_second_rejected() {
+    let msg = expect_plan_error(
+        r#"spec t
 uses lemma units
 data tick: measure -> unit second: 1
-rule value: (2024-01-01T03:30:00Z - 01:00:00) as minute"#;
-    let display = eval_display(code, "t", "value");
+"#,
+    );
     assert!(
-        display.contains("150") && display.contains("minute"),
-        "got {display}"
+        msg.contains("second"),
+        "local tick.second + stdlib second must Error, got: {msg}"
+    );
+}
+
+#[test]
+fn dep_later_slice_second_kilogram_declarer_rejected() {
+    let mut engine = Engine::new();
+    let err = engine
+        .load([(
+            path_source("b.lemma"),
+            r#"
+spec B 2025-01-01
+data mass: measure
+  -> unit kilogram: 1
+
+spec B 2025-07-01
+data mass: measure
+  -> unit kilogram: 1
+data bag: measure
+  -> unit kilogram: 999
+"#
+            .to_string(),
+        )])
+        .expect_err("B later slice must not declare a second kilogram");
+
+    let joined = err
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        joined.contains("kilogram"),
+        "second kilogram declarer on B later row must Error, got: {joined}"
+    );
+    assert!(
+        !joined.contains("BUG:"),
+        "must be planning Error, not panic, got: {joined}"
     );
 }

--- a/engine/tests/ratio_runtime_input.rs
+++ b/engine/tests/ratio_runtime_input.rs
@@ -91,6 +91,21 @@ fn run_veto_reason(engine: &Engine, spec: &str, raw: &str) -> String {
     rr.veto_reason.clone().expect("veto reason")
 }
 
+fn assert_data_veto(msg: &str, field: &str, type_label: &str) {
+    assert!(
+        msg.contains(&format!("Data {field} [{type_label}]:")),
+        "expected Data {field} [{type_label}] veto, got: {msg}"
+    );
+}
+
+fn assert_data_veto_contains(msg: &str, field: &str, type_label: &str, fact: &str) {
+    assert_data_veto(msg, field, type_label);
+    assert!(
+        msg.contains(fact),
+        "expected veto to contain '{fact}', got: {msg}"
+    );
+}
+
 fn percent_spec() -> &'static str {
     r#"
 spec s
@@ -106,10 +121,7 @@ fn rejects_bare_zero() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "0");
-    assert!(
-        msg.contains("Ratio value requires a unit"),
-        "expected unit requirement, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "requires a unit");
 }
 
 #[test]
@@ -117,10 +129,7 @@ fn rejects_bare_decimal() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "0.5");
-    assert!(
-        msg.contains("Ratio value requires a unit"),
-        "expected unit requirement, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "requires a unit");
 }
 
 #[test]
@@ -128,10 +137,7 @@ fn rejects_bare_negative() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "-0.25");
-    assert!(
-        msg.contains("Ratio value requires a unit"),
-        "expected unit requirement, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "requires a unit");
 }
 
 // ─── Accepted: percent sigil ──────────────────────────────────────────
@@ -274,8 +280,12 @@ fn rejects_empty() {
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "");
     assert!(
-        msg.contains("Ratio value cannot be empty"),
-        "expected empty ratio message, got: {msg}"
+        msg.contains("Data r [ratio]:") && msg.to_lowercase().contains("cannot be empty"),
+        "expected field-named empty ratio message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Ratio value cannot be empty"),
+        "must not dump FromStr grammar, got: {msg}"
     );
 }
 
@@ -285,8 +295,8 @@ fn rejects_whitespace_only() {
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "   ");
     assert!(
-        msg.contains("Ratio value cannot be empty"),
-        "expected empty ratio message, got: {msg}"
+        msg.contains("Data r [ratio]:") && msg.to_lowercase().contains("cannot be empty"),
+        "expected field-named empty ratio message, got: {msg}"
     );
 }
 
@@ -297,7 +307,7 @@ fn rejects_bare_percent_sigil() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "%");
-    assert!(msg.contains("'%' must follow a number"), "got: {msg}");
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 #[test]
@@ -305,7 +315,7 @@ fn rejects_bare_permille_sigil() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "%%");
-    assert!(msg.contains("'%%' must follow a number"), "got: {msg}");
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 #[test]
@@ -313,15 +323,9 @@ fn rejects_sigil_before_number() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let percent = run_veto_reason(&engine, "s", "%5");
-    assert!(
-        percent.contains("Invalid ratio value") && percent.contains("%5"),
-        "got: {percent}"
-    );
+    assert_data_veto_contains(&percent, "r", "ratio", "Invalid ratio");
     let permille = run_veto_reason(&engine, "s", "%%5");
-    assert!(
-        permille.contains("Invalid ratio value") && permille.contains("%%5"),
-        "got: {permille}"
-    );
+    assert_data_veto_contains(&permille, "r", "ratio", "Invalid ratio");
 }
 
 // ─── Rejected: sigil with separator (strict glue rule) ────────────────
@@ -331,10 +335,7 @@ fn rejects_percent_sigil_with_space() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "5 %");
-    assert!(
-        msg.contains("must be glued to the number") && msg.contains("'%'"),
-        "expected explicit glue-rule veto reason, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 #[test]
@@ -342,10 +343,7 @@ fn rejects_permille_sigil_with_space() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "5  %%");
-    assert!(
-        msg.contains("must be glued to the number") && msg.contains("'%%'"),
-        "expected explicit glue-rule veto reason, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 // ─── Rejected: digit after sigil / mixed sigil-keyword ────────────────
@@ -355,10 +353,7 @@ fn rejects_digit_after_percent_sigil() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "5%5");
-    assert!(
-        msg.contains("Invalid ratio value") && msg.contains("5%5"),
-        "got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 #[test]
@@ -366,10 +361,7 @@ fn rejects_digit_after_permille_sigil() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "5%%5");
-    assert!(
-        msg.contains("Invalid ratio value") && msg.contains("5%%5"),
-        "got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 #[test]
@@ -377,10 +369,7 @@ fn rejects_sigil_glued_to_keyword() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "5%percent");
-    assert!(
-        msg.contains("Invalid ratio value") && msg.contains("5%percent"),
-        "got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 // ─── Rejected: trailing junk ──────────────────────────────────────────
@@ -390,10 +379,7 @@ fn rejects_trailing_token_after_keyword() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "50 percent extra");
-    assert!(
-        msg.contains("Expected '<number>', '<number>%', '<number>%%', or '<number> <unit>'"),
-        "expected extra-token veto reason, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Invalid ratio");
 }
 
 // ─── Rejected: unknown unit name ──────────────────────────────────────
@@ -403,14 +389,8 @@ fn rejects_unknown_unit_name() {
     let mut engine = Engine::new();
     load(&mut engine, percent_spec());
     let msg = run_veto_reason(&engine, "s", "50 fictional");
-    assert!(
-        msg.contains("Unknown unit") && msg.contains("Valid units"),
-        "expected `Unknown unit … Valid units …` veto reason, got: {msg}"
-    );
-    assert!(
-        msg.contains("fictional"),
-        "error must name the offending unit, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "ratio", "Unknown unit");
+    assert_data_veto_contains(&msg, "r", "ratio", "fictional");
 }
 
 // ─── Measure-side regression: `%` is no longer accepted by NumberWithUnit ───
@@ -425,10 +405,8 @@ rule out: r
     let mut engine = Engine::new();
     load(&mut engine, code);
     let msg = run_veto_reason(&engine, "s", "5%");
-    assert!(
-        msg.contains("Measure value must include a unit"),
-        "expected friendly Measure-unit veto reason, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "measure", "must include a unit");
+    assert_data_veto_contains(&msg, "r", "measure", "eur");
     assert!(
         !msg.contains("Unknown unit 'percent'"),
         "Measure path must not leak a 'percent' unit lookup, got: {msg}"
@@ -445,10 +423,8 @@ rule out: r
     let mut engine = Engine::new();
     load(&mut engine, code);
     let msg = run_veto_reason(&engine, "s", "5%%");
-    assert!(
-        msg.contains("Measure value must include a unit"),
-        "expected friendly Measure-unit veto reason, got: {msg}"
-    );
+    assert_data_veto_contains(&msg, "r", "measure", "must include a unit");
+    assert_data_veto_contains(&msg, "r", "measure", "eur");
     assert!(
         !msg.contains("Unknown unit 'permille'"),
         "Measure path must not leak a 'permille' unit lookup, got: {msg}"

--- a/engine/tests/resource_limits_test.rs
+++ b/engine/tests/resource_limits_test.rs
@@ -155,8 +155,8 @@ fn test_data_value_size_limit() {
     );
     let reason = result.veto_reason.as_deref().expect("veto reason");
     assert!(
-        reason.contains("max_data_value_bytes"),
-        "veto reason must mention limit, got: {reason}"
+        reason.contains("Data name [text]:") && reason.contains("size limit"),
+        "veto reason must name field, type, and size limit, got: {reason}"
     );
 }
 

--- a/engine/tests/runtime_bad_input_veto.rs
+++ b/engine/tests/runtime_bad_input_veto.rs
@@ -129,6 +129,93 @@ rule doubled: age * 2
 
     let doubled = response.results.get("doubled").expect("doubled");
     assert!(doubled.vetoed, "unparsable age must veto doubled");
+    let reason = doubled.veto_reason.as_deref().expect("veto reason");
+    assert!(
+        reason.contains("Data age [number]:")
+            && reason.contains("twenty")
+            && reason.contains("Invalid number"),
+        "veto reason must name field, type, and parse fact, got: {reason}"
+    );
+    assert!(
+        !reason.contains("not a valid"),
+        "veto reason must not use generic invalid template, got: {reason}"
+    );
+}
+
+#[test]
+fn empty_measure_override_names_field_type_and_unit() {
+    let code = r#"
+spec s
+data mass: measure
+  -> unit kilogram: 1
+  -> unit gram: 0.001
+data price: mass
+rule total: price
+"#;
+    let mut engine = Engine::new();
+    engine
+        .load([(lemma::SourceType::Volatile, code.to_string())])
+        .expect("plan");
+
+    let now = DateTimeValue::now();
+    for empty in ["", "   "] {
+        let mut data = HashMap::new();
+        data.insert("price".to_string(), empty.to_string());
+
+        let response = assert_run_completes_with_veto_not_validation_error(
+            engine.run(None, "s", Some(&now), data, None, false),
+            &format!("price={empty:?} (empty measure)"),
+        );
+        let total = response.results.get("total").expect("total");
+        assert!(total.vetoed, "empty price must veto total");
+        let reason = total.veto_reason.as_deref().expect("veto reason");
+        assert!(
+            reason.contains("Data price [mass]:")
+                && reason.to_lowercase().contains("cannot be empty"),
+            "empty measure veto must name field and type, got: {reason}"
+        );
+        assert!(
+            !reason.contains("eur"),
+            "example unit must come from this type, got: {reason}"
+        );
+        assert!(
+            !reason.contains("Measure value cannot be empty"),
+            "veto reason must not dump FromStr grammar, got: {reason}"
+        );
+    }
+}
+
+#[test]
+fn empty_number_override_names_field_without_unit_lecture() {
+    let code = r#"
+spec s
+data age: number
+rule doubled: age * 2
+"#;
+    let mut engine = Engine::new();
+    engine
+        .load([(lemma::SourceType::Volatile, code.to_string())])
+        .expect("plan");
+
+    let now = DateTimeValue::now();
+    let mut data = HashMap::new();
+    data.insert("age".to_string(), "   ".to_string());
+
+    let response = assert_run_completes_with_veto_not_validation_error(
+        engine.run(None, "s", Some(&now), data, None, false),
+        "age=whitespace (empty number)",
+    );
+    let doubled = response.results.get("doubled").expect("doubled");
+    assert!(doubled.vetoed, "empty age must veto doubled");
+    let reason = doubled.veto_reason.as_deref().expect("veto reason");
+    assert!(
+        reason.contains("Data age [number]:") && reason.to_lowercase().contains("cannot be empty"),
+        "empty number veto must name field and type, got: {reason}"
+    );
+    assert!(
+        !reason.to_lowercase().contains("unit"),
+        "number empty veto must not mention units, got: {reason}"
+    );
 }
 
 #[test]

--- a/engine/tests/unified_ratio_units.rs
+++ b/engine/tests/unified_ratio_units.rs
@@ -1,6 +1,7 @@
-//! Unified ratio units: multiple `ratio` types per spec, shared builtin/custom units in the
-//! unit index, cross-type arithmetic/comparison, per-type `as` scoping, and expression-level
-//! (anonymous) ratios. Assertions use canonical `ValueKind` + `RationalInteger`, not display
+//! Unified ratio units: multiple `ratio` types per spec, shared builtin `percent` /
+//! `permille` in the unit index, unique custom unit names, cross-type
+//! arithmetic/comparison, per-type `as` scoping, and expression-level (anonymous)
+//! ratios. Assertions use canonical `ValueKind` + `RationalInteger`, not display
 //! substrings alone.
 
 use lemma::DateTimeValue;
@@ -339,7 +340,7 @@ rule margin_higher: margin_pct > insurance_pct
 }
 
 // -----------------------------------------------------------------------------
-// Section 3 — Per-type `as` scoping and shared custom units
+// Section 3 — Per-type `as` scoping and unique custom ratio units
 // -----------------------------------------------------------------------------
 
 #[test]
@@ -378,41 +379,25 @@ rule bad: margin as basis_points
 }
 
 #[test]
-fn shared_custom_unit_same_factor_two_types_number_as_ok() {
-    let code = r#"
-spec s
-data spread: ratio
-  -> unit basis_points: 10000
-data fee: ratio
-  -> unit basis_points: 10000
-rule from_number: 500 basis_points
-"#;
-    let mut engine = Engine::new();
-    load_ok(&mut engine, code, "shared_bps.lemma");
-
-    let response = run_spec(&engine, "s", HashMap::new());
-    assert_ratio_exact(
-        rule_value(&response, "from_number"),
-        "from_number",
-        "0.05",
-        Some("basis_points"),
-    );
-}
-
-#[test]
-fn conflicting_basis_points_factor_errors_at_load() {
+fn second_custom_ratio_unit_declarer_errors_at_load() {
     let code = r#"
 spec s
 data spread_a: ratio
   -> unit basis_points: 10000
 data spread_b: ratio
-  -> unit basis_points: 5000
+  -> unit basis_points: 10000
 rule out: spread_a
 "#;
     expect_load_error(
         code,
-        "conflict_bps.lemma",
-        &["spread_a", "spread_b", "basis_points"],
+        "unique_bps.lemma",
+        &[
+            "spread_a",
+            "spread_b",
+            "basis_points",
+            "defined on both",
+            "declared only once",
+        ],
     );
 }
 
@@ -433,41 +418,26 @@ rule out: margin
 }
 
 #[test]
-fn mixed_match_and_mismatch_factors_errors_on_first_mismatch() {
+fn second_custom_ratio_unit_declarer_among_three_types_errors() {
     let code = r#"
 spec s
-data spread_a: ratio
-  -> unit basis_points: 10000
-  -> unit ten_thousandth: 10000
-data spread_b: ratio
-  -> unit basis_points: 10000
-  -> unit ten_thousandth: 5000
-rule out: spread_a
+data a: ratio
+  -> unit thirds: 3
+data b: ratio
+  -> unit thirds: 3
+data c: ratio
+  -> unit thirds: 6
+rule out: a
 "#;
     expect_load_error(
         code,
-        "mixed_match_mismatch.lemma",
-        &["spread_a", "spread_b", "ten_thousandth"],
+        "three_types_unique.lemma",
+        &["thirds", "defined on both", "declared only once"],
     );
 }
 
 #[test]
-fn three_types_third_introduces_factor_conflict() {
-    let code = r#"
-spec s
-data a: ratio
-  -> unit thirds: 3
-data b: ratio
-  -> unit thirds: 3
-data c: ratio
-  -> unit thirds: 6
-rule out: a
-"#;
-    expect_load_error(code, "three_types_conflict.lemma", &["thirds"]);
-}
-
-#[test]
-fn three_types_third_introduces_factor_conflict_reordered() {
+fn second_custom_ratio_unit_declarer_reordered_errors() {
     let code = r#"
 spec s
 data c: ratio
@@ -478,7 +448,11 @@ data b: ratio
   -> unit thirds: 3
 rule out: a
 "#;
-    expect_load_error(code, "three_types_conflict_reordered.lemma", &["thirds"]);
+    expect_load_error(
+        code,
+        "three_types_unique_reordered.lemma",
+        &["thirds", "defined on both", "declared only once"],
+    );
 }
 
 // -----------------------------------------------------------------------------

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "OpenAPI 3.1 specification generator for Lemma specs."
 
 [dependencies]
-lemma = { package = "lemma-engine", version = "=0.9.7", path = "../engine" }
+lemma = { package = "lemma-engine", version = "=0.9.8", path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/openapi/src/lib.rs
+++ b/openapi/src/lib.rs
@@ -85,15 +85,15 @@ pub fn temporal_api_sources(engine: &Engine) -> Vec<ApiSource> {
 ///
 /// Convenience wrapper around [`generate_openapi_effective`]. The document reflects
 /// only the specs and interfaces active at `DateTimeValue::now()`.
-pub fn generate_openapi(engine: &Engine, explanations_enabled: bool) -> Value {
-    generate_openapi_effective(engine, explanations_enabled, &DateTimeValue::now())
+pub fn generate_openapi(engine: &Engine, explain: bool) -> Value {
+    generate_openapi_effective(engine, explain, &DateTimeValue::now())
 }
 
 /// Generate a complete OpenAPI 3.1 specification for a specific point in time.
 ///
 /// The specification includes:
 /// - `GET /` — list loaded specs (name, data/rule counts)
-/// - `/{spec_set_id}` GET (show: `spec_set_id`, `effective_from`, `data`, `rules`, `meta`, `versions`) and
+/// - `/{spec}` GET (show: `spec`, `effective_from`, `data`, `rules`, `meta`, `versions`) and
 ///   POST (evaluate: envelope `spec`, `effective`, `result`) with optional `Accept-Datetime` header
 /// - `?rules=` on POST only, to limit evaluated rules
 /// - `x-effective-from` / `x-effective-to` vendor extensions on each PathItem
@@ -103,20 +103,17 @@ pub fn generate_openapi(engine: &Engine, explanations_enabled: bool) -> Value {
 /// CLI `lemma server` also exposes shell routes (`/openapi.json`, `/health`, `/docs`) that are
 /// intentionally omitted from the generated document.
 ///
-/// When `explanations_enabled` is true, the document adds the `x-explanations` header parameter
+/// When `explain` is true, the document adds the `x-explain` header parameter
 /// to evaluation operations and describes the optional `explanation` field on rule results.
 pub fn generate_openapi_effective(
     engine: &Engine,
-    explanations_enabled: bool,
+    explain: bool,
     effective: &DateTimeValue,
 ) -> Value {
     let mut paths = Map::new();
     let mut components_schemas = Map::new();
 
-    components_schemas.insert(
-        "LemmaRuleResult".to_string(),
-        build_rule_result_schema(explanations_enabled),
-    );
+    components_schemas.insert("LemmaRuleResult".to_string(), build_rule_result_schema());
 
     let repositories = engine.list();
     let workspace = repositories
@@ -152,7 +149,7 @@ pub fn generate_openapi_effective(
                 spec_name,
                 &show,
                 (ls.effective_from.as_ref(), ls.effective_to.as_ref()),
-                explanations_enabled,
+                explain,
             );
             paths.insert(format!("/{spec_name}"), artifacts.path_item);
             for (name, schema_value) in artifacts.component_schemas {
@@ -163,14 +160,14 @@ pub fn generate_openapi_effective(
 
     let mut tags = vec![json!({
         "name": "Specs",
-        "description": "Simple API to retrieve the list of Lemma specs"
+        "description": "List loaded specs"
     })];
     for spec_name in &unique_spec_names {
         let safe_tag = spec_name.replace('.', "_");
         tags.push(json!({
             "name": safe_tag,
             "x-displayName": spec_name,
-            "description": format!("GET show or POST evaluate for spec '{}'. Use ?rules= on POST to limit evaluated rules.", spec_name)
+            "description": format!("Show and evaluate `{spec_name}`")
         }));
     }
 
@@ -190,7 +187,7 @@ pub fn generate_openapi_effective(
         "openapi": "3.1.0",
         "info": {
             "title": "Lemma API",
-            "description": "Lemma is a declarative language for expressing business logic — pricing rules, tax calculations, eligibility criteria, contracts, and policies. Learn more at [LemmaBase.com](https://lemmabase.com).\n\n**Temporal resolution.** `GET /{spec}` describes **version boundaries**: each entry in `versions` carries the half-open `[effective_from, effective_to)` validity range of a temporal version. `POST /{spec}` treats the request's effective instant (from the `Accept-Datetime` header, or the evaluation envelope's `effective` field) as the **evaluation instant** used to pick the active version and compute the result.",
+            "description": "Lemma is a declarative language for business logic: pricing, tax, eligibility, contracts, and policies. This API lists, shows, and evaluates loaded specs. Learn more at [LemmaBase.com](https://lemmabase.com).",
             "version": version_label
         },
         "tags": tags,
@@ -242,11 +239,11 @@ fn index_path_item(engine: &Engine) -> Value {
     json!({
         "get": {
             "operationId": "list",
-            "summary": "List loaded repositories and specs",
+            "summary": "List specs",
             "tags": ["Specs"],
             "responses": {
                 "200": {
-                    "description": "Same JSON as Engine.list() (metadata only: name, effective_from, effective_to per spec row)",
+                    "description": "Loaded repositories and their specs",
                     "content": {
                         "application/json": {
                             "schema": {
@@ -254,15 +251,28 @@ fn index_path_item(engine: &Engine) -> Value {
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "repository": { "type": ["string", "null"] },
+                                        "repository": {
+                                            "type": ["string", "null"],
+                                            "description": "Repository name. Null for the workspace."
+                                        },
                                         "specs": {
                                             "type": "array",
+                                            "description": "Specs in this repository",
                                             "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                    "name": { "type": "string" },
-                                                    "effective_from": { "type": ["string", "null"] },
-                                                    "effective_to": { "type": ["string", "null"] }
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "Spec name"
+                                                    },
+                                                    "effective_from": {
+                                                        "type": ["string", "null"],
+                                                        "description": "When this version starts. Null if unbounded."
+                                                    },
+                                                    "effective_to": {
+                                                        "type": ["string", "null"],
+                                                        "description": "When this version ends (exclusive). Null if this is the latest."
+                                                    }
                                                 },
                                                 "required": ["name"]
                                             }
@@ -286,7 +296,7 @@ fn index_path_item(engine: &Engine) -> Value {
 
 fn error_response_schema() -> Value {
     json!({
-        "description": "Evaluation error",
+        "description": "Bad request",
         "content": {
             "application/json": {
                 "schema": {
@@ -321,78 +331,74 @@ fn not_found_response_schema() -> Value {
 fn memento_spec_response_headers() -> Value {
     json!({
         "Memento-Datetime": {
-            "description": "RFC 7089: datetime of the resolved spec version (absent for unversioned specs)",
+            "description": "`effective_from` of the resolved version, when versioned",
             "schema": { "type": "string" }
         },
         "Vary": {
-            "description": "Indicates negotiation on Accept-Datetime",
+            "description": "Varies with Accept-Datetime",
             "schema": { "type": "string", "example": "Accept-Datetime" }
         }
     })
 }
 
-/// GET `/{spec}` body: matches [cli::server::GetSpecResponse].
+/// GET `/{spec}` body: [`lemma::Show`].
 fn build_get_show_response() -> Value {
     json!({
         "type": "object",
-        "required": ["spec_set_id", "spec", "data", "rules", "meta", "start_line"],
+        "required": ["spec", "data", "rules", "meta", "start_line"],
         "properties": {
-            "spec_set_id": {
-                "type": "string",
-                "description": "Spec set identifier (path segments, e.g. org/product/pricing)"
-            },
             "spec": {
                 "type": "string",
-                "description": "Resolved spec name"
+                "description": "Spec name"
             },
             "commentary": {
                 "type": ["string", "null"],
-                "description": "Optional commentary from the spec source"
+                "description": "Docstring after the spec line"
             },
             "effective_from": {
                 "type": ["string", "null"],
-                "description": "Effective-from of the resolved temporal version, if any"
+                "description": "When this version starts. Null if unbounded."
             },
             "effective_to": {
                 "type": ["string", "null"],
-                "description": "Exclusive effective-to of the resolved temporal version, if any"
+                "description": "When this version ends (exclusive). Null if this is the latest."
             },
             "start_line": {
                 "type": "integer",
-                "description": "1-based line number of the spec declaration in source"
+                "description": "Line of the spec declaration (1-based)"
             },
             "source_type": {
-                "description": "How this spec was loaded (path, inline, registry, etc.)"
+                "description": "How this spec was loaded"
             },
             "data": {
                 "type": "object",
-                "description": "Data used by the spec's rules, mapped to type metadata, optional prefilled, and optional suggestion",
+                "description": "Inputs: types, prefilled values, and suggestions",
                 "additionalProperties": true
             },
             "rules": {
                 "type": "object",
-                "description": "Local rule names mapped to result types (full planning-time interface)",
+                "description": "Rules and their result types",
                 "additionalProperties": true
             },
             "meta": {
                 "type": "object",
-                "description": "Spec metadata key/value pairs",
+                "description": "Spec metadata",
                 "additionalProperties": true
             },
             "versions": {
                 "type": "array",
-                "description": "All loaded temporal versions for this spec name, each with a half-open [effective_from, effective_to) range",
+                "description": "All versions of this spec. Ranges are `[effective_from, effective_to)`.",
                 "items": {
                     "type": "object",
                     "required": ["effective_from", "effective_to"],
                     "properties": {
                         "effective_from": {
                             "type": ["string", "null"],
-                            "description": "Start of validity for this version; null when unbounded (no earlier version exists)"
+                            "description": "When this version starts. Null if unbounded."
                         },
                         "effective_to": {
                             "type": ["string", "null"],
-                            "description": "Exclusive end of validity (same instant as the next version's effective_from); null when this is the latest version and has no successor"
+                            "description": "When this version ends (exclusive). Null if this is the latest."
                         }
                     }
                 }
@@ -402,61 +408,78 @@ fn build_get_show_response() -> Value {
 }
 
 /// Single rule output: flat fields matching engine [`lemma::RuleResult`].
-fn build_rule_result_schema(explanations_enabled: bool) -> Value {
-    let mut explanation = json!({
-        "type": "object",
-        "description": "Structured explanation tree when explanations are enabled"
-    });
-    if explanations_enabled {
-        explanation["description"] = Value::String(
-            "Structured explanation tree (present when x-explanations is sent and server uses --explanations)"
-                .to_string(),
-        );
-    }
-
+fn build_rule_result_schema() -> Value {
     json!({
         "type": "object",
         "required": ["vetoed", "rule_type"],
         "properties": {
-            "vetoed": { "type": "boolean" },
+            "vetoed": {
+                "type": "boolean",
+                "description": "True when the rule has no value"
+            },
             "display": {
                 "type": "string",
-                "description": "Human-readable formatted value when not vetoed"
+                "description": "Formatted value when not vetoed"
             },
-            "veto_reason": { "type": "string" },
+            "veto_reason": {
+                "type": "string",
+                "description": "Why the rule vetoed"
+            },
             "rule_type": {
                 "type": "string",
-                "description": "Result type name (e.g. number, boolean, money)"
+                "description": "Result type (number, boolean, money, ...)"
             },
             "measure": {
                 "type": "object",
                 "additionalProperties": { "type": "string" },
-                "description": "Named measure rule: unit name to magnitude string"
+                "description": "Measure value: unit name to magnitude"
             },
             "ratio": {
                 "type": "object",
                 "additionalProperties": { "type": "string" },
-                "description": "Named ratio rule: unit name to magnitude string"
+                "description": "Ratio value: unit name to magnitude"
             },
-            "number": { "type": "string" },
-            "boolean": { "type": "boolean" },
-            "text": { "type": "string" },
-            "date": { "type": "object" },
-            "time": { "type": "object" },
+            "number": {
+                "type": "string",
+                "description": "Value when the result is this type"
+            },
+            "boolean": {
+                "type": "boolean",
+                "description": "Value when the result is this type"
+            },
+            "text": {
+                "type": "string",
+                "description": "Value when the result is this type"
+            },
+            "date": {
+                "type": "object",
+                "description": "Value when the result is this type"
+            },
+            "time": {
+                "type": "object",
+                "description": "Value when the result is this type"
+            },
             "calendar": {
                 "type": "object",
+                "description": "Value when the result is this type",
                 "properties": {
                     "value": { "type": "string" },
                     "unit": { "type": "string" }
                 }
             },
-            "range": { "type": "object" },
+            "range": {
+                "type": "object",
+                "description": "Value when the result is this type"
+            },
             "missing_data": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Input keys still unbound for this rule after overlay-aware pruning (same keys as Show.data)"
+                "description": "Unbound input names for this rule"
             },
-            "explanation": explanation
+            "explanation": {
+                "type": "object",
+                "description": "How this result was computed. Needs `--explain` and `x-explain`."
+            }
         }
     })
 }
@@ -481,23 +504,23 @@ fn build_evaluate_response_schema(show: &lemma::Show, rule_names: &[String]) -> 
         "properties": {
             "spec": {
                 "type": "string",
-                "description": "Spec set id that was evaluated"
+                "description": "Spec that was evaluated"
             },
             "effective": {
                 "type": "string",
-                "description": "Evaluation instant used for temporal resolution (matches request instant unless overridden)"
+                "description": "Datetime used to pick the version and evaluate"
             },
             "spec_effective_from": {
                 "type": "string",
-                "description": "Start of the resolved spec version's declared temporal window"
+                "description": "When the resolved version starts"
             },
             "spec_effective_to": {
                 "type": "string",
-                "description": "End of the resolved spec version's declared temporal window (absent if unbounded)"
+                "description": "When the resolved version ends (exclusive). Absent if unbounded."
             },
             "results": {
                 "type": "object",
-                "description": "Rule names to evaluation results (definition order in response; keys match ?rules= filter when set)",
+                "description": "Results by rule name. Honors `?rules=`.",
                 "properties": Value::Object(result_props)
             }
         }
@@ -536,7 +559,7 @@ fn build_spec_openapi_artifacts(
     spec_name: &str,
     show: &lemma::Show,
     effective_range: (Option<&DateTimeValue>, Option<&DateTimeValue>),
-    explanations_enabled: bool,
+    explain: bool,
 ) -> SpecOpenApiArtifacts {
     let data = collect_input_data_from_show(show);
     let rule_names: Vec<String> = show.rules.keys().cloned().collect();
@@ -571,7 +594,7 @@ fn build_spec_openapi_artifacts(
             &post_form_body_schema_name,
         ),
         &rule_names,
-        explanations_enabled,
+        explain,
         effective_range,
     );
 
@@ -581,12 +604,12 @@ fn build_spec_openapi_artifacts(
     }
 }
 
-fn x_explanations_header_parameter() -> Value {
+fn x_explain_header_parameter() -> Value {
     json!({
-        "name": "x-explanations",
+        "name": "x-explain",
         "in": "header",
         "required": false,
-        "description": "Set to request explanation objects in the response (server must be started with --explanations)",
+        "description": "Include explanations. Server needs `--explain`.",
         "schema": { "type": "string", "default": "true" }
     })
 }
@@ -596,7 +619,7 @@ fn accept_datetime_header_parameter() -> Value {
         "name": "Accept-Datetime",
         "in": "header",
         "required": false,
-        "description": "RFC 7089 (Memento): resolve the spec version active at this datetime. Omit to evaluate at the request instant (now).",
+        "description": "Evaluate at this datetime. Omit for now.",
         "schema": { "type": "string", "format": "date-time" },
         "example": "Sat, 01 Jan 2025 00:00:00 GMT"
     })
@@ -607,7 +630,7 @@ fn build_spec_path_item_with_show_refs(
     spec_name: &str,
     component_names: (&str, &str, &str, &str),
     rule_names: &[String],
-    explanations_enabled: bool,
+    explain: bool,
     effective_range: (Option<&DateTimeValue>, Option<&DateTimeValue>),
 ) -> Value {
     let (
@@ -643,26 +666,24 @@ fn build_spec_path_item_with_show_refs(
         "name": "rules",
         "in": "query",
         "required": false,
-        "description": "Comma-separated list of rule names to evaluate; omit for all.",
+        "description": "Rules to evaluate, comma-separated. Omit for all.",
         "schema": { "type": "string" },
         "example": rules_example
     });
 
     let mut get_parameters: Vec<Value> = Vec::new();
     get_parameters.push(accept_datetime_header_parameter());
-    if explanations_enabled {
-        get_parameters.push(x_explanations_header_parameter());
+    if explain {
+        get_parameters.push(x_explain_header_parameter());
     }
 
-    let get_summary = "Show of resolved version (spec, data, rules, meta, versions)".to_string();
-    let post_summary = "Evaluate".to_string();
     let get_operation_id = format!("get_{}", spec_name);
     let post_operation_id = format!("post_{}", spec_name);
 
     let mut post_parameters: Vec<Value> = vec![rules_param];
     post_parameters.push(accept_datetime_header_parameter());
-    if explanations_enabled {
-        post_parameters.push(x_explanations_header_parameter());
+    if explain {
+        post_parameters.push(x_explain_header_parameter());
     }
 
     let datetime_or_null = |dt: Option<&DateTimeValue>| -> Value {
@@ -677,12 +698,12 @@ fn build_spec_path_item_with_show_refs(
         "x-effective-to": datetime_or_null(effective_to),
         "get": {
             "operationId": get_operation_id,
-            "summary": get_summary,
+            "summary": "Show spec",
             "tags": [tag],
             "parameters": get_parameters,
             "responses": {
                 "200": {
-                    "description": "Show of resolved version (spec_set_id, effective_from, data, rules, meta, versions).",
+                    "description": "Spec interface",
                     "headers": memento_spec_response_headers(),
                     "content": {
                         "application/json": {
@@ -696,7 +717,7 @@ fn build_spec_path_item_with_show_refs(
         },
         "post": {
             "operationId": post_operation_id,
-            "summary": post_summary,
+            "summary": "Evaluate",
             "tags": [tag],
             "parameters": post_parameters,
             "requestBody": {
@@ -713,7 +734,7 @@ fn build_spec_path_item_with_show_refs(
             },
             "responses": {
                 "200": {
-                    "description": "Evaluation envelope: spec, effective, result (per-rule RuleResultJson).",
+                    "description": "Evaluation results",
                     "headers": memento_spec_response_headers(),
                     "content": {
                         "application/json": {
@@ -1021,7 +1042,8 @@ mod tests {
         assert_ne!(get_ref, post_ref);
 
         let get_show = &spec["components"]["schemas"]["pricing_get_show"];
-        assert!(get_show["properties"]["spec_set_id"]["type"] == "string");
+        assert!(get_show["properties"]["spec"]["type"] == "string");
+        assert!(get_show["properties"].get("spec_set_id").is_none());
         assert!(get_show["properties"]["versions"].is_object());
         assert!(get_show["properties"]["start_line"]["type"] == "integer");
 
@@ -1079,7 +1101,7 @@ rule adult: age >= 18
     }
 
     #[test]
-    fn test_generate_openapi_explanations_enabled_adds_x_explanations_and_explanation_schema() {
+    fn test_generate_openapi_explain_adds_x_explain_and_explanation_schema() {
         let engine = create_engine_with_code(
             "spec pricing
             data quantity: 10
@@ -1088,7 +1110,7 @@ rule adult: age >= 18
         let spec = generate_openapi(&engine, true);
 
         let get_params = &spec["paths"]["/pricing"]["get"]["parameters"];
-        assert!(has_param(get_params, "x-explanations"));
+        assert!(has_param(get_params, "x-explain"));
 
         let rule_result = &spec["components"]["schemas"]["LemmaRuleResult"];
         assert!(rule_result["properties"]["explanation"].is_object());

--- a/xtask/src/llms.rs
+++ b/xtask/src/llms.rs
@@ -15,7 +15,9 @@ pub fn concat_guide_fragments(guide_dir: &Path) -> Result<String, String> {
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let path = entry.path();
-            if path.extension()?.to_str()? == "md" {
+            if path.extension()?.to_str()? == "md"
+                && !path.file_stem()?.to_str()?.ends_with("_improved")
+            {
                 Some(path)
             } else {
                 None


### PR DESCRIPTION
## [0.9.8] - 2026-08-26

0.9.8 aligns MCP with SDK `run`, requires one declaring type per unit name, and unifies HTTP explain with CLI `--explain`.

### Added

- **Hex `Lemma.Mcp.run/2`**: same catalog as CLI MCP `run`. `evaluate/2` remains as a deprecated alias.
- **MCP `repository`**: optional on `run`, `show`, and `source` (with `spec` for a repo spec, or `repository` alone for a whole repo).

### Changed

- **Unit uniqueness**: a unit name may be declared on only one type in scope. A second independent `-> unit` with the same name is a planning error. Extensions inherit; bare binds the declarer; use `Type.unit` or `alias.Type.unit` for the extension.
- **Import-alias unit sugar**: `alias.unit` (e.g. `units.kilogram`) is rejected. Write `alias.Type.unit` (`units.mass.kilogram`).
- **Custom ratio units**: same uniqueness as measures. Builtin `percent` / `permille` stay shared across named ratio types when factors match.
- **MCP `run`**: renamed from `evaluate` (deprecated alias kept). Args match SDK `run`: `rules` (string or array; `rule` rejected), JSON `data` object (not `name=value` strings). Returns Engine `Response` JSON; explanations always on (no `explain` arg).
- **MCP `--write`**: replaces `--admin` for write tools (`add_spec`, `update_spec`, `remove_spec`, `clear`, `install`). `attribute` replaces `source_id`.
- **MCP `check`**: success is `quality()` JSON array. Engine failures on `run` / `show` / `source` return `EngineError` JSON with `isError`.
- **HTTP `--explain`**: `lemma server --explain` and client header `x-explain` replace `--explanations` / `x-explanations`. Hex `Lemma.OpenAPI.generate_openapi` option is `:explain`.
- **HTTP GET `/{spec}`**: body is `Show` JSON (no `spec_set_id` wrapper).
- **Runtime data vetoes**: reasons are `Data field [type]: …`. Empty non-text input vetoes before parse. Interactive prompts use the same field `[type]` labels.
- **LLM authoring method**: Method fragment rewritten (inventory then distill, hard stop before write, resources of truth).

### Removed

- **`lemma mcp --admin`**: use `--write`.
- **`alias.unit` qualification**: use `Type.unit` or `alias.Type.unit`.
- **`lemma server --explanations`**: use `--explain`. Header `x-explanations` → `x-explain`.
